### PR TITLE
Configure Cloudflare static deployment

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "name": "pocketry",
+  "compatibility_date": "2026-08-26",
+  "assets": {
+    "directory": "./dist/public",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
## Summary
- add an asset-only Wrangler configuration for the Pocketry Worker
- deploy the Vite output from `dist/public`
- enable SPA fallback so direct navigation to `/bin` works

## Verification
- `npm run check`
- `npm test` (770 tests)
- `npm run build`