### PR TITLE
Add project README and fix legal document links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,93 @@
+# Pocketry
+
+Pocketry turns photographs of tools into editable outlines, shadow-board files,
+and printable Gridfinity bins. The application runs in the browser, with image
+processing, project storage, and model generation kept on the user's device.
+
+[Try Pocketry](https://pocketry.pages.dev) ·
+[View the source](https://github.com/wcscr/pocketry) ·
+[Read the license](LICENSE) ·
+[Read third-party notices](NOTICE)
+
+## What it does
+
+- Detect a tool silhouette from a PNG or JPEG photograph.
+- Calibrate image dimensions and refine exterior contours and interior holes.
+- Export traced geometry as SVG, DXF, DWG-compatible DXF, or STL.
+- Arrange traced tools as pockets in Gridfinity bins.
+- Configure full-, half-, and quarter-pitch bins and export STL or 3MF models.
+- Export top-down layouts for shadow boards and CNC workflows.
+
+Pocketry is still subject to physical print validation. Inspect generated files
+and confirm dimensions and printer settings before relying on them for a final
+part.
+
+## Privacy
+
+The static application processes images and generates models locally in the
+browser. Projects are stored in the browser using IndexedDB. The hosted version
+does not require uploading tool photographs to Pocketry's server.
+
+## Run locally
+
+Pocketry requires Node.js 22 and npm.
+
+```sh
+npm ci
+npm run dev
+```
+
+The development server defaults to <http://localhost:5000>. If that port is in
+use, choose another one:
+
+```sh
+PORT=5001 npm run dev
+```
+
+## Verify and build
+
+Run the required type-check and test gate:
+
+```sh
+npm run check
+npm test
+```
+
+Create the production build in `dist/public`:
+
+```sh
+npm run build
+```
+
+The build includes `LICENSE.txt` and `NOTICE.txt` alongside the application.
+
+## Deploy to Cloudflare Pages
+
+Connect the GitHub repository to a Cloudflare Pages project with these build
+settings:
+
+- Production branch: `main`
+- Framework preset: None
+- Build command: `npm run build`
+- Build output directory: `dist/public`
+- Environment variable: `NODE_VERSION=22`
+
+Pocketry's public deployment is <https://pocketry.pages.dev>.
+
+## License and attribution
+
+Pocketry's original work is licensed under the
+[GNU Affero General Public License v3.0 only](LICENSE). Commercial use is
+permitted, but modified distributed versions and modified versions offered over
+a network must comply with the AGPL's source-sharing requirements.
+
+Third-party components and adapted source retain their original licenses. Their
+licenses, copyright notices, and provenance are recorded in [NOTICE](NOTICE).
+The detailed direct-source review is available in
+[docs/open-source-review.md](docs/open-source-review.md).
+
+## Contributing
+
+Issues and pull requests are welcome. Keep changes focused, add or update tests,
+run the required verification commands, and update `NOTICE` whenever adding a
+direct dependency, bundled artifact, copied component, or adapted source.

--- a/server/vite.test.ts
+++ b/server/vite.test.ts
@@ -1,0 +1,53 @@
+import express, { type Express } from "express";
+import type { Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { serveLegalFiles } from "./vite";
+
+let server: Server | undefined;
+
+afterEach(async () => {
+  if (!server) return;
+
+  await new Promise<void>((resolve, reject) => {
+    server?.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+  server = undefined;
+});
+
+async function listen(app: Express): Promise<string> {
+  server = await new Promise<Server>((resolve, reject) => {
+    const listeningServer = app.listen(0, "127.0.0.1", () => {
+      resolve(listeningServer);
+    });
+    listeningServer.once("error", reject);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected the legal-file test server to use a TCP port");
+  }
+
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe("serveLegalFiles", () => {
+  it.each([
+    ["LICENSE.txt", "GNU AFFERO GENERAL PUBLIC LICENSE"],
+    ["NOTICE.txt", "Pocketry"],
+  ])("serves %s as plain text", async (fileName, expectedText) => {
+    const app = express();
+    serveLegalFiles(app);
+    const baseUrl = await listen(app);
+
+    const response = await fetch(`${baseUrl}/${fileName}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toMatch(
+      /^text\/plain; charset=utf-8$/,
+    );
+    expect(await response.text()).toContain(expectedText);
+  });
+});

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -15,6 +15,11 @@ import { nanoid } from "nanoid";
 
 const viteLogger = createLogger();
 
+const legalFiles = [
+  { route: "/LICENSE.txt", source: "LICENSE" },
+  { route: "/NOTICE.txt", source: "NOTICE" },
+] as const;
+
 export function log(message: string, source = "express") {
   const formattedTime = new Date().toLocaleTimeString("en-US", {
     hour: "numeric",
@@ -24,6 +29,20 @@ export function log(message: string, source = "express") {
   });
 
   console.log(`${formattedTime} [${source}] ${message}`);
+}
+
+/** Serve repository legal files before Vite's SPA fallback in development. */
+export function serveLegalFiles(app: Express) {
+  for (const legalFile of legalFiles) {
+    app.get(legalFile.route, (_req, res, next) => {
+      res.type("text/plain").sendFile(
+        path.resolve(__dirname, "..", legalFile.source),
+        (error) => {
+          if (error) next(error);
+        },
+      );
+    });
+  }
 }
 
 export async function setupVite(app: Express, server: Server) {
@@ -47,6 +66,7 @@ export async function setupVite(app: Express, server: Server) {
     appType: "custom",
   });
 
+  serveLegalFiles(app);
   app.use(vite.middlewares);
   app.use("*", async (req, res, next) => {
     const url = req.originalUrl;


### PR DESCRIPTION
## Summary
- add a root project README covering features, privacy, local development, verification, Cloudflare Pages deployment, licensing, and contributions
- serve LICENSE.txt and NOTICE.txt ahead of the local Vite SPA fallback
- add integration coverage for both legal document routes

## Verification
- npm run check
- npm test (773 tests across 64 files)
- npm run build
- verified local LICENSE.txt and NOTICE.txt return 200 with text/plain content