### PR TITLE
Correct Pocketry copyright ownership

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Pocketry
-Copyright (c) 2026 Will Cobb
+Copyright (c) 2026 Sugarcreek Research, LLC
 
 This product includes third-party software and directly adapted open-source
 work. Pocketry's original work is distributed under the GNU Affero General

--- a/server/vite.test.ts
+++ b/server/vite.test.ts
@@ -36,7 +36,7 @@ async function listen(app: Express): Promise<string> {
 describe("serveLegalFiles", () => {
   it.each([
     ["LICENSE.txt", "GNU AFFERO GENERAL PUBLIC LICENSE"],
-    ["NOTICE.txt", "Pocketry"],
+    ["NOTICE.txt", "Copyright (c) 2026 Sugarcreek Research, LLC"],
   ])("serves %s as plain text", async (fileName, expectedText) => {
     const app = express();
     serveLegalFiles(app);


### PR DESCRIPTION
## Summary
- identify Sugarcreek Research, LLC as the copyright owner of Pocketry original work in NOTICE
- preserve every third-party copyright notice unchanged
- update legal-file regression coverage to assert the company notice

## Verification
- npm run check
- npm test (773 tests across 64 files)
- npm run build