### PR TITLE
Improve scale and add perspective correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ server/public
 
 # Local mesh export artifacts (npm run export:bin)
 exports/
+output/pdf/
 
 # Legacy scaffold and pasted-session artifacts
 .replit

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ processing, project storage, and model generation kept on the user's device.
 ## What it does
 
 - Detect a tool silhouette from a PNG or JPEG photograph.
-- Calibrate image dimensions and refine exterior contours and interior holes.
+- Calibrate image dimensions with a printable A4 or US Letter PDF sheet, which
+  Pocketry identifies automatically, and correct camera perspective.
+- Refine exterior contours and interior holes.
 - Export traced geometry as SVG, DXF, DWG-compatible DXF, or STL.
 - Arrange traced tools as pockets in Gridfinity bins.
 - Configure full-, half-, and quarter-pitch bins and export STL or 3MF models.
@@ -23,8 +25,10 @@ and confirm dimensions and printer settings before relying on them for a final
 part.
 
 Perspective correction rectifies the flat reference plane represented by the
-calibration sheet or four selected paper corners. Thick tools extend above that
-plane and can still show parallax when photographed at an angle. A future
+calibration sheet or four selected paper corners. The automatic path fits all
+16 refined marker corners for better precision; the marker IDs distinguish A4
+from US Letter without a paper-size prompt. Thick tools extend above that plane
+and can still show parallax when photographed at an angle. A future
 imaging improvement should investigate height-aware or multi-view correction
 for those tools rather than treating a planar homography as a complete 3D
 camera correction.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Pocketry is still subject to physical print validation. Inspect generated files
 and confirm dimensions and printer settings before relying on them for a final
 part.
 
+Perspective correction rectifies the flat reference plane represented by the
+calibration sheet or four selected paper corners. Thick tools extend above that
+plane and can still show parallax when photographed at an angle. A future
+imaging improvement should investigate height-aware or multi-view correction
+for those tools rather than treating a planar homography as a complete 3D
+camera correction.
+
 ## Privacy
 
 The static application processes images and generates models locally in the

--- a/client/src/app.smoke.test.tsx
+++ b/client/src/app.smoke.test.tsx
@@ -187,6 +187,15 @@ describe("App", () => {
     expect(help?.textContent).toContain(
       "automatically looks for its calibration-sheet markers",
     );
+    expect(help?.textContent).toContain(
+      "paper size is identified automatically",
+    );
+    expect(
+      help?.querySelector('[data-testid="help-print-template-a4"]'),
+    ).not.toBeNull();
+    expect(
+      help?.querySelector('[data-testid="help-print-template-letter"]'),
+    ).not.toBeNull();
     expect(help?.textContent).toContain("another item with a precisely known dimension");
     expect(help?.textContent).toContain("Before printing the full bin");
     expect(help?.textContent).toContain("Preview/shadow-board layout");

--- a/client/src/app.smoke.test.tsx
+++ b/client/src/app.smoke.test.tsx
@@ -134,6 +134,14 @@ describe("App", () => {
     expect(container.textContent).toContain("Gridfinity Extended");
     expect(container.textContent).toContain("Gridfinity Layout Tool");
     expect(container.textContent).toContain("Outline App");
+    expect(container.textContent).toContain("Tracefinity");
+    expect(container.textContent).toContain("ToolTrace.ai");
+    expect(container.textContent).toContain("Systemax DIY");
+    expect(container.textContent).toContain("Gridfinity Rebase");
+    expect(container.textContent).toContain("GridFlock");
+    expect(container.textContent).toContain(
+      "complement Pocketry or provide alternatives",
+    );
     expect(
       container.querySelector<HTMLAnchorElement>('a[href="/LICENSE.txt"]'),
     ).not.toBeNull();

--- a/client/src/components/help/help-dialog.tsx
+++ b/client/src/components/help/help-dialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { downloadCalibrationTemplate } from "@/lib/calibrate/download-template";
 
 export interface HelpDialogProps {
   open: boolean;
@@ -50,9 +51,29 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
               </li>
               <li>
                 Pocketry automatically looks for its calibration-sheet markers
-                when the image loads. If found, it proposes a real-world{" "}
-                <strong>Scale</strong>; check the ruler overlay and accept it
-                before continuing.
+                when the image loads. A4 and US Letter sheets use different
+                markers, so the paper size is identified automatically. If all
+                four markers are visible, Pocketry can also correct camera
+                perspective before tracing. Check the preview, then accept it.
+                If you do not have a sheet yet, download and print the{" "}
+                <button
+                  type="button"
+                  className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                  onClick={() => downloadCalibrationTemplate("a4")}
+                  data-testid="help-print-template-a4"
+                >
+                  A4 PDF template
+                </button>{" "}
+                or{" "}
+                <button
+                  type="button"
+                  className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                  onClick={() => downloadCalibrationTemplate("letter")}
+                  data-testid="help-print-template-letter"
+                >
+                  US Letter PDF template
+                </button>{" "}
+                at 100% scale.
               </li>
               <li>
                 If automatic scale detection is unavailable or not sufficiently

--- a/client/src/components/trace/trace-canvas-history.test.tsx
+++ b/client/src/components/trace/trace-canvas-history.test.tsx
@@ -89,6 +89,47 @@ function SeedScaleDraft(): null {
   return null;
 }
 
+function SeedPerspectiveSelection(): null {
+  const { dispatch } = useTrace();
+  React.useEffect(() => {
+    dispatch({
+      type: "SOURCE_LOADED",
+      imageUrl: "data:image/png;base64,AA==",
+      fileName: "tool.png",
+    });
+    dispatch({ type: "SOURCE_READY", imageSize: { width: 100, height: 100 } });
+    dispatch({ type: "START_PERSPECTIVE_SELECTION" });
+  }, [dispatch]);
+  return null;
+}
+
+function SeedAutoScale(): JSX.Element {
+  const { dispatch } = useTrace();
+  React.useEffect(() => {
+    dispatch({
+      type: "SOURCE_LOADED",
+      imageUrl: "data:image/png;base64,AA==",
+      fileName: "tool.png",
+    });
+    dispatch({ type: "SOURCE_READY", imageSize: { width: 100, height: 100 } });
+    dispatch({
+      type: "AUTO_CALIBRATION_DETECTED",
+      calibration: {
+        startX: 10,
+        startY: 10,
+        endX: 90,
+        endY: 90,
+        lengthMm: 250,
+      },
+    });
+  }, [dispatch]);
+  return (
+    <button type="button" onClick={() => dispatch({ type: "ACCEPT_AUTO_CALIBRATION" })}>
+      Accept auto scale
+    </button>
+  );
+}
+
 function installIdentitySvgCoordinates(): () => void {
   const ctmDescriptor = Object.getOwnPropertyDescriptor(
     SVGElement.prototype,
@@ -190,6 +231,38 @@ describe("TraceCanvas edit history", () => {
     React.act(() => root.unmount());
   });
 
+  it("hides an accepted sheet ruler before region selection", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("ResizeObserver", NoopResizeObserver);
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await React.act(async () => {
+      root.render(
+        <TraceProvider>
+          <SeedAutoScale />
+          <TooltipProvider>
+            <TraceCanvas onReprocess={() => {}} />
+          </TooltipProvider>
+        </TraceProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(host.querySelector('[data-testid="ruler-line"]')).not.toBeNull();
+    React.act(() =>
+      host
+        .querySelector<HTMLButtonElement>("button")!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+
+    expect(host.querySelector('[data-testid="ruler-line"]')).toBeNull();
+    expect(host.querySelectorAll('[data-testid="ruler-marker"]')).toHaveLength(0);
+
+    React.act(() => root.unmount());
+  });
+
   it("extends the draft ruler to follow the pointer after its first marker", async () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     vi.stubGlobal("ResizeObserver", NoopResizeObserver);
@@ -233,6 +306,61 @@ describe("TraceCanvas edit history", () => {
       expect(host.querySelector('[data-testid="ruler-length-label"]')?.textContent).toBe(
         "100 mm",
       );
+    } finally {
+      React.act(() => root.unmount());
+      restoreSvgCoordinates();
+    }
+  });
+
+  it("places four manual perspective corners and closes the correction quad", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("ResizeObserver", NoopResizeObserver);
+    const restoreSvgCoordinates = installIdentitySvgCoordinates();
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    try {
+      await React.act(async () => {
+        root.render(
+          <TraceProvider>
+            <SeedPerspectiveSelection />
+            <TooltipProvider>
+              <TraceCanvas onReprocess={() => {}} />
+            </TooltipProvider>
+          </TraceProvider>,
+        );
+        await Promise.resolve();
+      });
+
+      const canvas = host.querySelector("svg");
+      expect(canvas).not.toBeNull();
+      const points = [
+        [10, 10],
+        [90, 12],
+        [88, 90],
+        [12, 88],
+      ];
+      for (const [clientX, clientY] of points) {
+        await React.act(async () => {
+          canvas?.dispatchEvent(
+            new MouseEvent("pointerdown", {
+              bubbles: true,
+              button: 0,
+              clientX,
+              clientY,
+            }),
+          );
+        });
+      }
+
+      expect(host.querySelectorAll('[data-testid="perspective-marker"]')).toHaveLength(
+        4,
+      );
+      expect(host.querySelectorAll("[data-perspective-handle]")).toHaveLength(4);
+      expect(
+        host.querySelector('[data-testid="perspective-outline"]')?.getAttribute("d"),
+      ).toContain("Z");
     } finally {
       React.act(() => root.unmount());
       restoreSvgCoordinates();

--- a/client/src/components/trace/trace-canvas-history.test.tsx
+++ b/client/src/components/trace/trace-canvas-history.test.tsx
@@ -71,6 +71,70 @@ function SeedTrace(): null {
   return null;
 }
 
+function SeedScaleDraft(): null {
+  const { dispatch } = useTrace();
+  React.useEffect(() => {
+    dispatch({
+      type: "SOURCE_LOADED",
+      imageUrl: "data:image/png;base64,AA==",
+      fileName: "tool.png",
+    });
+    dispatch({ type: "SOURCE_READY", imageSize: { width: 100, height: 100 } });
+    dispatch({ type: "SET_MODE", mode: "calibrate" });
+    dispatch({
+      type: "SET_DRAFT_CALIBRATION",
+      draftCalibration: { startX: 10, startY: 20 },
+    });
+  }, [dispatch]);
+  return null;
+}
+
+function installIdentitySvgCoordinates(): () => void {
+  const ctmDescriptor = Object.getOwnPropertyDescriptor(
+    SVGElement.prototype,
+    "getScreenCTM",
+  );
+  const pointDescriptor = Object.getOwnPropertyDescriptor(
+    SVGSVGElement.prototype,
+    "createSVGPoint",
+  );
+
+  Object.defineProperty(SVGElement.prototype, "getScreenCTM", {
+    configurable: true,
+    value: () => ({ inverse: () => ({}) }),
+  });
+  Object.defineProperty(SVGSVGElement.prototype, "createSVGPoint", {
+    configurable: true,
+    value: () => {
+      const point = {
+        x: 0,
+        y: 0,
+        matrixTransform: () => ({ x: point.x, y: point.y }),
+      };
+      return point;
+    },
+  });
+
+  return () => {
+    if (ctmDescriptor) {
+      Object.defineProperty(SVGElement.prototype, "getScreenCTM", ctmDescriptor);
+    } else {
+      delete (SVGElement.prototype as unknown as { getScreenCTM?: unknown })
+        .getScreenCTM;
+    }
+    if (pointDescriptor) {
+      Object.defineProperty(
+        SVGSVGElement.prototype,
+        "createSVGPoint",
+        pointDescriptor,
+      );
+    } else {
+      delete (SVGSVGElement.prototype as unknown as { createSVGPoint?: unknown })
+        .createSVGPoint;
+    }
+  };
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
   document.body.replaceChildren();
@@ -115,10 +179,63 @@ describe("TraceCanvas edit history", () => {
     expect(stroke?.getAttribute("stroke-width")).toBe("2.75");
     expect(stroke?.getAttribute("class")).toContain("stroke-fuchsia-500/95");
     expect(region?.getAttribute("opacity")).toBe("0.4");
-    // Accepted calibration is retained in state but no longer dominates the
-    // canvas after the user leaves scale mode.
-    expect(host.querySelector("[data-ruler-handle]")).toBeNull();
+    // A completed ruler remains visible and editable after scale mode ends.
+    expect(host.querySelectorAll('[data-testid="ruler-marker"]')).toHaveLength(2);
+    expect(host.querySelectorAll("[data-ruler-handle]")).toHaveLength(2);
+    expect(host.querySelector('[data-testid="ruler-line"]')).not.toBeNull();
+    expect(host.querySelector('[data-testid="ruler-length-label"]')?.textContent).toBe(
+      "50 mm",
+    );
 
     React.act(() => root.unmount());
+  });
+
+  it("extends the draft ruler to follow the pointer after its first marker", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("ResizeObserver", NoopResizeObserver);
+    const restoreSvgCoordinates = installIdentitySvgCoordinates();
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    try {
+      await React.act(async () => {
+        root.render(
+          <TraceProvider>
+            <SeedScaleDraft />
+            <TooltipProvider>
+              <TraceCanvas onReprocess={() => {}} />
+            </TooltipProvider>
+          </TraceProvider>,
+        );
+        await Promise.resolve();
+      });
+
+      const canvas = host.querySelector("svg");
+      expect(canvas).not.toBeNull();
+      expect(host.querySelectorAll('[data-testid="ruler-marker"]')).toHaveLength(1);
+
+      await React.act(async () => {
+        canvas?.dispatchEvent(
+          new MouseEvent("pointermove", {
+            bubbles: true,
+            clientX: 70,
+            clientY: 80,
+          }),
+        );
+      });
+
+      const line = host.querySelector('[data-testid="ruler-line"]');
+      expect(line?.getAttribute("data-ruler-preview")).toBe("true");
+      expect(line?.getAttribute("x2")).toBe("70");
+      expect(line?.getAttribute("y2")).toBe("80");
+      expect(host.querySelectorAll('[data-testid="ruler-marker"]')).toHaveLength(2);
+      expect(host.querySelector('[data-testid="ruler-length-label"]')?.textContent).toBe(
+        "100 mm",
+      );
+    } finally {
+      React.act(() => root.unmount());
+      restoreSvgCoordinates();
+    }
   });
 });

--- a/client/src/components/trace/trace-canvas.tsx
+++ b/client/src/components/trace/trace-canvas.tsx
@@ -244,7 +244,9 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
     // Ruler handles stay draggable in every mode, matching the old behaviour.
     if (displayedCalibration) {
       const target = event.target as Element;
-      const handle = target.getAttribute?.("data-ruler-handle");
+      const handle = target
+        .closest?.("[data-ruler-handle]")
+        ?.getAttribute("data-ruler-handle");
       if (handle === "start" || handle === "end") {
         dragRef.current = { kind: "ruler", end: handle };
         event.currentTarget.setPointerCapture(event.pointerId);
@@ -263,7 +265,10 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
     }
 
     if (mode === "calibrate" && event.button === 0) {
-      if (!draftCalibration?.startX) {
+      if (
+        draftCalibration?.startX === undefined ||
+        draftCalibration.startY === undefined
+      ) {
         dispatch({
           type: "SET_DRAFT_CALIBRATION",
           draftCalibration: { startX: image.x, startY: image.y },
@@ -273,7 +278,7 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
           type: "SET_CALIBRATION",
           calibration: {
             startX: draftCalibration.startX,
-            startY: draftCalibration.startY ?? image.y,
+            startY: draftCalibration.startY,
             endX: image.x,
             endY: image.y,
             lengthMm: rulerLengthMm,
@@ -354,6 +359,25 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
 
     const drag = dragRef.current;
     if (!drag) {
+      if (
+        mode === "calibrate" &&
+        !viewport.isPanning &&
+        draftCalibration?.startX !== undefined &&
+        draftCalibration.startY !== undefined
+      ) {
+        const image = toImage(event.clientX, event.clientY);
+        if (image) {
+          dispatch({
+            type: "SET_DRAFT_CALIBRATION",
+            draftCalibration: {
+              ...draftCalibration,
+              endX: image.x,
+              endY: image.y,
+            },
+          });
+        }
+        return;
+      }
       updateHover(event);
       viewport.handlers.onPointerMove(event);
       return;
@@ -503,11 +527,12 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
           region={region}
           regionActive={mode === "region"}
           calibration={
-            mode === "calibrate" || pendingAutoCalibration
-              ? displayedCalibration
-              : null
+            mode === "calibrate" && draftCalibration?.startX !== undefined
+              ? null
+              : displayedCalibration
           }
           draftCalibration={mode === "calibrate" ? draftCalibration : null}
+          rulerLengthMm={rulerLengthMm}
           busy={processing}
           cursor={cursor}
           hoveredVertexIndex={hoveredVertexIndex}

--- a/client/src/components/trace/trace-canvas.tsx
+++ b/client/src/components/trace/trace-canvas.tsx
@@ -87,9 +87,12 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
     selection,
     region,
     calibration,
+    calibrationSource,
     pendingAutoCalibration,
     draftCalibration,
     rulerLengthMm,
+    pendingPerspective,
+    manualPerspectivePoints,
     mode,
     processing,
     dispatch,
@@ -99,7 +102,15 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
     undo,
     redo,
   } = store;
-  const displayedCalibration = pendingAutoCalibration ?? calibration;
+  // Detected sheet geometry is useful while the user reviews it, but becomes
+  // visual noise once accepted and the region tool takes over. A manually
+  // placed ruler remains visible so its handles and label stay editable.
+  const displayedCalibration =
+    pendingAutoCalibration ?? (calibrationSource === "manual" ? calibration : null);
+  const perspectiveOverlayPoints =
+    manualPerspectivePoints.length > 0
+      ? manualPerspectivePoints
+      : (pendingPerspective?.points ?? []);
 
   const containerSize = useCanvasViewportSize();
   const svgRef = useRef<SVGSVGElement | null>(null);
@@ -119,6 +130,7 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
   // Mirrors the hook's space tracking so the cursor can promise a pan before
   // the drag starts.
   const [shiftHeld, setShiftHeld] = useState(false);
+  const [perspectivePointer, setPerspectivePointer] = useState<Point | null>(null);
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Shift") setShiftHeld(true);
@@ -136,6 +148,12 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
       window.removeEventListener("blur", onBlur);
     };
   }, []);
+
+  useEffect(() => {
+    if (mode !== "perspective" || manualPerspectivePoints.length >= 4) {
+      setPerspectivePointer(null);
+    }
+  }, [mode, manualPerspectivePoints.length]);
 
   useEffect(() => {
     viewport.attachWheel(svgRef.current);
@@ -173,6 +191,7 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
     | { kind: "region"; origin: Point }
     | { kind: "vertex"; ref: RingRef; index: number }
     | { kind: "ruler"; end: "start" | "end" }
+    | { kind: "perspective"; index: number }
     | null
   >(null);
 
@@ -241,8 +260,22 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
     const image = toImage(event.clientX, event.clientY);
     if (!image) return;
 
-    // Ruler handles stay draggable in every mode, matching the old behaviour.
-    if (displayedCalibration) {
+    if (manualPerspectivePoints.length > 0) {
+      const target = event.target as Element;
+      const handle = target
+        .closest?.("[data-perspective-handle]")
+        ?.getAttribute("data-perspective-handle");
+      const index = handle === null ? Number.NaN : Number(handle);
+      if (Number.isInteger(index) && index >= 0 && index < 4) {
+        dragRef.current = { kind: "perspective", index };
+        event.currentTarget.setPointerCapture(event.pointerId);
+        return;
+      }
+    }
+
+    // Ruler handles stay draggable except while the page-corner tool owns the
+    // pointer; its markers may legitimately overlap the scale ruler.
+    if (displayedCalibration && mode !== "perspective") {
       const target = event.target as Element;
       const handle = target
         .closest?.("[data-ruler-handle]")
@@ -252,6 +285,14 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
         event.currentTarget.setPointerCapture(event.pointerId);
         return;
       }
+    }
+
+    if (mode === "perspective" && event.button === 0) {
+      dispatch({
+        type: "ADD_PERSPECTIVE_POINT",
+        point: clampPointToImage(image, imageSize),
+      });
+      return;
     }
 
     if (mode === "region" && event.button === 0) {
@@ -359,6 +400,13 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
 
     const drag = dragRef.current;
     if (!drag) {
+      if (mode === "perspective" && manualPerspectivePoints.length < 4) {
+        const image = toImage(event.clientX, event.clientY);
+        setPerspectivePointer(
+          image ? clampPointToImage(image, imageSize) : null,
+        );
+        return;
+      }
       if (
         mode === "calibrate" &&
         !viewport.isPanning &&
@@ -402,6 +450,13 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
             ? { ...displayedCalibration, startX: image.x, startY: image.y }
             : { ...displayedCalibration, endX: image.x, endY: image.y },
       });
+      return;
+    }
+
+    if (drag.kind === "perspective") {
+      const points = [...manualPerspectivePoints];
+      points[drag.index] = clampPointToImage(image, imageSize);
+      dispatch({ type: "SET_PERSPECTIVE_POINTS", points });
       return;
     }
 
@@ -507,7 +562,13 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
     if (viewport.isSpaceHeld || shiftHeld) return "grab";
     // Promise the grab before the drag, too.
     if (hoveredVertexIndex !== null) return "move";
-    if (mode === "region" || mode === "calibrate") return "crosshair";
+    if (
+      mode === "region" ||
+      mode === "calibrate" ||
+      mode === "perspective"
+    ) {
+      return "crosshair";
+    }
     return "default";
   }, [mode, viewport.isPanning, viewport.isSpaceHeld, shiftHeld, hoveredVertexIndex]);
 
@@ -527,12 +588,17 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
           region={region}
           regionActive={mode === "region"}
           calibration={
-            mode === "calibrate" && draftCalibration?.startX !== undefined
+            mode === "perspective"
+              ? null
+              : mode === "calibrate" && draftCalibration?.startX !== undefined
               ? null
               : displayedCalibration
           }
           draftCalibration={mode === "calibrate" ? draftCalibration : null}
           rulerLengthMm={rulerLengthMm}
+          perspectivePoints={perspectiveOverlayPoints}
+          perspectiveEditable={manualPerspectivePoints.length > 0}
+          perspectivePreview={perspectivePointer}
           busy={processing}
           cursor={cursor}
           hoveredVertexIndex={hoveredVertexIndex}
@@ -540,7 +606,10 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
           onPointerMove={handlePointerMove}
           onPointerUp={endDrag}
           onPointerCancel={endDrag}
-          onPointerLeave={() => setHoveredVertexIndex(null)}
+          onPointerLeave={() => {
+            setHoveredVertexIndex(null);
+            setPerspectivePointer(null);
+          }}
           onContextMenu={handleContextMenu}
         />
       ) : (
@@ -717,6 +786,16 @@ function rectFromPoints(
   const right = Math.min(bounds.width, Math.max(a.x, b.x));
   const bottom = Math.min(bounds.height, Math.max(a.y, b.y));
   return { x, y, width: Math.max(0, right - x), height: Math.max(0, bottom - y) };
+}
+
+function clampPointToImage(
+  point: Point,
+  bounds: { width: number; height: number },
+): Point {
+  return {
+    x: Math.max(0, Math.min(Math.max(0, bounds.width - 1), point.x)),
+    y: Math.max(0, Math.min(Math.max(0, bounds.height - 1), point.y)),
+  };
 }
 
 interface ShortcutHandlers {

--- a/client/src/components/trace/trace-controls-panel.test.tsx
+++ b/client/src/components/trace/trace-controls-panel.test.tsx
@@ -11,6 +11,8 @@ import { TraceProvider, useTrace } from "@/state/trace-store";
 
 import { TraceControlsPanel } from "./trace-controls-panel";
 
+vi.mock("@/lib/download", () => ({ downloadBlob: vi.fn() }));
+
 const CALIBRATION: Calibration = {
   startX: 0,
   startY: 0,
@@ -18,6 +20,8 @@ const CALIBRATION: Calibration = {
   endY: 0,
   lengthMm: 50,
 };
+
+const applyPerspective = vi.fn();
 
 class NoopResizeObserver implements ResizeObserver {
   observe() {}
@@ -54,6 +58,41 @@ function Harness(): JSX.Element {
         Detect auto scale
       </button>
       <button
+        data-testid="detect-auto-perspective"
+        onClick={() =>
+          dispatch({
+            type: "AUTO_CALIBRATION_DETECTED",
+            calibration: CALIBRATION,
+            perspective: {
+              source: "template",
+              points: [
+                { x: 10, y: 10 },
+                { x: 110, y: 12 },
+                { x: 108, y: 140 },
+                { x: 12, y: 138 },
+              ],
+            },
+          })
+        }
+      >
+        Detect auto perspective
+      </button>
+      <button
+        data-testid="complete-perspective-points"
+        onClick={() => {
+          for (const point of [
+            { x: 10, y: 10 },
+            { x: 790, y: 12 },
+            { x: 788, y: 590 },
+            { x: 12, y: 588 },
+          ]) {
+            dispatch({ type: "ADD_PERSPECTIVE_POINT", point });
+          }
+        }}
+      >
+        Complete perspective points
+      </button>
+      <button
         data-testid="complete-manual-scale"
         onClick={() => dispatch({ type: "SET_CALIBRATION", calibration: CALIBRATION })}
       >
@@ -76,6 +115,7 @@ function Harness(): JSX.Element {
         onExport={() => {}}
         onReprocess={() => {}}
         onDetectMarkers={() => {}}
+        onApplyPerspective={applyPerspective}
       />
     </>
   );
@@ -85,6 +125,7 @@ let host: HTMLDivElement;
 let root: Root;
 
 beforeEach(() => {
+  applyPerspective.mockReset();
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   vi.stubGlobal("ResizeObserver", NoopResizeObserver);
   vi.spyOn(window, "requestAnimationFrame").mockImplementation(
@@ -94,7 +135,6 @@ beforeEach(() => {
   vi.spyOn(window, "cancelAnimationFrame").mockImplementation(
     (handle: number) => window.clearTimeout(handle),
   );
-
   host = document.createElement("div");
   document.body.appendChild(host);
   root = createRoot(host);
@@ -227,6 +267,43 @@ describe("TraceControlsPanel guided workflow", () => {
     expect(document.activeElement).toBe(regionTrigger);
     expect(regionTrigger?.className).toContain(
       "animate-[pulse_1s_ease-in-out_3]",
+    );
+  });
+
+  it("offers automatic and manual perspective correction paths", async () => {
+    await click("load-source");
+    await click("detect-auto-perspective");
+
+    const automaticCorrection = host.querySelector<HTMLButtonElement>(
+      '[data-testid="button-apply-auto-perspective"]',
+    );
+    expect(automaticCorrection).not.toBeNull();
+    expect(automaticCorrection?.disabled).toBe(true);
+    expect(section("scale")?.textContent).toContain("Choose A4 or US Letter");
+
+    await click("button-calibration-sheet-options");
+    await React.act(async () => {
+      document.body
+        .querySelector<HTMLButtonElement>('[data-testid="button-template-letter"]')!
+        .click();
+      await new Promise((resolve) => window.setTimeout(resolve, 10));
+    });
+
+    expect(automaticCorrection?.disabled).toBe(false);
+    await click("button-apply-auto-perspective");
+    expect(applyPerspective).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: "template" }),
+      "letter",
+    );
+
+    await click("button-select-perspective-points");
+    expect(host.textContent).toContain("corner 1 of 4");
+    await click("complete-perspective-points");
+    expect(host.textContent).toContain("Four corners selected");
+    await click("button-apply-manual-perspective");
+    expect(applyPerspective).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: "manual" }),
+      "letter",
     );
   });
 

--- a/client/src/components/trace/trace-controls-panel.test.tsx
+++ b/client/src/components/trace/trace-controls-panel.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Calibration } from "@shared/geometry/scale";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { downloadBlob } from "@/lib/download";
 import { ShapeLibraryProvider } from "@/state/shape-library";
 import { TraceProvider, useTrace } from "@/state/trace-store";
 
@@ -65,6 +66,7 @@ function Harness(): JSX.Element {
             calibration: CALIBRATION,
             perspective: {
               source: "template",
+              paper: "letter",
               points: [
                 { x: 10, y: 10 },
                 { x: 110, y: 12 },
@@ -126,6 +128,7 @@ let root: Root;
 
 beforeEach(() => {
   applyPerspective.mockReset();
+  vi.mocked(downloadBlob).mockReset();
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   vi.stubGlobal("ResizeObserver", NoopResizeObserver);
   vi.spyOn(window, "requestAnimationFrame").mockImplementation(
@@ -278,24 +281,26 @@ describe("TraceControlsPanel guided workflow", () => {
       '[data-testid="button-apply-auto-perspective"]',
     );
     expect(automaticCorrection).not.toBeNull();
-    expect(automaticCorrection?.disabled).toBe(true);
-    expect(section("scale")?.textContent).toContain("Choose A4 or US Letter");
-
-    await click("button-calibration-sheet-options");
-    await React.act(async () => {
-      document.body
-        .querySelector<HTMLButtonElement>('[data-testid="button-template-letter"]')!
-        .click();
-      await new Promise((resolve) => window.setTimeout(resolve, 10));
-    });
-
     expect(automaticCorrection?.disabled).toBe(false);
+    expect(section("scale")?.textContent).toContain(
+      "US Letter template detected automatically",
+    );
     await click("button-apply-auto-perspective");
     expect(applyPerspective).toHaveBeenLastCalledWith(
       expect.objectContaining({ source: "template" }),
       "letter",
     );
 
+    await click("link-print-template-letter");
+    expect(downloadBlob).toHaveBeenLastCalledWith(
+      expect.any(Blob),
+      "pocketry-calibration-letter.pdf",
+    );
+    const downloadedPdf = vi.mocked(downloadBlob).mock.calls.at(-1)![0];
+    expect(downloadedPdf.type).toBe("application/pdf");
+    expect(
+      new TextDecoder().decode(await downloadedPdf.arrayBuffer()).startsWith("%PDF-1.4"),
+    ).toBe(true);
     await click("button-select-perspective-points");
     expect(host.textContent).toContain("corner 1 of 4");
     await click("complete-perspective-points");

--- a/client/src/components/trace/trace-controls-panel.test.tsx
+++ b/client/src/components/trace/trace-controls-panel.test.tsx
@@ -125,6 +125,21 @@ async function click(testId: string): Promise<void> {
   });
 }
 
+async function changeNumber(id: string, value: string): Promise<void> {
+  await React.act(async () => {
+    const input = host.querySelector<HTMLInputElement>(`#${id}`);
+    expect(input).not.toBeNull();
+    input!.focus();
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )!.set!;
+    setter.call(input, value);
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    await new Promise((resolve) => window.setTimeout(resolve, 10));
+  });
+}
+
 function section(id: string): HTMLElement | null {
   return host.querySelector<HTMLElement>(`#trace-settings-${id}`);
 }
@@ -271,5 +286,19 @@ describe("TraceControlsPanel guided workflow", () => {
     expect(host.textContent).toContain(
       "Detection starts when you finish",
     );
+  });
+
+  it("updates the displayed manual scale when the reference length changes", async () => {
+    await click("load-source");
+    await click("complete-manual-scale");
+
+    expect(section("scale")?.textContent).toContain("0.500 mm/px");
+    await React.act(async () => {
+      sectionTrigger("scale")?.click();
+      await new Promise((resolve) => window.setTimeout(resolve, 10));
+    });
+    await changeNumber("ruler-length", "200");
+    expect(section("scale")?.textContent).toContain("2.000 mm/px");
+    expect(section("scale")?.textContent).toContain("2 mm/px (0.5 px/mm)");
   });
 });

--- a/client/src/components/trace/trace-controls-panel.tsx
+++ b/client/src/components/trace/trace-controls-panel.tsx
@@ -49,8 +49,8 @@ import {
   type PerspectiveProposal,
   type PerspectiveQuad,
 } from "@/lib/calibrate/perspective";
-import { calibrationTemplateSvg, type TemplatePaper } from "@/lib/calibrate/template";
-import { downloadBlob } from "@/lib/download";
+import { downloadCalibrationTemplate } from "@/lib/calibrate/download-template";
+import type { TemplatePaper } from "@/lib/calibrate/template";
 import { describeScale, exportScale } from "@/lib/export/scale";
 import { normalizeTracedShape } from "@/lib/gridfinity/traced-shape";
 import { MARGIN_MM_OPTIONS } from "@/lib/image-processor";
@@ -81,13 +81,6 @@ const TRACE_SETTINGS_SECTION_DETAILS = [
   { id: "trace-settings-contours", label: "Contours", tone: "violet" },
   { id: "trace-settings-output", label: "Output", tone: "emerald" },
 ] as const;
-
-function downloadCalibrationTemplate(paper: TemplatePaper): void {
-  downloadBlob(
-    new Blob([calibrationTemplateSvg(paper)], { type: "image/svg+xml" }),
-    `pocketry-calibration-${paper}.svg`,
-  );
-}
 
 /**
  * Everything that used to sit above or below the canvas, moved into the side
@@ -183,9 +176,8 @@ export function TraceControlsPanel({
     "scale" | "region" | "detection" | null
   >(null);
   const [calibrationSheetOpen, setCalibrationSheetOpen] = useState(false);
-  // Marker spacing is identical on A4 and Letter, so detection cannot infer
-  // the page size. Never silently assume one: downloading or explicitly
-  // selecting a template supplies the missing information.
+  // The template marker family identifies paper automatically. A markerless
+  // four-corner fallback still needs the printed paper's dimensions.
   const [perspectivePaper, setPerspectivePaper] =
     useState<TemplatePaper | null>(null);
   const previousSourceRevision = useRef(sourceRevision);
@@ -385,34 +377,21 @@ export function TraceControlsPanel({
               </p>
               {pendingPerspective ? (
                 <>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="auto-perspective-paper" className="text-xs">
-                      Printed paper size
-                    </Label>
-                    <Select
-                      value={perspectivePaper ?? undefined}
-                      onValueChange={(value) =>
-                        setPerspectivePaper(value as TemplatePaper)
-                      }
-                    >
-                      <SelectTrigger id="auto-perspective-paper" className="w-full">
-                        <SelectValue placeholder="Choose A4 or US Letter" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="a4">A4</SelectItem>
-                        <SelectItem value="letter">US Letter</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
+                  <p className="text-xs font-medium text-amber-800 dark:text-amber-200">
+                    {pendingPerspective.paper === "a4" ? "A4" : "US Letter"}{" "}
+                    template detected automatically
+                  </p>
                   <Button
                     size="sm"
                     className="w-full"
-                    disabled={processing || perspectivePaper === null}
-                    onClick={() => {
-                      if (perspectivePaper) {
-                        onApplyPerspective(pendingPerspective, perspectivePaper);
-                      }
-                    }}
+                    disabled={processing || !pendingPerspective.paper}
+                    onClick={() =>
+                      pendingPerspective.paper &&
+                      onApplyPerspective(
+                        pendingPerspective,
+                        pendingPerspective.paper,
+                      )
+                    }
                     data-testid="button-apply-auto-perspective"
                   >
                     <ScanLine className="mr-1.5 h-4 w-4" />
@@ -537,13 +516,14 @@ export function TraceControlsPanel({
             ) : (
               <>
                 <p className="text-xs text-muted-foreground">
-                  If markers are unavailable, select the four visible paper
+                  The printed markers identify A4 or US Letter automatically.
+                  If the markers are unavailable, select the four visible paper
                   corners: top-left, top-right, bottom-right, then bottom-left.
                 </p>
                 {!pendingPerspective && (
                   <div className="space-y-1.5">
                     <Label htmlFor="manual-perspective-paper" className="text-xs">
-                      Paper size
+                      Paper size for manual fallback
                     </Label>
                     <Select
                       value={perspectivePaper ?? undefined}
@@ -615,6 +595,34 @@ export function TraceControlsPanel({
             )}
           </div>
 
+          <p className="text-xs text-muted-foreground">
+            Need a calibration sheet?{" "}
+            <button
+              type="button"
+              className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+              onClick={() => {
+                setPerspectivePaper("a4");
+                downloadCalibrationTemplate("a4");
+              }}
+              data-testid="link-print-template-a4"
+            >
+              Print A4 PDF template
+            </button>{" "}
+            or{" "}
+            <button
+              type="button"
+              className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+              onClick={() => {
+                setPerspectivePaper("letter");
+                downloadCalibrationTemplate("letter");
+              }}
+              data-testid="link-print-template-letter"
+            >
+              Print US Letter PDF template
+            </button>
+            .
+          </p>
+
           <Dialog open={calibrationSheetOpen} onOpenChange={setCalibrationSheetOpen}>
             <Button
               variant="link"
@@ -630,8 +638,9 @@ export function TraceControlsPanel({
                 <DialogTitle>Calibration sheet</DialogTitle>
                 <DialogDescription>
                   Print the sheet once at 100%, then include it beneath tools for
-                  automatic scale detection. The downloaded size is also selected
-                  for perspective correction.
+                  automatic scale and perspective correction. A4 and US Letter
+                  use different marker IDs, so Pocketry identifies the paper size
+                  for you.
                 </DialogDescription>
               </DialogHeader>
               <Button
@@ -656,7 +665,7 @@ export function TraceControlsPanel({
                   }}
                   data-testid="button-template-a4"
                 >
-                  A4
+                  Print A4 PDF
                 </Button>
                 <Button
                   variant={perspectivePaper === "letter" ? "default" : "outline"}
@@ -667,7 +676,7 @@ export function TraceControlsPanel({
                   }}
                   data-testid="button-template-letter"
                 >
-                  US Letter
+                  Print US Letter PDF
                 </Button>
               </div>
             </DialogContent>

--- a/client/src/components/trace/trace-controls-panel.tsx
+++ b/client/src/components/trace/trace-controls-panel.tsx
@@ -7,6 +7,8 @@ import {
   Image as ImageIcon,
   Layers,
   Ruler,
+  RotateCcw,
+  ScanLine,
   ScanSearch,
   Sparkles,
   Settings2,
@@ -42,6 +44,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  validPerspectiveQuad,
+  type PerspectiveProposal,
+  type PerspectiveQuad,
+} from "@/lib/calibrate/perspective";
 import { calibrationTemplateSvg, type TemplatePaper } from "@/lib/calibrate/template";
 import { downloadBlob } from "@/lib/download";
 import { describeScale, exportScale } from "@/lib/export/scale";
@@ -59,6 +66,11 @@ export interface TraceControlsPanelProps {
   onReprocess: () => void;
   /** Re-run ArUco marker detection on the full frame, with feedback. */
   onDetectMarkers: () => void;
+  /** Rectify the selected paper plane and replace the working image. */
+  onApplyPerspective: (
+    proposal: PerspectiveProposal,
+    paper: TemplatePaper,
+  ) => void;
 }
 
 const TRACE_SETTINGS_SECTION_DETAILS = [
@@ -89,6 +101,7 @@ export function TraceControlsPanel({
   onExport,
   onReprocess,
   onDetectMarkers,
+  onApplyPerspective,
 }: TraceControlsPanelProps): JSX.Element {
   const store = useTrace();
   const {
@@ -102,6 +115,10 @@ export function TraceControlsPanel({
     pendingAutoCalibration,
     calibrationSource,
     rulerLengthMm,
+    pendingPerspective,
+    manualPerspectivePoints,
+    perspectiveCorrection,
+    perspectiveOriginalImageUrl,
     region,
     sensitivity,
     tolerancePx,
@@ -109,6 +126,7 @@ export function TraceControlsPanel({
     margin,
     exportFormat,
     extrusionHeight,
+    processing,
   } = store;
 
   const scale = exportScale(calibration, imageSize.height);
@@ -165,6 +183,11 @@ export function TraceControlsPanel({
     "scale" | "region" | "detection" | null
   >(null);
   const [calibrationSheetOpen, setCalibrationSheetOpen] = useState(false);
+  // Marker spacing is identical on A4 and Letter, so detection cannot infer
+  // the page size. Never silently assume one: downloading or explicitly
+  // selecting a template supplies the missing information.
+  const [perspectivePaper, setPerspectivePaper] =
+    useState<TemplatePaper | null>(null);
   const previousSourceRevision = useRef(sourceRevision);
   const previousScaleComplete = useRef(calibration !== null);
   const previousAutoPending = useRef(pendingAutoCalibration !== null);
@@ -255,6 +278,15 @@ export function TraceControlsPanel({
 
   const shapeLibrary = useShapeLibrary();
   const [, navigate] = useLocation();
+
+  const manualPerspectiveProposal: PerspectiveProposal | null =
+    manualPerspectivePoints.length === 4 &&
+    validPerspectiveQuad(manualPerspectivePoints)
+      ? {
+          source: "manual",
+          points: manualPerspectivePoints as PerspectiveQuad,
+        }
+      : null;
 
   const handleAddToBin = () => {
     const shape = normalizeTracedShape(outline, scale, fileName || "Traced tool");
@@ -351,14 +383,61 @@ export function TraceControlsPanel({
                 Pocketry found {displayedScale.mmPerPx?.toFixed(3)} mm/px. Review
                 the ruler on the image, then accept it to continue.
               </p>
-              <Button
-                size="sm"
-                className="w-full"
-                onClick={() => dispatch({ type: "ACCEPT_AUTO_CALIBRATION" })}
-                data-testid="button-accept-auto-scale"
-              >
-                Accept detected scale
-              </Button>
+              {pendingPerspective ? (
+                <>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="auto-perspective-paper" className="text-xs">
+                      Printed paper size
+                    </Label>
+                    <Select
+                      value={perspectivePaper ?? undefined}
+                      onValueChange={(value) =>
+                        setPerspectivePaper(value as TemplatePaper)
+                      }
+                    >
+                      <SelectTrigger id="auto-perspective-paper" className="w-full">
+                        <SelectValue placeholder="Choose A4 or US Letter" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="a4">A4</SelectItem>
+                        <SelectItem value="letter">US Letter</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <Button
+                    size="sm"
+                    className="w-full"
+                    disabled={processing || perspectivePaper === null}
+                    onClick={() => {
+                      if (perspectivePaper) {
+                        onApplyPerspective(pendingPerspective, perspectivePaper);
+                      }
+                    }}
+                    data-testid="button-apply-auto-perspective"
+                  >
+                    <ScanLine className="mr-1.5 h-4 w-4" />
+                    Correct perspective &amp; use scale
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full"
+                    onClick={() => dispatch({ type: "ACCEPT_AUTO_CALIBRATION" })}
+                    data-testid="button-accept-auto-scale"
+                  >
+                    Use scale without correction
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  size="sm"
+                  className="w-full"
+                  onClick={() => dispatch({ type: "ACCEPT_AUTO_CALIBRATION" })}
+                  data-testid="button-accept-auto-scale"
+                >
+                  Accept detected scale
+                </Button>
+              )}
             </div>
           )}
 
@@ -427,6 +506,115 @@ export function TraceControlsPanel({
             </Button>
           )}
 
+          <div className="space-y-2 rounded-md border p-3">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <ScanLine className="h-4 w-4 text-amber-600" />
+              Perspective correction
+            </div>
+            {perspectiveCorrection ? (
+              <>
+                <p className="text-xs text-muted-foreground">
+                  Corrected from{" "}
+                  {perspectiveCorrection.source === "template"
+                    ? "four template markers"
+                    : "four manually selected page corners"}{" "}
+                  using{" "}
+                  {perspectiveCorrection.paper === "a4" ? "A4" : "US Letter"}{" "}
+                  dimensions.
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  disabled={!perspectiveOriginalImageUrl}
+                  onClick={() => dispatch({ type: "RESTORE_PERSPECTIVE_SOURCE" })}
+                  data-testid="button-restore-perspective-source"
+                >
+                  <RotateCcw className="mr-1.5 h-4 w-4" />
+                  Restore original photo
+                </Button>
+              </>
+            ) : (
+              <>
+                <p className="text-xs text-muted-foreground">
+                  If markers are unavailable, select the four visible paper
+                  corners: top-left, top-right, bottom-right, then bottom-left.
+                </p>
+                {!pendingPerspective && (
+                  <div className="space-y-1.5">
+                    <Label htmlFor="manual-perspective-paper" className="text-xs">
+                      Paper size
+                    </Label>
+                    <Select
+                      value={perspectivePaper ?? undefined}
+                      onValueChange={(value) =>
+                        setPerspectivePaper(value as TemplatePaper)
+                      }
+                    >
+                      <SelectTrigger
+                        id="manual-perspective-paper"
+                        className="w-full"
+                      >
+                        <SelectValue placeholder="Choose A4 or US Letter" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="a4">A4</SelectItem>
+                        <SelectItem value="letter">US Letter</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+                <Button
+                  variant={store.mode === "perspective" ? "default" : "outline"}
+                  size="sm"
+                  className="w-full"
+                  onClick={() =>
+                    dispatch({
+                      type:
+                        store.mode === "perspective"
+                          ? "CANCEL_PERSPECTIVE_SELECTION"
+                          : "START_PERSPECTIVE_SELECTION",
+                    })
+                  }
+                  data-testid="button-select-perspective-points"
+                >
+                  {store.mode === "perspective"
+                    ? `Cancel · corner ${manualPerspectivePoints.length + 1} of 4`
+                    : manualPerspectivePoints.length === 4
+                      ? "Reselect page corners"
+                      : "Select four page corners"}
+                </Button>
+                {manualPerspectivePoints.length > 0 && (
+                  <p className="text-[11px] text-muted-foreground" role="status">
+                    {manualPerspectivePoints.length < 4
+                      ? `${manualPerspectivePoints.length} of 4 corners selected.`
+                      : manualPerspectiveProposal
+                        ? "Four corners selected. Drag a numbered marker to refine it, or apply the correction."
+                        : "The selected points cross or collapse. Reselect the corners in clockwise order."}
+                  </p>
+                )}
+                {manualPerspectiveProposal && (
+                  <Button
+                    size="sm"
+                    className="w-full"
+                    disabled={processing || perspectivePaper === null}
+                    onClick={() => {
+                      if (perspectivePaper) {
+                        onApplyPerspective(
+                          manualPerspectiveProposal,
+                          perspectivePaper,
+                        );
+                      }
+                    }}
+                    data-testid="button-apply-manual-perspective"
+                  >
+                    Apply perspective correction
+                  </Button>
+                )}
+              </>
+            )}
+          </div>
+
           <Dialog open={calibrationSheetOpen} onOpenChange={setCalibrationSheetOpen}>
             <Button
               variant="link"
@@ -442,7 +630,8 @@ export function TraceControlsPanel({
                 <DialogTitle>Calibration sheet</DialogTitle>
                 <DialogDescription>
                   Print the sheet once at 100%, then include it beneath tools for
-                  automatic scale detection.
+                  automatic scale detection. The downloaded size is also selected
+                  for perspective correction.
                 </DialogDescription>
               </DialogHeader>
               <Button
@@ -459,15 +648,23 @@ export function TraceControlsPanel({
               </Button>
               <div className="grid grid-cols-2 gap-2">
                 <Button
-                  variant="outline"
-                  onClick={() => downloadCalibrationTemplate("a4")}
+                  variant={perspectivePaper === "a4" ? "default" : "outline"}
+                  aria-pressed={perspectivePaper === "a4"}
+                  onClick={() => {
+                    setPerspectivePaper("a4");
+                    downloadCalibrationTemplate("a4");
+                  }}
                   data-testid="button-template-a4"
                 >
                   A4
                 </Button>
                 <Button
-                  variant="outline"
-                  onClick={() => downloadCalibrationTemplate("letter")}
+                  variant={perspectivePaper === "letter" ? "default" : "outline"}
+                  aria-pressed={perspectivePaper === "letter"}
+                  onClick={() => {
+                    setPerspectivePaper("letter");
+                    downloadCalibrationTemplate("letter");
+                  }}
                   data-testid="button-template-letter"
                 >
                   US Letter

--- a/client/src/components/trace/trace-scene.test.tsx
+++ b/client/src/components/trace/trace-scene.test.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { Calibration, DraftCalibration } from "@shared/geometry/scale";
+
+import { TraceScene } from "./trace-scene";
+
+const calibration: Calibration = {
+  startX: 10,
+  startY: 20,
+  endX: 110,
+  endY: 20,
+  lengthMm: 50,
+};
+
+function renderRuler({
+  completed = null,
+  draft = null,
+  rulerLengthMm = 100,
+}: {
+  completed?: Calibration | null;
+  draft?: DraftCalibration | null;
+  rulerLengthMm?: number;
+}): string {
+  return renderToStaticMarkup(
+    <TraceScene
+      imageUrl="data:image/png;base64,AA=="
+      imageSize={{ width: 200, height: 100 }}
+      transform={{ scale: 1, translateX: 0, translateY: 0 }}
+      outline={[]}
+      selection={null}
+      region={null}
+      calibration={completed}
+      draftCalibration={draft}
+      rulerLengthMm={rulerLengthMm}
+    />,
+  );
+}
+
+function count(markup: string, fragment: string): number {
+  return markup.split(fragment).length - 1;
+}
+
+describe("TraceScene ruler overlay", () => {
+  it("renders completed endpoints as persistent X markers with a length label", () => {
+    const markup = renderRuler({ completed: calibration });
+
+    expect(count(markup, 'data-testid="ruler-marker"')).toBe(2);
+    expect(count(markup, "data-ruler-handle=")).toBe(2);
+    expect(markup).toContain('data-testid="ruler-line"');
+    expect(markup).toContain('data-testid="ruler-length-label"');
+    expect(markup).toContain("50 mm");
+    expect(markup).toContain("M 3 13 L 17 27 M 17 13 L 3 27");
+  });
+
+  it("renders a live dashed ruler from the first marker to the pointer", () => {
+    const markup = renderRuler({
+      draft: { startX: 10, startY: 20, endX: 80, endY: 70 },
+      rulerLengthMm: 125.5,
+    });
+
+    expect(count(markup, 'data-testid="ruler-marker"')).toBe(2);
+    expect(count(markup, "data-ruler-handle=")).toBe(0);
+    expect(markup).toContain('data-ruler-preview="true"');
+    expect(markup).toContain('stroke-dasharray="6 4"');
+    expect(markup).toContain("125.5 mm");
+  });
+
+  it("shows only the first X before the pointer supplies a preview endpoint", () => {
+    const markup = renderRuler({ draft: { startX: 10, startY: 20 } });
+
+    expect(count(markup, 'data-testid="ruler-marker"')).toBe(1);
+    expect(markup).not.toContain('data-testid="ruler-line"');
+    expect(markup).not.toContain('data-testid="ruler-length-label"');
+  });
+});

--- a/client/src/components/trace/trace-scene.test.tsx
+++ b/client/src/components/trace/trace-scene.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import type { Calibration, DraftCalibration } from "@shared/geometry/scale";
+import type { Point } from "@shared/geometry/types";
 
 import { TraceScene } from "./trace-scene";
 
@@ -18,10 +19,16 @@ function renderRuler({
   completed = null,
   draft = null,
   rulerLengthMm = 100,
+  perspectivePoints = [],
+  perspectiveEditable = false,
+  perspectivePreview = null,
 }: {
   completed?: Calibration | null;
   draft?: DraftCalibration | null;
   rulerLengthMm?: number;
+  perspectivePoints?: readonly Point[];
+  perspectiveEditable?: boolean;
+  perspectivePreview?: Point | null;
 }): string {
   return renderToStaticMarkup(
     <TraceScene
@@ -34,6 +41,9 @@ function renderRuler({
       calibration={completed}
       draftCalibration={draft}
       rulerLengthMm={rulerLengthMm}
+      perspectivePoints={perspectivePoints}
+      perspectiveEditable={perspectiveEditable}
+      perspectivePreview={perspectivePreview}
     />,
   );
 }
@@ -73,5 +83,36 @@ describe("TraceScene ruler overlay", () => {
     expect(count(markup, 'data-testid="ruler-marker"')).toBe(1);
     expect(markup).not.toContain('data-testid="ruler-line"');
     expect(markup).not.toContain('data-testid="ruler-length-label"');
+  });
+
+  it("renders four numbered, editable perspective corners as a closed quad", () => {
+    const markup = renderRuler({
+      perspectivePoints: [
+        { x: 10, y: 10 },
+        { x: 190, y: 12 },
+        { x: 188, y: 90 },
+        { x: 12, y: 88 },
+      ],
+      perspectiveEditable: true,
+    });
+
+    expect(count(markup, 'data-testid="perspective-marker"')).toBe(4);
+    expect(count(markup, "data-perspective-handle=")).toBe(4);
+    expect(markup).toContain('data-testid="perspective-outline"');
+    expect(markup).toContain("L 12 88 Z");
+  });
+
+  it("previews the next manual perspective edge at the pointer", () => {
+    const markup = renderRuler({
+      perspectivePoints: [
+        { x: 10, y: 10 },
+        { x: 190, y: 12 },
+      ],
+      perspectiveEditable: true,
+      perspectivePreview: { x: 180, y: 90 },
+    });
+
+    expect(markup).toContain('data-perspective-preview="true"');
+    expect(markup).toContain("L 180 90");
   });
 });

--- a/client/src/components/trace/trace-scene.tsx
+++ b/client/src/components/trace/trace-scene.tsx
@@ -32,6 +32,12 @@ export interface TraceSceneProps {
   draftCalibration: DraftCalibration | null;
   /** Known physical length shown beside both preview and completed rulers. */
   rulerLengthMm: number;
+  /** Template centres or manually selected page corners awaiting correction. */
+  perspectivePoints?: readonly Point[];
+  /** Manual points remain draggable after all four have been placed. */
+  perspectiveEditable?: boolean;
+  /** Pointer-following endpoint while manual corner placement is active. */
+  perspectivePreview?: Point | null;
   /** Dims the outline while a new one is being computed. */
   busy?: boolean;
   /**
@@ -59,6 +65,8 @@ const RULER_HIT_RADIUS = 12;
 const RULER_MARKER_HALF_SIZE = 7;
 const RULER_LABEL_OFFSET = 18;
 const RULER_LABEL_HEIGHT = 22;
+const PERSPECTIVE_MARKER_RADIUS = 10;
+const PERSPECTIVE_HIT_RADIUS = 15;
 
 /**
  * The canvas scene: one `<svg>` filling the viewport, with the image and every
@@ -93,6 +101,9 @@ export function TraceScene({
   calibration,
   draftCalibration,
   rulerLengthMm,
+  perspectivePoints = [],
+  perspectiveEditable = false,
+  perspectivePreview = null,
   busy = false,
   hoveredVertexIndex = null,
   onPointerDown,
@@ -230,6 +241,12 @@ export function TraceScene({
           calibration={calibration}
           draft={draftCalibration}
           rulerLengthMm={rulerLengthMm}
+          inv={inv}
+        />
+        <PerspectiveOverlay
+          points={perspectivePoints}
+          editable={perspectiveEditable}
+          preview={perspectivePreview}
           inv={inv}
         />
       </g>
@@ -434,6 +451,93 @@ function rulerMarkerPath(point: Point, halfSize: number): string {
 
 function formatRulerLength(lengthMm: number): string {
   return Number.isFinite(lengthMm) ? String(Number(lengthMm.toPrecision(6))) : "—";
+}
+
+function PerspectiveOverlay({
+  points,
+  editable,
+  preview,
+  inv,
+}: {
+  points: readonly Point[];
+  editable: boolean;
+  preview: Point | null;
+  inv: number;
+}): JSX.Element | null {
+  if (points.length === 0) return null;
+
+  const pathPoints =
+    preview && points.length < 4 ? [...points, preview] : [...points];
+  const path = pathPoints
+    .map((point, index) => `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`)
+    .join(" ");
+  const closedPath = points.length === 4 ? `${path} Z` : path;
+  const previewing = preview !== null && points.length < 4;
+
+  return (
+    <g data-testid="perspective-overlay">
+      {pathPoints.length > 1 && (
+        <>
+          <path
+            d={closedPath}
+            fill={points.length === 4 ? "rgba(14, 165, 233, 0.08)" : "none"}
+            className="stroke-white/95"
+            strokeWidth={6}
+            strokeDasharray={previewing ? "6 4" : undefined}
+            vectorEffect="non-scaling-stroke"
+            pointerEvents="none"
+          />
+          <path
+            d={closedPath}
+            fill="none"
+            className="stroke-sky-500"
+            strokeWidth={2.5}
+            strokeDasharray={previewing ? "6 4" : undefined}
+            vectorEffect="non-scaling-stroke"
+            pointerEvents="none"
+            data-testid="perspective-outline"
+            data-perspective-preview={previewing || undefined}
+          />
+        </>
+      )}
+      {points.map((point, index) => (
+        <g
+          key={index}
+          data-testid="perspective-marker"
+          data-perspective-handle={editable ? index : undefined}
+        >
+          {editable && (
+            <circle
+              cx={point.x}
+              cy={point.y}
+              r={PERSPECTIVE_HIT_RADIUS * inv}
+              fill="transparent"
+            />
+          )}
+          <circle
+            cx={point.x}
+            cy={point.y}
+            r={PERSPECTIVE_MARKER_RADIUS * inv}
+            className="fill-sky-500 stroke-white"
+            strokeWidth={2}
+            vectorEffect="non-scaling-stroke"
+            pointerEvents="none"
+          />
+          <text
+            x={point.x}
+            y={point.y}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fontSize={11 * inv}
+            className="fill-white font-bold"
+            pointerEvents="none"
+          >
+            {index + 1}
+          </text>
+        </g>
+      ))}
+    </g>
+  );
 }
 
 function ringToPath(ring: readonly Point[]): string {

--- a/client/src/components/trace/trace-scene.tsx
+++ b/client/src/components/trace/trace-scene.tsx
@@ -1,11 +1,16 @@
 import { memo, useMemo, type PointerEvent as ReactPointerEvent } from "react";
 
-import { OUTER_RING, type Point, type Rect, type RingRef } from "@shared/geometry/types";
+import type { Calibration, DraftCalibration } from "@shared/geometry/scale";
+import {
+  OUTER_RING,
+  type Outline,
+  type Point,
+  type Rect,
+  type RingRef,
+} from "@shared/geometry/types";
 
 import { iterateRings, sameRingRef } from "@/lib/geometry/outline";
 import { outlineToPathData } from "@/lib/export/svg";
-import type { Outline } from "@shared/geometry/types";
-import type { Calibration, DraftCalibration } from "@shared/geometry/scale";
 
 /** The viewport transform applied to the whole scene. */
 export interface SceneTransform {
@@ -25,6 +30,8 @@ export interface TraceSceneProps {
   regionActive?: boolean;
   calibration: Calibration | null;
   draftCalibration: DraftCalibration | null;
+  /** Known physical length shown beside both preview and completed rulers. */
+  rulerLengthMm: number;
   /** Dims the outline while a new one is being computed. */
   busy?: boolean;
   /**
@@ -48,8 +55,10 @@ export interface TraceSceneProps {
 /** Screen-space sizes, divided by the scale so they stay constant when zooming. */
 const HANDLE_RADIUS = 5;
 const HANDLE_RADIUS_SELECTED = 7;
-const RULER_HANDLE_RADIUS = 7;
 const RULER_HIT_RADIUS = 12;
+const RULER_MARKER_HALF_SIZE = 7;
+const RULER_LABEL_OFFSET = 18;
+const RULER_LABEL_HEIGHT = 22;
 
 /**
  * The canvas scene: one `<svg>` filling the viewport, with the image and every
@@ -83,6 +92,7 @@ export function TraceScene({
   regionActive = false,
   calibration,
   draftCalibration,
+  rulerLengthMm,
   busy = false,
   hoveredVertexIndex = null,
   onPointerDown,
@@ -219,6 +229,7 @@ export function TraceScene({
         <RulerOverlay
           calibration={calibration}
           draft={draftCalibration}
+          rulerLengthMm={rulerLengthMm}
           inv={inv}
         />
       </g>
@@ -260,10 +271,12 @@ const SourceImage = memo(function SourceImage({
 function RulerOverlay({
   calibration,
   draft,
+  rulerLengthMm,
   inv,
 }: {
   calibration: Calibration | null;
   draft: DraftCalibration | null;
+  rulerLengthMm: number;
   inv: number;
 }): JSX.Element | null {
   const start: Point | null = calibration
@@ -274,48 +287,153 @@ function RulerOverlay({
 
   const end: Point | null = calibration
     ? { x: calibration.endX, y: calibration.endY }
-    : null;
+    : draft?.endX !== undefined && draft?.endY !== undefined
+      ? { x: draft.endX, y: draft.endY }
+      : null;
 
   if (!start) return null;
 
+  const lengthMm = calibration?.lengthMm ?? rulerLengthMm;
+  const markerHalfSize = RULER_MARKER_HALF_SIZE * inv;
+
   return (
-    <g>
+    <g data-testid="ruler-overlay">
       {end && (
-        <line
-          x1={start.x}
-          y1={start.y}
-          x2={end.x}
-          y2={end.y}
-          className="stroke-amber-500"
-          strokeWidth={2}
-          vectorEffect="non-scaling-stroke"
-        />
+        <>
+          <line
+            x1={start.x}
+            y1={start.y}
+            x2={end.x}
+            y2={end.y}
+            className="stroke-white/95"
+            strokeWidth={6}
+            strokeDasharray={calibration ? undefined : "6 4"}
+            vectorEffect="non-scaling-stroke"
+            pointerEvents="none"
+          />
+          <line
+            x1={start.x}
+            y1={start.y}
+            x2={end.x}
+            y2={end.y}
+            className="stroke-amber-500"
+            strokeWidth={2.5}
+            strokeDasharray={calibration ? undefined : "6 4"}
+            vectorEffect="non-scaling-stroke"
+            pointerEvents="none"
+            data-testid="ruler-line"
+            data-ruler-preview={calibration ? undefined : "true"}
+          />
+          <RulerLengthLabel
+            start={start}
+            end={end}
+            lengthMm={lengthMm}
+            inv={inv}
+          />
+        </>
       )}
       {[start, end].map((point, index) =>
         point ? (
-          <g key={index}>
-            {/* An invisible, generously sized hit target: the visible dot is
-                too small to grab reliably, especially on a touchscreen. */}
-            <circle
-              cx={point.x}
-              cy={point.y}
-              r={RULER_HIT_RADIUS * inv}
-              fill="transparent"
-              data-ruler-handle={index === 0 ? "start" : "end"}
-            />
-            <circle
-              cx={point.x}
-              cy={point.y}
-              r={RULER_HANDLE_RADIUS * inv}
-              className="fill-amber-500 stroke-background"
-              strokeWidth={1.5}
+          <g
+            key={index}
+            data-testid="ruler-marker"
+            data-ruler-marker={index === 0 ? "start" : "end"}
+            data-ruler-handle={
+              calibration ? (index === 0 ? "start" : "end") : undefined
+            }
+          >
+            {calibration && (
+              <circle
+                cx={point.x}
+                cy={point.y}
+                r={RULER_HIT_RADIUS * inv}
+                fill="transparent"
+              />
+            )}
+            <path
+              d={rulerMarkerPath(point, markerHalfSize)}
+              fill="none"
+              className="stroke-white/95"
+              strokeWidth={6}
               vectorEffect="non-scaling-stroke"
+              pointerEvents="none"
+            />
+            <path
+              d={rulerMarkerPath(point, markerHalfSize)}
+              fill="none"
+              className="stroke-amber-500"
+              strokeWidth={2.5}
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+              pointerEvents="none"
             />
           </g>
         ) : null,
       )}
     </g>
   );
+}
+
+function RulerLengthLabel({
+  start,
+  end,
+  lengthMm,
+  inv,
+}: {
+  start: Point;
+  end: Point;
+  lengthMm: number;
+  inv: number;
+}): JSX.Element {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const distance = Math.hypot(dx, dy);
+  const normal =
+    distance > 0 ? { x: -dy / distance, y: dx / distance } : { x: 0, y: -1 };
+  const offset = RULER_LABEL_OFFSET * inv;
+  const x = (start.x + end.x) / 2 + normal.x * offset;
+  const y = (start.y + end.y) / 2 + normal.y * offset;
+  const label = `${formatRulerLength(lengthMm)} mm`;
+  const width = Math.max(46, label.length * 7 + 14) * inv;
+  const height = RULER_LABEL_HEIGHT * inv;
+
+  return (
+    <g data-testid="ruler-length-label" pointerEvents="none">
+      <rect
+        x={x - width / 2}
+        y={y - height / 2}
+        width={width}
+        height={height}
+        rx={6 * inv}
+        className="fill-background/95 stroke-amber-500"
+        strokeWidth={1.5}
+        vectorEffect="non-scaling-stroke"
+      />
+      <text
+        x={x}
+        y={y}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize={12 * inv}
+        className="fill-foreground font-semibold"
+      >
+        {label}
+      </text>
+    </g>
+  );
+}
+
+function rulerMarkerPath(point: Point, halfSize: number): string {
+  return [
+    `M ${point.x - halfSize} ${point.y - halfSize}`,
+    `L ${point.x + halfSize} ${point.y + halfSize}`,
+    `M ${point.x + halfSize} ${point.y - halfSize}`,
+    `L ${point.x - halfSize} ${point.y + halfSize}`,
+  ].join(" ");
+}
+
+function formatRulerLength(lengthMm: number): string {
+  return Number.isFinite(lengthMm) ? String(Number(lengthMm.toPrecision(6))) : "—";
 }
 
 function ringToPath(ring: readonly Point[]): string {

--- a/client/src/lib/calibrate/aruco-4x4.ts
+++ b/client/src/lib/calibrate/aruco-4x4.ts
@@ -1,6 +1,6 @@
 /**
- * ArUco DICT_4X4 marker patterns — the four markers Pocketry's calibration
- * sheet uses, ported as data from OpenCV.
+ * ArUco DICT_4X4 marker patterns — the eight markers Pocketry's A4 and US
+ * Letter calibration sheets use, ported as data from OpenCV.
  *
  * Upstream: https://github.com/opencv/opencv
  * File:     modules/objdetect/src/aruco/predefined_dictionaries.hpp
@@ -19,12 +19,16 @@
  * dictionary compiled into opencv.js itself.
  */
 
-/** Canonical (rotation 0) bit patterns of DICT_4X4 markers 0–3. */
+/** Canonical (rotation 0) bit patterns of DICT_4X4 markers 0–7. */
 export const ARUCO_4X4_BITS: readonly number[] = [
   0xb532, // id 0
   0x0f9a, // id 1
   0x332d, // id 2
   0x9946, // id 3
+  0x549e, // id 4
+  0x79cd, // id 5
+  0x9e2e, // id 6
+  0xc4f2, // id 7
 ];
 
 /** Marker side length in modules: 4 data cells plus the black border ring. */

--- a/client/src/lib/calibrate/auto-calibrate.ts
+++ b/client/src/lib/calibrate/auto-calibrate.ts
@@ -8,6 +8,7 @@ import {
   type PerspectiveProposal,
 } from "./perspective";
 import { solveScaleFromMarkers, type ScaleSolution } from "./solve";
+import { paperFromTemplateMarkerIds, type TemplatePaper } from "./template";
 
 /**
  * Detect → solve → Calibration, in one step the UI can act on.
@@ -23,6 +24,8 @@ export type AutoCalibrationResult =
       kind: "calibrated";
       calibration: Calibration;
       solution: ScaleSolution;
+      /** Paper size encoded by this template's unique marker-id family. */
+      paper: TemplatePaper;
       /** Present only when all four unique template markers can define a homography. */
       perspectiveProposal: PerspectiveProposal | null;
     }
@@ -38,12 +41,18 @@ export function runAutoCalibration(cv: any, image: ImageData): AutoCalibrationRe
   if (!detection) return { kind: "no-markers" };
   if (!detection.isTemplate) return { kind: "foreign-sheet", family: detection.family };
 
-  const solution = solveScaleFromMarkers(detection.markers);
-  // 4x4 markers that aren't the template's ids 0–3 are still a foreign sheet.
-  if (!solution) return { kind: "foreign-sheet", family: detection.family };
+  const paper = paperFromTemplateMarkerIds(
+    detection.markers.map((marker) => marker.id),
+  );
+  const solution = paper ? solveScaleFromMarkers(detection.markers, paper) : null;
+  // Other or mixed DICT_4X4_50 ids are still a foreign sheet.
+  if (!paper || !solution) {
+    return { kind: "foreign-sheet", family: detection.family };
+  }
 
   return {
     kind: "calibrated",
+    paper,
     // The synthesised ruler joins the longest detected pair — for the full
     // sheet that is a 250 mm diagonal, the geometry least sensitive to
     // per-marker centre noise.
@@ -55,7 +64,7 @@ export function runAutoCalibration(cv: any, image: ImageData): AutoCalibrationRe
       lengthMm: solution.ruler.lengthMm,
     },
     solution,
-    perspectiveProposal: proposalFromTemplateMarkers(detection.markers),
+    perspectiveProposal: proposalFromTemplateMarkers(detection.markers, paper),
   };
 }
 

--- a/client/src/lib/calibrate/auto-calibrate.ts
+++ b/client/src/lib/calibrate/auto-calibrate.ts
@@ -3,6 +3,10 @@ import type { Calibration } from "@shared/geometry/scale";
 import { loadOpenCV } from "@/lib/opencv";
 
 import { detectCalibrationSheet, hasArucoSupport } from "./detect";
+import {
+  proposalFromTemplateMarkers,
+  type PerspectiveProposal,
+} from "./perspective";
 import { solveScaleFromMarkers, type ScaleSolution } from "./solve";
 
 /**
@@ -15,7 +19,13 @@ import { solveScaleFromMarkers, type ScaleSolution } from "./solve";
  * printable template.
  */
 export type AutoCalibrationResult =
-  | { kind: "calibrated"; calibration: Calibration; solution: ScaleSolution }
+  | {
+      kind: "calibrated";
+      calibration: Calibration;
+      solution: ScaleSolution;
+      /** Present only when all four unique template markers can define a homography. */
+      perspectiveProposal: PerspectiveProposal | null;
+    }
   | { kind: "foreign-sheet"; family: string }
   | { kind: "no-markers" }
   | { kind: "unsupported" };
@@ -45,6 +55,7 @@ export function runAutoCalibration(cv: any, image: ImageData): AutoCalibrationRe
       lengthMm: solution.ruler.lengthMm,
     },
     solution,
+    perspectiveProposal: proposalFromTemplateMarkers(detection.markers),
   };
 }
 

--- a/client/src/lib/calibrate/detect.test.ts
+++ b/client/src/lib/calibrate/detect.test.ts
@@ -139,6 +139,8 @@ describe("runAutoCalibration", () => {
     const derived = mmPerPixel(result.calibration)!;
     expect(Math.abs(derived - 1 / PX_PER_MM) / (1 / PX_PER_MM)).toBeLessThan(0.005);
     expect(result.solution.maxDeviation).toBeLessThan(0.01);
+    expect(result.perspectiveProposal?.source).toBe("template");
+    expect(result.perspectiveProposal?.points).toHaveLength(4);
   });
 
   it("classifies a 6x6 sheet as foreign", () => {

--- a/client/src/lib/calibrate/detect.test.ts
+++ b/client/src/lib/calibrate/detect.test.ts
@@ -8,7 +8,9 @@ import { detectArucoMarkers, detectCalibrationSheet, hasArucoSupport } from "./d
 import { solveScaleFromMarkers } from "./solve";
 import {
   TEMPLATE_MARKER_SIZE_MM,
+  TEMPLATE_PAPER_MM,
   templateMarkerCentersMm,
+  type TemplatePaper,
 } from "./template";
 
 /**
@@ -30,16 +32,19 @@ beforeAll(async () => {
 
 const PX_PER_MM = 2;
 
-/** White A4 "photo" with the template's markers rendered at PX_PER_MM. */
-function composeSheet(dictionaryId: () => number): ImageData {
-  const width = Math.round(210 * PX_PER_MM);
-  const height = Math.round(297 * PX_PER_MM);
+/** White template "photo" with its markers rendered at PX_PER_MM. */
+function composeSheet(
+  dictionaryId: () => number,
+  paper: TemplatePaper = "a4",
+): ImageData {
+  const width = Math.round(TEMPLATE_PAPER_MM[paper].width * PX_PER_MM);
+  const height = Math.round(TEMPLATE_PAPER_MM[paper].height * PX_PER_MM);
   const data = new Uint8ClampedArray(width * height * 4).fill(255);
 
   const sizePx = TEMPLATE_MARKER_SIZE_MM * PX_PER_MM; // 60
   const dictionary = cv.getPredefinedDictionary(dictionaryId());
   try {
-    for (const { id, x, y } of templateMarkerCentersMm("a4")) {
+    for (const { id, x, y } of templateMarkerCentersMm(paper)) {
       const marker = new cv.Mat();
       try {
         cv.generateImageMarker(dictionary, id, sizePx, marker, 1);
@@ -85,6 +90,44 @@ describe("aruco detection (closed loop with the shipped bundle)", () => {
       const originY = Math.round(expected.y * PX_PER_MM - sizePx / 2);
       expect(marker.centerPx.x).toBeCloseTo(originX + sizePx / 2 - 0.5, 0);
       expect(marker.centerPx.y).toBeCloseTo(originY + sizePx / 2 - 0.5, 0);
+      expect(marker.cornersPx).toHaveLength(4);
+    }
+  });
+
+  it("keeps decoded corner identity when the sheet is rotated", () => {
+    const scene = composeSheet(() => cv.DICT_4X4_50);
+    const original = detectArucoMarkers(cv, scene, cv.DICT_4X4_50);
+    const source = cv.matFromImageData(scene);
+    const rotated = new cv.Mat();
+    try {
+      cv.rotate(source, rotated, cv.ROTATE_180);
+      const rotatedImage = {
+        data: new Uint8ClampedArray(rotated.data),
+        width: rotated.cols,
+        height: rotated.rows,
+        colorSpace: "srgb",
+      } as ImageData;
+      const detected = detectArucoMarkers(
+        cv,
+        rotatedImage,
+        cv.DICT_4X4_50,
+      );
+      for (const marker of detected) {
+        const before = original.find(({ id }) => id === marker.id)!;
+        for (let index = 0; index < 4; index++) {
+          expect(marker.cornersPx![index].x).toBeCloseTo(
+            scene.width - 1 - before.cornersPx![index].x,
+            0,
+          );
+          expect(marker.cornersPx![index].y).toBeCloseTo(
+            scene.height - 1 - before.cornersPx![index].y,
+            0,
+          );
+        }
+      }
+    } finally {
+      rotated.delete();
+      source.delete();
     }
   });
 
@@ -128,8 +171,13 @@ describe("aruco detection (closed loop with the shipped bundle)", () => {
 });
 
 describe("runAutoCalibration", () => {
-  it("produces a usable Calibration from the template sheet", () => {
-    const result = runAutoCalibration(cv, composeSheet(() => cv.DICT_4X4_50));
+  it.each(["a4", "letter"] as const)(
+    "produces a usable Calibration and identifies a %s sheet",
+    (paper) => {
+    const result = runAutoCalibration(
+      cv,
+      composeSheet(() => cv.DICT_4X4_50, paper),
+    );
     expect(result.kind).toBe("calibrated");
     if (result.kind !== "calibrated") return;
 
@@ -139,9 +187,13 @@ describe("runAutoCalibration", () => {
     const derived = mmPerPixel(result.calibration)!;
     expect(Math.abs(derived - 1 / PX_PER_MM) / (1 / PX_PER_MM)).toBeLessThan(0.005);
     expect(result.solution.maxDeviation).toBeLessThan(0.01);
+    expect(result.paper).toBe(paper);
     expect(result.perspectiveProposal?.source).toBe("template");
     expect(result.perspectiveProposal?.points).toHaveLength(4);
-  });
+    expect(result.perspectiveProposal?.correspondences?.source).toHaveLength(16);
+    expect(result.perspectiveProposal?.correspondences?.destinationMm).toHaveLength(16);
+    },
+  );
 
   it("classifies a 6x6 sheet as foreign", () => {
     const result = runAutoCalibration(cv, composeSheet(() => cv.DICT_6X6_250));

--- a/client/src/lib/calibrate/detect.ts
+++ b/client/src/lib/calibrate/detect.ts
@@ -71,6 +71,11 @@ export function detectArucoMarkers(
     cv.cvtColor(src, gray, cv.COLOR_RGBA2GRAY);
     dictionary = cv.getPredefinedDictionary(predefinedDictionary);
     parameters = new cv.aruco_DetectorParameters();
+    // The default is CORNER_REFINE_NONE. Subpixel refinement gives the
+    // homography stable point correspondences without changing the template.
+    if (typeof cv.CORNER_REFINE_SUBPIX === "number") {
+      parameters.cornerRefinementMethod = cv.CORNER_REFINE_SUBPIX;
+    }
     refine = new cv.aruco_RefineParameters(10, 3, true);
     detector = new cv.aruco_ArucoDetector(dictionary, parameters, refine);
     detector.detectMarkers(gray, corners, ids, rejected);
@@ -90,6 +95,7 @@ export function detectArucoMarkers(
         ];
         markers.push({
           id,
+          cornersPx: cornersPx as [Point, Point, Point, Point],
           centerPx: {
             x: (cornersPx[0].x + cornersPx[1].x + cornersPx[2].x + cornersPx[3].x) / 4,
             y: (cornersPx[0].y + cornersPx[1].y + cornersPx[2].y + cornersPx[3].y) / 4,

--- a/client/src/lib/calibrate/download-template.ts
+++ b/client/src/lib/calibrate/download-template.ts
@@ -1,0 +1,13 @@
+import { downloadBlob } from "@/lib/download";
+
+import { calibrationTemplatePdf } from "./template-pdf";
+import type { TemplatePaper } from "./template";
+
+/** Downloads one true-size, printable Pocketry calibration sheet. */
+export function downloadCalibrationTemplate(paper: TemplatePaper): void {
+  const pdf = calibrationTemplatePdf(paper);
+  downloadBlob(
+    new Blob([pdf], { type: "application/pdf" }),
+    `pocketry-calibration-${paper}.pdf`,
+  );
+}

--- a/client/src/lib/calibrate/perspective.test.ts
+++ b/client/src/lib/calibrate/perspective.test.ts
@@ -1,0 +1,165 @@
+import { createRequire } from "node:module";
+
+import { mmPerPixel } from "@shared/geometry/scale";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  perspectiveLayout,
+  proposalFromTemplateMarkers,
+  runPerspectiveCorrection,
+  validPerspectiveQuad,
+  type PerspectiveProposal,
+  type PerspectiveQuad,
+} from "./perspective";
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- opencv.js is untyped */
+let cv: any;
+
+beforeAll(async () => {
+  const required = createRequire(import.meta.url)(
+    "../../../public/opencv/opencv.js",
+  ) as unknown;
+  cv = await Promise.resolve(required);
+}, 60000);
+
+function imageData(width: number, height: number): ImageData {
+  const data = new Uint8ClampedArray(width * height * 4).fill(255);
+  for (let y = 180; y < 410; y++) {
+    for (let x = 120; x < 310; x++) {
+      const at = (y * width + x) * 4;
+      data[at] = 20;
+      data[at + 1] = 80;
+      data[at + 2] = 180;
+      data[at + 3] = 255;
+    }
+  }
+  return { data, width, height, colorSpace: "srgb" } as ImageData;
+}
+
+function pixel(image: ImageData, x: number, y: number): number[] {
+  const at = (y * image.width + x) * 4;
+  return [...image.data.slice(at, at + 4)];
+}
+
+describe("perspective geometry", () => {
+  it("orders the four unique template ids and rejects incomplete sets", () => {
+    const markers = [
+      { id: 2, centerPx: { x: 90, y: 120 } },
+      { id: 0, centerPx: { x: 10, y: 20 } },
+      { id: 3, centerPx: { x: 20, y: 110 } },
+      { id: 1, centerPx: { x: 100, y: 30 } },
+    ];
+    expect(proposalFromTemplateMarkers(markers)?.points).toEqual([
+      { x: 10, y: 20 },
+      { x: 100, y: 30 },
+      { x: 90, y: 120 },
+      { x: 20, y: 110 },
+    ]);
+    expect(proposalFromTemplateMarkers(markers.slice(0, 3))).toBeNull();
+    expect(proposalFromTemplateMarkers([...markers, markers[0]])).toBeNull();
+  });
+
+  it("maps an A4 sheet to a uniform two-pixels-per-mm plane", () => {
+    const proposal: PerspectiveProposal = {
+      source: "manual",
+      points: [
+        { x: 10, y: 10 },
+        { x: 200, y: 20 },
+        { x: 190, y: 280 },
+        { x: 20, y: 270 },
+      ],
+    };
+    const layout = perspectiveLayout(proposal, "a4");
+    expect(layout).toMatchObject({ width: 421, height: 595, pxPerMm: 2 });
+    expect(layout.destination).toEqual([
+      { x: 0, y: 0 },
+      { x: 420, y: 0 },
+      { x: 420, y: 594 },
+      { x: 0, y: 594 },
+    ]);
+  });
+
+  it("rejects a crossed manual selection", () => {
+    expect(
+      validPerspectiveQuad([
+        { x: 0, y: 0 },
+        { x: 100, y: 100 },
+        { x: 100, y: 0 },
+        { x: 0, y: 100 },
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("perspective correction with the shipped OpenCV build", () => {
+  it("rectifies a synthetic keystoned A4 photograph back to a metric plane", () => {
+    const canonical = imageData(421, 595);
+    const sourceCorners: PerspectiveQuad = [
+      { x: 0, y: 0 },
+      { x: 420, y: 0 },
+      { x: 420, y: 594 },
+      { x: 0, y: 594 },
+    ];
+    const photographedCorners: PerspectiveQuad = [
+      { x: 70, y: 25 },
+      { x: 445, y: 65 },
+      { x: 490, y: 505 },
+      { x: 35, y: 545 },
+    ];
+
+    const canonicalMat = cv.matFromImageData(canonical);
+    const photographedMat = new cv.Mat();
+    const from = cv.matFromArray(
+      4,
+      1,
+      cv.CV_32FC2,
+      sourceCorners.flatMap(({ x, y }) => [x, y]),
+    );
+    const to = cv.matFromArray(
+      4,
+      1,
+      cv.CV_32FC2,
+      photographedCorners.flatMap(({ x, y }) => [x, y]),
+    );
+    const transform = cv.getPerspectiveTransform(from, to);
+    try {
+      cv.warpPerspective(
+        canonicalMat,
+        photographedMat,
+        transform,
+        new cv.Size(525, 570),
+        cv.INTER_LINEAR,
+        cv.BORDER_CONSTANT,
+        new cv.Scalar(255, 255, 255, 255),
+      );
+      const photographed = {
+        data: new Uint8ClampedArray(photographedMat.data),
+        width: photographedMat.cols,
+        height: photographedMat.rows,
+        colorSpace: "srgb",
+      } as ImageData;
+      const corrected = runPerspectiveCorrection(
+        cv,
+        photographed,
+        { source: "manual", points: photographedCorners },
+        "a4",
+      );
+
+      expect(corrected.width).toBe(421);
+      expect(corrected.height).toBe(595);
+      expect(mmPerPixel(corrected.calibration)).toBeCloseTo(0.5, 9);
+      expect(pixel(corrected.imageData, 210, 290).slice(0, 3)).toEqual([
+        20, 80, 180,
+      ]);
+      expect(pixel(corrected.imageData, 40, 100).slice(0, 3)).toEqual([
+        255, 255, 255,
+      ]);
+    } finally {
+      transform.delete();
+      to.delete();
+      from.delete();
+      photographedMat.delete();
+      canonicalMat.delete();
+    }
+  });
+});

--- a/client/src/lib/calibrate/perspective.test.ts
+++ b/client/src/lib/calibrate/perspective.test.ts
@@ -11,6 +11,10 @@ import {
   type PerspectiveProposal,
   type PerspectiveQuad,
 } from "./perspective";
+import {
+  templateMarkerCentersMm,
+  templateMarkerCornersMm,
+} from "./template";
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- opencv.js is untyped */
 let cv: any;
@@ -41,22 +45,59 @@ function pixel(image: ImageData, x: number, y: number): number[] {
   return [...image.data.slice(at, at + 4)];
 }
 
+function marker(id: number, x: number, y: number) {
+  return {
+    id,
+    centerPx: { x, y },
+    cornersPx: [
+      { x: x - 5, y: y - 5 },
+      { x: x + 5, y: y - 5 },
+      { x: x + 5, y: y + 5 },
+      { x: x - 5, y: y + 5 },
+    ] as PerspectiveQuad,
+  };
+}
+
+function transformPoints(points: readonly { x: number; y: number }[], transform: any) {
+  const input = cv.matFromArray(
+    points.length,
+    1,
+    cv.CV_32FC2,
+    points.flatMap(({ x, y }) => [x, y]),
+  );
+  const output = new cv.Mat();
+  try {
+    cv.perspectiveTransform(input, output, transform);
+    return points.map((_, index) => ({
+      x: output.data32F[index * 2],
+      y: output.data32F[index * 2 + 1],
+    }));
+  } finally {
+    output.delete();
+    input.delete();
+  }
+}
+
 describe("perspective geometry", () => {
   it("orders the four unique template ids and rejects incomplete sets", () => {
     const markers = [
-      { id: 2, centerPx: { x: 90, y: 120 } },
-      { id: 0, centerPx: { x: 10, y: 20 } },
-      { id: 3, centerPx: { x: 20, y: 110 } },
-      { id: 1, centerPx: { x: 100, y: 30 } },
+      marker(2, 90, 120),
+      marker(0, 10, 20),
+      marker(3, 20, 110),
+      marker(1, 100, 30),
     ];
-    expect(proposalFromTemplateMarkers(markers)?.points).toEqual([
+    const proposal = proposalFromTemplateMarkers(markers, "a4");
+    expect(proposal?.points).toEqual([
       { x: 10, y: 20 },
       { x: 100, y: 30 },
       { x: 90, y: 120 },
       { x: 20, y: 110 },
     ]);
-    expect(proposalFromTemplateMarkers(markers.slice(0, 3))).toBeNull();
-    expect(proposalFromTemplateMarkers([...markers, markers[0]])).toBeNull();
+    expect(proposal?.paper).toBe("a4");
+    expect(proposal?.correspondences?.source).toHaveLength(16);
+    expect(proposal?.correspondences?.destinationMm).toHaveLength(16);
+    expect(proposalFromTemplateMarkers(markers.slice(0, 3), "a4")).toBeNull();
+    expect(proposalFromTemplateMarkers([...markers, markers[0]], "a4")).toBeNull();
   });
 
   it("maps an A4 sheet to a uniform two-pixels-per-mm plane", () => {
@@ -148,6 +189,7 @@ describe("perspective correction with the shipped OpenCV build", () => {
       expect(corrected.width).toBe(421);
       expect(corrected.height).toBe(595);
       expect(mmPerPixel(corrected.calibration)).toBeCloseTo(0.5, 9);
+      expect(corrected.reprojectionErrorPx).toBeNull();
       expect(pixel(corrected.imageData, 210, 290).slice(0, 3)).toEqual([
         20, 80, 180,
       ]);
@@ -160,6 +202,96 @@ describe("perspective correction with the shipped OpenCV build", () => {
       from.delete();
       photographedMat.delete();
       canonicalMat.delete();
+    }
+  });
+
+  it("uses all sixteen refined marker corners for a precision template fit", () => {
+    const canonical = imageData(421, 595);
+    const canonicalPage: PerspectiveQuad = [
+      { x: 0, y: 0 },
+      { x: 420, y: 0 },
+      { x: 420, y: 594 },
+      { x: 0, y: 594 },
+    ];
+    const photographedPage: PerspectiveQuad = [
+      { x: 65, y: 22 },
+      { x: 452, y: 72 },
+      { x: 494, y: 512 },
+      { x: 31, y: 548 },
+    ];
+    const from = cv.matFromArray(
+      4,
+      1,
+      cv.CV_32FC2,
+      canonicalPage.flatMap(({ x, y }) => [x, y]),
+    );
+    const to = cv.matFromArray(
+      4,
+      1,
+      cv.CV_32FC2,
+      photographedPage.flatMap(({ x, y }) => [x, y]),
+    );
+    const photographTransform = cv.getPerspectiveTransform(from, to);
+    const canonicalMat = cv.matFromImageData(canonical);
+    const photographedMat = new cv.Mat();
+    try {
+      cv.warpPerspective(
+        canonicalMat,
+        photographedMat,
+        photographTransform,
+        new cv.Size(525, 570),
+        cv.INTER_LINEAR,
+        cv.BORDER_CONSTANT,
+        new cv.Scalar(255, 255, 255, 255),
+      );
+
+      const centers = transformPoints(
+        templateMarkerCentersMm("a4").map(({ x, y }) => ({
+          x: x * 2,
+          y: y * 2,
+        })),
+        photographTransform,
+      );
+      const physicalCorners = templateMarkerCornersMm("a4");
+      const photographedCorners = transformPoints(
+        physicalCorners.flatMap(({ corners }) =>
+          corners.map(({ x, y }) => ({ x: x * 2, y: y * 2 })),
+        ),
+        photographTransform,
+      );
+      const markers = templateMarkerCentersMm("a4").map(({ id }, index) => ({
+        id,
+        centerPx: centers[index],
+        cornersPx: photographedCorners.slice(
+          index * 4,
+          index * 4 + 4,
+        ) as PerspectiveQuad,
+      }));
+      const proposal = proposalFromTemplateMarkers(markers, "a4")!;
+      const photographed = {
+        data: new Uint8ClampedArray(photographedMat.data),
+        width: photographedMat.cols,
+        height: photographedMat.rows,
+        colorSpace: "srgb",
+      } as ImageData;
+      const corrected = runPerspectiveCorrection(
+        cv,
+        photographed,
+        proposal,
+        "a4",
+      );
+
+      expect(corrected.reprojectionErrorPx).not.toBeNull();
+      expect(corrected.reprojectionErrorPx!).toBeLessThan(0.01);
+      expect(pixel(corrected.imageData, 210, 290).slice(0, 3)).toEqual([
+        20, 80, 180,
+      ]);
+    } finally {
+      photographedMat.delete();
+      canonicalMat.delete();
+      photographTransform.delete();
+      to.delete();
+      from.delete();
     }
   });
 });

--- a/client/src/lib/calibrate/perspective.ts
+++ b/client/src/lib/calibrate/perspective.ts
@@ -1,0 +1,232 @@
+import type { Calibration } from "@shared/geometry/scale";
+import type { Point } from "@shared/geometry/types";
+
+import { loadOpenCV } from "@/lib/opencv";
+
+import {
+  TEMPLATE_SPACING_MM,
+  TEMPLATE_MARKER_IDS,
+  TEMPLATE_PAPER_MM,
+  templateMarkerCentersMm,
+  type TemplatePaper,
+} from "./template";
+import type { DetectedMarker } from "./solve";
+
+/** The four source points, ordered top-left, top-right, bottom-right, bottom-left. */
+export type PerspectiveQuad = [Point, Point, Point, Point];
+
+export type PerspectiveSource = "template" | "manual";
+
+/** A proposed mapping from the photographed plane to a metric paper rectangle. */
+export interface PerspectiveProposal {
+  source: PerspectiveSource;
+  points: PerspectiveQuad;
+}
+
+export interface PerspectiveLayout {
+  width: number;
+  height: number;
+  pxPerMm: number;
+  destination: PerspectiveQuad;
+}
+
+export interface PerspectiveCorrectionResult extends PerspectiveLayout {
+  imageData: ImageData;
+  calibration: Calibration;
+}
+
+/**
+ * Two pixels per millimetre nearly fills the existing 800 x 600 working frame
+ * for portrait A4 while keeping both A4 and Letter below the cap. More pixels
+ * would be discarded by the canvas cap; fewer would throw away source detail.
+ */
+export const RECTIFIED_PX_PER_MM = 2;
+
+/** Builds an ordered four-marker proposal, or null when any template id is absent. */
+export function proposalFromTemplateMarkers(
+  markers: readonly DetectedMarker[],
+): PerspectiveProposal | null {
+  const unique = new Map<number, DetectedMarker>();
+  const duplicates = new Set<number>();
+  for (const marker of markers) {
+    if (unique.has(marker.id)) duplicates.add(marker.id);
+    else unique.set(marker.id, marker);
+  }
+
+  const ordered: Point[] = [];
+  for (const id of TEMPLATE_MARKER_IDS) {
+    if (duplicates.has(id)) return null;
+    const marker = unique.get(id);
+    if (!marker) return null;
+    ordered.push(marker.centerPx);
+  }
+  return { source: "template", points: ordered as PerspectiveQuad };
+}
+
+/** Rescales a proposal between detection and working-image coordinate spaces. */
+export function scalePerspectiveProposal(
+  proposal: PerspectiveProposal,
+  factor: number,
+): PerspectiveProposal {
+  return {
+    ...proposal,
+    points: proposal.points.map((point) => ({
+      x: point.x * factor,
+      y: point.y * factor,
+    })) as PerspectiveQuad,
+  };
+}
+
+/**
+ * Defines the corrected paper raster and the four destination correspondences.
+ * Manual points are page corners. Template points are marker centres, whose
+ * page locations are already fixed by the printable sheet.
+ */
+export function perspectiveLayout(
+  proposal: PerspectiveProposal,
+  paper: TemplatePaper,
+  max = { width: 800, height: 600 },
+): PerspectiveLayout {
+  const page = TEMPLATE_PAPER_MM[paper];
+  const availableX = Math.max(1, max.width - 1) / page.width;
+  const availableY = Math.max(1, max.height - 1) / page.height;
+  const pxPerMm = Math.min(RECTIFIED_PX_PER_MM, availableX, availableY);
+  const width = Math.ceil(page.width * pxPerMm) + 1;
+  const height = Math.ceil(page.height * pxPerMm) + 1;
+
+  const destination =
+    proposal.source === "template"
+      ? (templateMarkerCentersMm(paper).map(({ x, y }) => ({
+          x: x * pxPerMm,
+          y: y * pxPerMm,
+        })) as PerspectiveQuad)
+      : ([
+          { x: 0, y: 0 },
+          { x: page.width * pxPerMm, y: 0 },
+          { x: page.width * pxPerMm, y: page.height * pxPerMm },
+          { x: 0, y: page.height * pxPerMm },
+        ] as PerspectiveQuad);
+
+  return { width, height, pxPerMm, destination };
+}
+
+/** Rejects collapsed, self-intersecting, or incorrectly ordered quads. */
+export function validPerspectiveQuad(points: readonly Point[]): boolean {
+  if (points.length !== 4) return false;
+  if (points.some((point) => !Number.isFinite(point.x) || !Number.isFinite(point.y))) {
+    return false;
+  }
+
+  let areaTwice = 0;
+  const turns: number[] = [];
+  for (let index = 0; index < 4; index++) {
+    const a = points[index];
+    const b = points[(index + 1) % 4];
+    const c = points[(index + 2) % 4];
+    areaTwice += a.x * b.y - b.x * a.y;
+    turns.push((b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x));
+  }
+  if (Math.abs(areaTwice) < 50) return false;
+  const positive = turns.every((turn) => turn > 1e-6);
+  const negative = turns.every((turn) => turn < -1e-6);
+  return positive || negative;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- opencv.js is untyped */
+
+/** Pure OpenCV composition, separated so tests exercise the shipped build. */
+export function runPerspectiveCorrection(
+  cv: any,
+  image: ImageData,
+  proposal: PerspectiveProposal,
+  paper: TemplatePaper,
+  max = { width: 800, height: 600 },
+): PerspectiveCorrectionResult {
+  if (!validPerspectiveQuad(proposal.points)) {
+    throw new Error(
+      "The four correction points must form one non-overlapping rectangle in clockwise order.",
+    );
+  }
+
+  const layout = perspectiveLayout(proposal, paper, max);
+  const source = cv.matFromImageData(image);
+  const corrected = new cv.Mat();
+  const sourcePoints = cv.matFromArray(
+    4,
+    1,
+    cv.CV_32FC2,
+    proposal.points.flatMap(({ x, y }) => [x, y]),
+  );
+  const destinationPoints = cv.matFromArray(
+    4,
+    1,
+    cv.CV_32FC2,
+    layout.destination.flatMap(({ x, y }) => [x, y]),
+  );
+  let transform: any | null = null;
+
+  try {
+    transform = cv.getPerspectiveTransform(sourcePoints, destinationPoints);
+    cv.warpPerspective(
+      source,
+      corrected,
+      transform,
+      new cv.Size(layout.width, layout.height),
+      cv.INTER_LINEAR,
+      cv.BORDER_CONSTANT,
+      new cv.Scalar(255, 255, 255, 255),
+    );
+
+    const pixels = new Uint8ClampedArray(corrected.data);
+    const imageData =
+      typeof ImageData === "function"
+        ? new ImageData(pixels, layout.width, layout.height)
+        : ({
+            data: pixels,
+            width: layout.width,
+            height: layout.height,
+            colorSpace: "srgb",
+          } as ImageData);
+
+    const start = layout.destination[0];
+    const end = layout.destination[2];
+    const lengthMm =
+      proposal.source === "template"
+        ? Math.hypot(TEMPLATE_SPACING_MM.width, TEMPLATE_SPACING_MM.height)
+        : Math.hypot(TEMPLATE_PAPER_MM[paper].width, TEMPLATE_PAPER_MM[paper].height);
+
+    return {
+      ...layout,
+      imageData,
+      calibration: {
+        startX: start.x,
+        startY: start.y,
+        endX: end.x,
+        endY: end.y,
+        lengthMm,
+      },
+    };
+  } finally {
+    transform?.delete?.();
+    destinationPoints.delete();
+    sourcePoints.delete();
+    corrected.delete();
+    source.delete();
+  }
+}
+
+/** Browser entry point using Pocketry's bundled OpenCV build. */
+export async function correctPerspective(
+  image: ImageData,
+  proposal: PerspectiveProposal,
+  paper: TemplatePaper,
+): Promise<PerspectiveCorrectionResult> {
+  const cv = await loadOpenCV();
+  if (
+    typeof cv?.getPerspectiveTransform !== "function" ||
+    typeof cv?.warpPerspective !== "function"
+  ) {
+    throw new Error("Perspective correction is unavailable in this browser session.");
+  }
+  return runPerspectiveCorrection(cv, image, proposal, paper);
+}

--- a/client/src/lib/calibrate/perspective.ts
+++ b/client/src/lib/calibrate/perspective.ts
@@ -7,6 +7,7 @@ import {
   TEMPLATE_SPACING_MM,
   TEMPLATE_MARKER_IDS,
   TEMPLATE_PAPER_MM,
+  templateMarkerCornersMm,
   templateMarkerCentersMm,
   type TemplatePaper,
 } from "./template";
@@ -21,6 +22,13 @@ export type PerspectiveSource = "template" | "manual";
 export interface PerspectiveProposal {
   source: PerspectiveSource;
   points: PerspectiveQuad;
+  /** Automatically encoded by the marker-id family for template proposals. */
+  paper?: TemplatePaper;
+  /** Redundant marker-corner correspondences for a precision homography. */
+  correspondences?: {
+    source: Point[];
+    destinationMm: Point[];
+  };
 }
 
 export interface PerspectiveLayout {
@@ -33,6 +41,8 @@ export interface PerspectiveLayout {
 export interface PerspectiveCorrectionResult extends PerspectiveLayout {
   imageData: ImageData;
   calibration: Calibration;
+  /** Root-mean-square destination error; null for a four-click manual fit. */
+  reprojectionErrorPx: number | null;
 }
 
 /**
@@ -42,9 +52,13 @@ export interface PerspectiveCorrectionResult extends PerspectiveLayout {
  */
 export const RECTIFIED_PX_PER_MM = 2;
 
+/** Reject a template fit whose residual exceeds 0.75 mm on the output plane. */
+export const MAX_REPROJECTION_RMS_PX = 1.5;
+
 /** Builds an ordered four-marker proposal, or null when any template id is absent. */
 export function proposalFromTemplateMarkers(
   markers: readonly DetectedMarker[],
+  paper: TemplatePaper,
 ): PerspectiveProposal | null {
   const unique = new Map<number, DetectedMarker>();
   const duplicates = new Set<number>();
@@ -54,13 +68,26 @@ export function proposalFromTemplateMarkers(
   }
 
   const ordered: Point[] = [];
-  for (const id of TEMPLATE_MARKER_IDS) {
+  const source: Point[] = [];
+  const destinationMm: Point[] = [];
+  const physicalCorners = new Map(
+    templateMarkerCornersMm(paper).map((marker) => [marker.id, marker.corners]),
+  );
+  for (const id of TEMPLATE_MARKER_IDS[paper]) {
     if (duplicates.has(id)) return null;
     const marker = unique.get(id);
-    if (!marker) return null;
+    const destinationCorners = physicalCorners.get(id);
+    if (!marker?.cornersPx || !destinationCorners) return null;
     ordered.push(marker.centerPx);
+    source.push(...marker.cornersPx);
+    destinationMm.push(...destinationCorners);
   }
-  return { source: "template", points: ordered as PerspectiveQuad };
+  return {
+    source: "template",
+    paper,
+    points: ordered as PerspectiveQuad,
+    correspondences: { source, destinationMm },
+  };
 }
 
 /** Rescales a proposal between detection and working-image coordinate spaces. */
@@ -74,6 +101,15 @@ export function scalePerspectiveProposal(
       x: point.x * factor,
       y: point.y * factor,
     })) as PerspectiveQuad,
+    correspondences: proposal.correspondences
+      ? {
+          ...proposal.correspondences,
+          source: proposal.correspondences.source.map((point) => ({
+            x: point.x * factor,
+            y: point.y * factor,
+          })),
+        }
+      : undefined,
   };
 }
 
@@ -147,26 +183,73 @@ export function runPerspectiveCorrection(
       "The four correction points must form one non-overlapping rectangle in clockwise order.",
     );
   }
+  if (proposal.paper && proposal.paper !== paper) {
+    throw new Error("The detected template paper does not match the requested correction.");
+  }
 
   const layout = perspectiveLayout(proposal, paper, max);
   const source = cv.matFromImageData(image);
   const corrected = new cv.Mat();
+  const precisionFit =
+    proposal.correspondences &&
+    proposal.correspondences.source.length >= 4 &&
+    proposal.correspondences.source.length ===
+      proposal.correspondences.destinationMm.length
+      ? proposal.correspondences
+      : null;
+  const sourceCoordinates = precisionFit?.source ?? proposal.points;
+  const destinationCoordinates = precisionFit
+    ? precisionFit.destinationMm.map(({ x, y }) => ({
+        x: x * layout.pxPerMm,
+        y: y * layout.pxPerMm,
+      }))
+    : layout.destination;
   const sourcePoints = cv.matFromArray(
-    4,
+    sourceCoordinates.length,
     1,
     cv.CV_32FC2,
-    proposal.points.flatMap(({ x, y }) => [x, y]),
+    sourceCoordinates.flatMap(({ x, y }) => [x, y]),
   );
   const destinationPoints = cv.matFromArray(
-    4,
+    destinationCoordinates.length,
     1,
     cv.CV_32FC2,
-    layout.destination.flatMap(({ x, y }) => [x, y]),
+    destinationCoordinates.flatMap(({ x, y }) => [x, y]),
   );
   let transform: any | null = null;
+  const projected = new cv.Mat();
 
   try {
-    transform = cv.getPerspectiveTransform(sourcePoints, destinationPoints);
+    transform = precisionFit
+      ? cv.findHomography(sourcePoints, destinationPoints, 0)
+      : cv.getPerspectiveTransform(sourcePoints, destinationPoints);
+    if (!transform || transform.rows !== 3 || transform.cols !== 3) {
+      throw new Error("The correction points could not define a stable plane.");
+    }
+
+    let reprojectionErrorPx: number | null = null;
+    if (precisionFit) {
+      cv.perspectiveTransform(sourcePoints, projected, transform);
+      const values = projected.data32F as Float32Array;
+      let sumSquared = 0;
+      for (let index = 0; index < destinationCoordinates.length; index++) {
+        const dx = values[index * 2] - destinationCoordinates[index].x;
+        const dy = values[index * 2 + 1] - destinationCoordinates[index].y;
+        sumSquared += dx * dx + dy * dy;
+      }
+      reprojectionErrorPx = Math.sqrt(
+        sumSquared / destinationCoordinates.length,
+      );
+      if (
+        !Number.isFinite(reprojectionErrorPx) ||
+        reprojectionErrorPx > MAX_REPROJECTION_RMS_PX
+      ) {
+        throw new Error(
+          "The template corners disagree too much for a precise correction. Flatten the sheet, avoid the phone's ultra-wide lens, and retake the photo.",
+        );
+      }
+    }
+
     cv.warpPerspective(
       source,
       corrected,
@@ -198,6 +281,7 @@ export function runPerspectiveCorrection(
     return {
       ...layout,
       imageData,
+      reprojectionErrorPx,
       calibration: {
         startX: start.x,
         startY: start.y,
@@ -207,6 +291,7 @@ export function runPerspectiveCorrection(
       },
     };
   } finally {
+    projected.delete();
     transform?.delete?.();
     destinationPoints.delete();
     sourcePoints.delete();

--- a/client/src/lib/calibrate/solve.test.ts
+++ b/client/src/lib/calibrate/solve.test.ts
@@ -4,8 +4,12 @@ import { solveScaleFromMarkers, SKEW_WARN_FRACTION } from "./solve";
 import { templateMarkerCentersMm } from "./template";
 
 /** Detected markers synthesised from the template at `pxPerMm`. */
-function syntheticMarkers(pxPerMm: number, ids?: number[]) {
-  return templateMarkerCentersMm("a4")
+function syntheticMarkers(
+  pxPerMm: number,
+  ids?: number[],
+  paper: "a4" | "letter" = "a4",
+) {
+  return templateMarkerCentersMm(paper)
     .filter((entry) => !ids || ids.includes(entry.id))
     .map((entry) => ({
       id: entry.id,
@@ -23,6 +27,16 @@ describe("solveScaleFromMarkers", () => {
     expect(solution.maxDeviation).toBeCloseTo(0, 9);
     // The longest pair is a 250 mm diagonal — the 3-4-5 self-check.
     expect(solution.ruler.lengthMm).toBeCloseTo(250, 9);
+  });
+
+  it("recovers Letter scale from its distinct marker family", () => {
+    const solution = solveScaleFromMarkers(
+      syntheticMarkers(2, undefined, "letter"),
+      "letter",
+    )!;
+    expect(solution.mmPerPx).toBeCloseTo(0.5, 9);
+    expect(solution.markerIds).toEqual([4, 5, 6, 7]);
+    expect(solution.pairCount).toBe(6);
   });
 
   it("works from any two markers", () => {

--- a/client/src/lib/calibrate/solve.ts
+++ b/client/src/lib/calibrate/solve.ts
@@ -21,6 +21,8 @@ import {
 export interface DetectedMarker {
   id: number;
   centerPx: Point;
+  /** Canonical marker corners: top-left, top-right, bottom-right, bottom-left. */
+  cornersPx?: [Point, Point, Point, Point];
 }
 
 export interface ScaleSolution {
@@ -43,7 +45,7 @@ export const SKEW_WARN_FRACTION = 0.02;
 
 export function solveScaleFromMarkers(
   markers: readonly DetectedMarker[],
-  paper: TemplatePaper = "a4",
+  paper: TemplatePaper,
 ): ScaleSolution | null {
   const template = new Map(
     templateMarkerCentersMm(paper).map((entry) => [entry.id, entry]),
@@ -51,7 +53,7 @@ export function solveScaleFromMarkers(
   const usable = markers.filter(
     (marker) =>
       template.has(marker.id) &&
-      (TEMPLATE_MARKER_IDS as readonly number[]).includes(marker.id),
+      TEMPLATE_MARKER_IDS[paper].includes(marker.id),
   );
   // Dedupe ids: a reflection or reprint can yield the same id twice; trust
   // neither copy.

--- a/client/src/lib/calibrate/template-pdf.test.ts
+++ b/client/src/lib/calibrate/template-pdf.test.ts
@@ -92,6 +92,24 @@ describe("printable calibration PDF", () => {
     }
   });
 
+  it("uses A4's extra height to separate the header from the markers", () => {
+    const a4 = pdfText("a4");
+    const letter = pdfText("letter");
+    const instructionBaseline = (pdf: string) =>
+      Number(
+        pdf.match(
+          /BT \/F1 [\d.]+ Tf [\d.]+ ([\d.]+) Td \(Place the tool/,
+        )![1],
+      ) /
+      (72 / 25.4);
+
+    expect(instructionBaseline(a4)).toBeCloseTo(297 - 22, 4);
+    expect(instructionBaseline(letter)).toBeCloseTo(279.4 - 22.7, 4);
+
+    const a4InstructionFromTop = 297 - instructionBaseline(a4);
+    expect(33.5 - a4InstructionFromTop).toBeCloseTo(11.5, 4);
+  });
+
   it("emits a complete single-page PDF with a cross-reference table", () => {
     for (const paper of ["a4", "letter"] as const) {
       const pdf = pdfText(paper);

--- a/client/src/lib/calibrate/template-pdf.test.ts
+++ b/client/src/lib/calibrate/template-pdf.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { calibrationTemplatePdf } from "./template-pdf";
+
+function pdfText(paper: "a4" | "letter"): string {
+  return new TextDecoder().decode(calibrationTemplatePdf(paper));
+}
+
+function markerRectangles(pdf: string): { x: number; y: number }[] {
+  return [...pdf.matchAll(/0 g\n([\d.]+) ([\d.]+) 85\.0394 85\.0394 re f/g)].map(
+    (match) => ({ x: Number(match[1]), y: Number(match[2]) }),
+  );
+}
+
+describe("printable calibration PDF", () => {
+  it("uses exact A4 and US Letter page boxes with print scaling disabled", () => {
+    const a4 = pdfText("a4");
+    expect(a4).toContain("/MediaBox [0 0 595.2756 841.8898]");
+    expect(a4).toContain("/CropBox [0 0 595.2756 841.8898]");
+    expect(a4).toContain("/PrintScaling /None");
+
+    const letter = pdfText("letter");
+    expect(letter).toContain("/MediaBox [0 0 612 792]");
+    expect(letter).toContain("/CropBox [0 0 612 792]");
+    expect(letter).toContain("/PrintScaling /None");
+  });
+
+  it("draws four 30 mm markers at 150 x 200 mm centre spacing", () => {
+    for (const paper of ["a4", "letter"] as const) {
+      const rectangles = markerRectangles(pdfText(paper));
+      expect(rectangles).toHaveLength(4);
+      const xs = [...new Set(rectangles.map(({ x }) => x))].sort((a, b) => a - b);
+      const ys = [...new Set(rectangles.map(({ y }) => y))].sort((a, b) => a - b);
+      expect((xs[1] - xs[0]) / (72 / 25.4)).toBeCloseTo(150, 4);
+      expect((ys[1] - ys[0]) / (72 / 25.4)).toBeCloseTo(200, 4);
+      expect(85.0394 / (72 / 25.4)).toBeCloseTo(30, 4);
+    }
+  });
+
+  it("uses the intended paper-specific marker IDs and a 100 mm check bar", () => {
+    const a4 = pdfText("a4");
+    for (const id of [0, 1, 2, 3]) expect(a4).toContain(`(id ${id})`);
+    expect(a4).not.toContain("(id 4)");
+
+    const letter = pdfText("letter");
+    for (const id of [4, 5, 6, 7]) expect(letter).toContain(`(id ${id})`);
+    expect(letter).not.toContain("(id 0)");
+
+    const lines = [...a4.matchAll(/([\d.]+) ([\d.]+) m ([\d.]+) \2 l S/g)];
+    expect(
+      lines.some(
+        (match) =>
+          Math.abs((Number(match[3]) - Number(match[1])) / (72 / 25.4) - 100) <
+          0.0001,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps every drawn element inside an 8 mm print-safe margin", () => {
+    for (const paper of ["a4", "letter"] as const) {
+      const pdf = pdfText(paper);
+      const mediaBox = pdf.match(/\/MediaBox \[0 0 ([\d.]+) ([\d.]+)\]/)!;
+      const width = Number(mediaBox[1]);
+      const height = Number(mediaBox[2]);
+      const safe = 8 * (72 / 25.4);
+      const checkLabel = pdf.match(
+        /BT \/F1 [\d.]+ Tf [\d.]+ ([\d.]+) Td \(check: this bar/,
+      )!;
+      expect(Number(checkLabel[1]) / (72 / 25.4)).toBeCloseTo(14, 4);
+      const pageRect = `${width} ${height} re f`;
+      const coordinates = [
+        ...pdf.matchAll(/([\d.]+) ([\d.]+) ([\d.]+) ([\d.]+) re f/g),
+      ]
+        .filter((match) => !match[0].includes(pageRect))
+        .map((match) => ({
+          x: Number(match[1]),
+          y: Number(match[2]),
+          width: Number(match[3]),
+          height: Number(match[4]),
+        }));
+      expect(coordinates.length).toBeGreaterThan(4);
+      for (const rectangle of coordinates) {
+        expect(rectangle.x).toBeGreaterThanOrEqual(safe - 0.001);
+        expect(rectangle.y).toBeGreaterThanOrEqual(safe - 0.001);
+        expect(rectangle.x + rectangle.width).toBeLessThanOrEqual(
+          width - safe + 0.001,
+        );
+        expect(rectangle.y + rectangle.height).toBeLessThanOrEqual(
+          height - safe + 0.001,
+        );
+      }
+    }
+  });
+
+  it("emits a complete single-page PDF with a cross-reference table", () => {
+    for (const paper of ["a4", "letter"] as const) {
+      const pdf = pdfText(paper);
+      expect(pdf.startsWith("%PDF-1.4\n")).toBe(true);
+      expect(pdf).toContain("/Type /Page");
+      expect(pdf).toContain("xref\n0 6");
+      expect(pdf.trimEnd().endsWith("%%EOF")).toBe(true);
+    }
+  });
+});

--- a/client/src/lib/calibrate/template-pdf.ts
+++ b/client/src/lib/calibrate/template-pdf.ts
@@ -3,6 +3,7 @@ import {
   TEMPLATE_MARKER_SIZE_MM,
   TEMPLATE_PAPER_MM,
   TEMPLATE_PRINT_SAFE_MARGIN_MM,
+  templateHeaderBaselinesMm,
   templateMarkerCentersMm,
   type TemplatePaper,
 } from "./template";
@@ -49,6 +50,7 @@ export function calibrationTemplatePdf(paper: TemplatePaper): Uint8Array {
   const pageWidth = page.width * PDF_POINTS_PER_MM;
   const pageHeight = page.height * PDF_POINTS_PER_MM;
   const centers = templateMarkerCentersMm(paper);
+  const header = templateHeaderBaselinesMm(paper);
   const markerSize = TEMPLATE_MARKER_SIZE_MM * PDF_POINTS_PER_MM;
   const moduleSize = markerSize / ARUCO_4X4_MODULES;
   const commands: string[] = ["1 g", `0 0 ${number(pageWidth)} ${number(pageHeight)} re f`];
@@ -116,14 +118,14 @@ export function calibrationTemplatePdf(paper: TemplatePaper): Uint8Array {
   drawCenteredText(
     `Pocketry ${paper === "a4" ? "A4" : "US Letter"} calibration sheet - print at 100% scale (no fit to page)`,
     centerX,
-    centers[0].y - TEMPLATE_MARKER_SIZE_MM / 2 - 8,
+    header.title,
     5,
     0,
   );
   drawCenteredText(
     "Place the tool between the markers, keep all four visible, shoot from directly above.",
     centerX,
-    centers[0].y - TEMPLATE_MARKER_SIZE_MM / 2 - 2,
+    header.instructions,
     3.5,
     0.2,
   );

--- a/client/src/lib/calibrate/template-pdf.ts
+++ b/client/src/lib/calibrate/template-pdf.ts
@@ -1,0 +1,193 @@
+import { ARUCO_4X4_MODULES, markerBits } from "./aruco-4x4";
+import {
+  TEMPLATE_MARKER_SIZE_MM,
+  TEMPLATE_PAPER_MM,
+  TEMPLATE_PRINT_SAFE_MARGIN_MM,
+  templateMarkerCentersMm,
+  type TemplatePaper,
+} from "./template";
+
+export const PDF_POINTS_PER_MM = 72 / 25.4;
+
+function number(value: number): string {
+  return value.toFixed(4).replace(/\.?0+$/, "");
+}
+
+function escapePdfText(text: string): string {
+  return text.replace(/([\\()])/g, "\\$1");
+}
+
+/** Conservative Helvetica width estimate, sufficient for centred sheet labels. */
+function estimatedTextWidth(text: string, fontSize: number): number {
+  let units = 0;
+  for (const character of text) {
+    if ("ilI1.,:;!'".includes(character)) units += 0.28;
+    else if ("mwMW@".includes(character)) units += 0.86;
+    else if (character === " ") units += 0.28;
+    else units += 0.54;
+  }
+  return units * fontSize;
+}
+
+function concatBytes(parts: readonly Uint8Array[]): Uint8Array {
+  const size = parts.reduce((sum, part) => sum + part.length, 0);
+  const output = new Uint8Array(size);
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+  return output;
+}
+
+/**
+ * Builds a one-page vector PDF whose drawing coordinates are derived directly
+ * from the same millimetre template geometry used by the detector.
+ */
+export function calibrationTemplatePdf(paper: TemplatePaper): Uint8Array {
+  const page = TEMPLATE_PAPER_MM[paper];
+  const pageWidth = page.width * PDF_POINTS_PER_MM;
+  const pageHeight = page.height * PDF_POINTS_PER_MM;
+  const centers = templateMarkerCentersMm(paper);
+  const markerSize = TEMPLATE_MARKER_SIZE_MM * PDF_POINTS_PER_MM;
+  const moduleSize = markerSize / ARUCO_4X4_MODULES;
+  const commands: string[] = ["1 g", `0 0 ${number(pageWidth)} ${number(pageHeight)} re f`];
+
+  const pdfX = (millimetres: number) => millimetres * PDF_POINTS_PER_MM;
+  const pdfY = (millimetresFromTop: number) =>
+    pageHeight - millimetresFromTop * PDF_POINTS_PER_MM;
+  const drawTopOriginRect = (
+    xMm: number,
+    yMm: number,
+    widthMm: number,
+    heightMm: number,
+    gray: number,
+  ) => {
+    commands.push(
+      `${number(gray)} g`,
+      `${number(pdfX(xMm))} ${number(pdfY(yMm + heightMm))} ${number(
+        pdfX(widthMm),
+      )} ${number(pdfX(heightMm))} re f`,
+    );
+  };
+  const drawCenteredText = (
+    text: string,
+    centerXMm: number,
+    baselineYMm: number,
+    fontSizeMm: number,
+    gray: number,
+  ) => {
+    const fontSize = pdfX(fontSizeMm);
+    const x = pdfX(centerXMm) - estimatedTextWidth(text, fontSize) / 2;
+    commands.push(
+      `${number(gray)} g`,
+      `BT /F1 ${number(fontSize)} Tf ${number(x)} ${number(
+        pdfY(baselineYMm),
+      )} Td (${escapePdfText(text)}) Tj ET`,
+    );
+  };
+
+  for (const { id, x, y } of centers) {
+    const originX = x - TEMPLATE_MARKER_SIZE_MM / 2;
+    const originY = y - TEMPLATE_MARKER_SIZE_MM / 2;
+    drawTopOriginRect(
+      originX,
+      originY,
+      TEMPLATE_MARKER_SIZE_MM,
+      TEMPLATE_MARKER_SIZE_MM,
+      0,
+    );
+    const bits = markerBits(id);
+    for (let row = 0; row < 4; row++) {
+      for (let col = 0; col < 4; col++) {
+        if (!bits[row][col]) continue;
+        commands.push(
+          "1 g",
+          `${number(pdfX(originX) + (col + 1) * moduleSize)} ${number(
+            pdfY(originY) - (row + 2) * moduleSize,
+          )} ${number(moduleSize)} ${number(moduleSize)} re f`,
+        );
+      }
+    }
+    drawCenteredText(`id ${id}`, x, originY + TEMPLATE_MARKER_SIZE_MM + 5, 3.5, 0.2);
+  }
+
+  const centerX = page.width / 2;
+  drawCenteredText(
+    `Pocketry ${paper === "a4" ? "A4" : "US Letter"} calibration sheet - print at 100% scale (no fit to page)`,
+    centerX,
+    centers[0].y - TEMPLATE_MARKER_SIZE_MM / 2 - 8,
+    5,
+    0,
+  );
+  drawCenteredText(
+    "Place the tool between the markers, keep all four visible, shoot from directly above.",
+    centerX,
+    centers[0].y - TEMPLATE_MARKER_SIZE_MM / 2 - 2,
+    3.5,
+    0.2,
+  );
+
+  const rulerY = page.height - TEMPLATE_PRINT_SAFE_MARGIN_MM;
+  const rulerX = centerX - 50;
+  commands.push(
+    "0 G",
+    `${number(pdfX(0.5))} w`,
+    `${number(pdfX(rulerX))} ${number(pdfY(rulerY))} m ${number(
+      pdfX(rulerX + 100),
+    )} ${number(pdfY(rulerY))} l S`,
+  );
+  for (let index = 0; index <= 10; index++) {
+    const x = rulerX + index * 10;
+    const tick = index % 5 === 0 ? 4 : 2.5;
+    commands.push(
+      `${number(pdfX(0.3))} w`,
+      `${number(pdfX(x))} ${number(pdfY(rulerY))} m ${number(
+        pdfX(x),
+      )} ${number(pdfY(rulerY - tick))} l S`,
+    );
+  }
+  drawCenteredText(
+    "check: this bar is exactly 100 mm - marker centres 150 x 200 mm, diagonals 250 mm",
+    centerX,
+    rulerY - 6,
+    3.5,
+    0.2,
+  );
+
+  const encoder = new TextEncoder();
+  const content = encoder.encode(`${commands.join("\n")}\n`);
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R /ViewerPreferences << /PrintScaling /None >> >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${number(
+      pageWidth,
+    )} ${number(pageHeight)}] /CropBox [0 0 ${number(pageWidth)} ${number(
+      pageHeight,
+    )}] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>`,
+    `<< /Length ${content.length} >>\nstream\n${new TextDecoder().decode(content)}endstream`,
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+  ];
+
+  const chunks: Uint8Array[] = [encoder.encode("%PDF-1.4\n")];
+  const offsets = [0];
+  let byteOffset = chunks[0].length;
+  objects.forEach((object, index) => {
+    offsets.push(byteOffset);
+    const chunk = encoder.encode(`${index + 1} 0 obj\n${object}\nendobj\n`);
+    chunks.push(chunk);
+    byteOffset += chunk.length;
+  });
+  const xrefOffset = byteOffset;
+  const xref = ["xref", `0 ${objects.length + 1}`, "0000000000 65535 f "];
+  for (const offset of offsets.slice(1)) {
+    xref.push(`${String(offset).padStart(10, "0")} 00000 n `);
+  }
+  xref.push(
+    `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>`,
+    `startxref\n${xrefOffset}`,
+    "%%EOF",
+  );
+  chunks.push(encoder.encode(`${xref.join("\n")}\n`));
+  return concatBytes(chunks);
+}

--- a/client/src/lib/calibrate/template.test.ts
+++ b/client/src/lib/calibrate/template.test.ts
@@ -3,17 +3,22 @@ import { describe, expect, it } from "vitest";
 import { ARUCO_4X4_BITS, markerBits } from "./aruco-4x4";
 import {
   calibrationTemplateSvg,
+  paperFromTemplateMarkerIds,
+  TEMPLATE_MARKER_IDS,
   TEMPLATE_MARKER_SIZE_MM,
   TEMPLATE_PAPER_MM,
   TEMPLATE_SPACING_MM,
+  templateMarkerCornersMm,
   templateMarkerCentersMm,
 } from "./template";
 
 describe("ArUco 4x4 dictionary port", () => {
-  it("carries the canonical DICT_4X4 patterns for ids 0-3", () => {
+  it("carries the canonical DICT_4X4 patterns for ids 0-7", () => {
     // Decoded from OpenCV 4.11.0 predefined_dictionaries.hpp (rotation 0 of
     // each marker's byte record) — see the module header for provenance.
-    expect(ARUCO_4X4_BITS).toEqual([0xb532, 0x0f9a, 0x332d, 0x9946]);
+    expect(ARUCO_4X4_BITS).toEqual([
+      0xb532, 0x0f9a, 0x332d, 0x9946, 0x549e, 0x79cd, 0x9e2e, 0xc4f2,
+    ]);
   });
 
   it("decodes id 0 row-major, MSB first", () => {
@@ -26,7 +31,7 @@ describe("ArUco 4x4 dictionary port", () => {
   });
 
   it("rejects unported ids", () => {
-    expect(() => markerBits(7)).toThrow(/no ported pattern/);
+    expect(() => markerBits(8)).toThrow(/no ported pattern/);
   });
 });
 
@@ -34,7 +39,7 @@ describe("calibration template", () => {
   it("places marker centres on the 150×200 rectangle with 3-4-5 diagonals", () => {
     for (const paper of ["a4", "letter"] as const) {
       const centers = templateMarkerCentersMm(paper);
-      expect(centers.map((c) => c.id)).toEqual([0, 1, 2, 3]);
+      expect(centers.map((c) => c.id)).toEqual(TEMPLATE_MARKER_IDS[paper]);
 
       const [tl, tr, br, bl] = centers;
       expect(tr.x - tl.x).toBeCloseTo(TEMPLATE_SPACING_MM.width, 9);
@@ -49,6 +54,28 @@ describe("calibration template", () => {
         expect(y - half).toBeGreaterThanOrEqual(10);
         expect(x + half).toBeLessThanOrEqual(page.width - 10);
         expect(y + half).toBeLessThanOrEqual(page.height - 10);
+      }
+    }
+  });
+
+  it("uses distinct marker families so paper size is automatic", () => {
+    expect(paperFromTemplateMarkerIds([0, 2])).toBe("a4");
+    expect(paperFromTemplateMarkerIds([4, 7])).toBe("letter");
+    expect(paperFromTemplateMarkerIds([0])).toBeNull();
+    expect(paperFromTemplateMarkerIds([0, 4])).toBeNull();
+    expect(paperFromTemplateMarkerIds([12, 13])).toBeNull();
+  });
+
+  it("provides all sixteen physical marker corners for precision fitting", () => {
+    for (const paper of ["a4", "letter"] as const) {
+      const markers = templateMarkerCornersMm(paper);
+      expect(markers).toHaveLength(4);
+      expect(markers.flatMap(({ corners }) => corners)).toHaveLength(16);
+      for (const marker of markers) {
+        expect(marker.corners[1].x - marker.corners[0].x).toBeCloseTo(
+          TEMPLATE_MARKER_SIZE_MM,
+          9,
+        );
       }
     }
   });
@@ -69,7 +96,10 @@ describe("calibration template", () => {
     const whiteCells = svg.match(/fill="#fff"/g) ?? [];
     const popcount = (bits: number) =>
       bits.toString(2).split("").filter((b) => b === "1").length;
-    const expected = ARUCO_4X4_BITS.reduce((sum, bits) => sum + popcount(bits), 0);
+    const expected = TEMPLATE_MARKER_IDS.a4.reduce(
+      (sum, id) => sum + popcount(ARUCO_4X4_BITS[id]),
+      0,
+    );
     // One background rect is white too.
     expect(whiteCells.length).toBe(expected + 1);
     // One black base rect per marker (texts also use #000, hence rect-scoped).
@@ -84,6 +114,10 @@ describe("calibration template", () => {
     expect(svg).toContain("print at 100% scale");
     expect(svg).toContain("id 0");
     expect(svg).toContain("id 3");
+    const letter = calibrationTemplateSvg("letter");
+    expect(letter).toContain("id 4");
+    expect(letter).toContain("id 7");
+    expect(letter).not.toContain("id 0");
   });
 
   it("is deterministic", () => {

--- a/client/src/lib/calibrate/template.ts
+++ b/client/src/lib/calibrate/template.ts
@@ -37,6 +37,21 @@ export const TEMPLATE_MARKER_SIZE_MM = 30;
 /** Minimum clearance between printed calibration content and the paper edge. */
 export const TEMPLATE_PRINT_SAFE_MARGIN_MM = 8;
 
+/** Header baselines; A4 uses its extra height to leave more marker clearance. */
+export function templateHeaderBaselinesMm(
+  paper: TemplatePaper,
+): { title: number; instructions: number } {
+  if (paper === "a4") {
+    return {
+      title: TEMPLATE_PRINT_SAFE_MARGIN_MM + 7,
+      instructions: TEMPLATE_PRINT_SAFE_MARGIN_MM + 14,
+    };
+  }
+  const markerTop =
+    templateMarkerCentersMm(paper)[0].y - TEMPLATE_MARKER_SIZE_MM / 2;
+  return { title: markerTop - 8, instructions: markerTop - 2 };
+}
+
 /** Corner assignment, clockwise from top-left, unique to each paper size. */
 export const TEMPLATE_MARKER_IDS: Record<
   TemplatePaper,
@@ -132,6 +147,7 @@ function markerSvg(id: number, centerX: number, centerY: number): string {
 export function calibrationTemplateSvg(paper: TemplatePaper): string {
   const page = TEMPLATE_PAPER_MM[paper];
   const centers = templateMarkerCentersMm(paper);
+  const header = templateHeaderBaselinesMm(paper);
   const cx = page.width / 2;
 
   const markers = centers.map(({ id, x, y }) => markerSvg(id, x, y)).join("\n  ");
@@ -146,8 +162,8 @@ export function calibrationTemplateSvg(paper: TemplatePaper): string {
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${page.width}mm" height="${page.height}mm" viewBox="0 0 ${page.width} ${page.height}">
   <rect width="${page.width}" height="${page.height}" fill="#fff"/>
-  <text x="${cx}" y="${centers[0].y - TEMPLATE_MARKER_SIZE_MM / 2 - 8}" text-anchor="middle" font-size="5" font-family="sans-serif" fill="#000">Pocketry calibration sheet — print at 100% scale (no “fit to page”)</text>
-  <text x="${cx}" y="${centers[0].y - TEMPLATE_MARKER_SIZE_MM / 2 - 2}" text-anchor="middle" font-size="3.5" font-family="sans-serif" fill="#333">Place the tool between the markers, keep all four visible, shoot from directly above.</text>
+  <text x="${cx}" y="${header.title}" text-anchor="middle" font-size="5" font-family="sans-serif" fill="#000">Pocketry calibration sheet — print at 100% scale (no “fit to page”)</text>
+  <text x="${cx}" y="${header.instructions}" text-anchor="middle" font-size="3.5" font-family="sans-serif" fill="#333">Place the tool between the markers, keep all four visible, shoot from directly above.</text>
   ${markers}
   <g>
     <line x1="${rulerX}" y1="${rulerY}" x2="${rulerX + 100}" y2="${rulerY}" stroke="#000" stroke-width="0.5"/>

--- a/client/src/lib/calibrate/template.ts
+++ b/client/src/lib/calibrate/template.ts
@@ -11,8 +11,14 @@ import { ARUCO_4X4_MODULES, markerBits } from "./aruco-4x4";
  * numbers double as a self-check. IDs are fixed per corner, which lets the
  * solver identify orientation however the sheet is rotated in the photo:
  *
- *     id 0 ── top left        id 1 ── top right
- *     id 3 ── bottom left     id 2 ── bottom right
+ *     A4:     id 0 ── top left        id 1 ── top right
+ *             id 3 ── bottom left     id 2 ── bottom right
+ *
+ *     Letter: id 4 ── top left        id 5 ── top right
+ *             id 7 ── bottom left     id 6 ── bottom right
+ *
+ * Distinct marker families let the detector infer the paper size rather than
+ * asking the user which sheet was printed.
  *
  * The SVG's user unit is the millimetre (`width="210mm"` + matching viewBox),
  * so any browser or slicer printing at 100% produces true-size markers; the
@@ -28,8 +34,19 @@ export const TEMPLATE_SPACING_MM = { width: 150, height: 200 } as const;
 /** Printed side length of one marker, border modules included. */
 export const TEMPLATE_MARKER_SIZE_MM = 30;
 
-/** Corner assignment, clockwise from top-left. */
-export const TEMPLATE_MARKER_IDS = [0, 1, 2, 3] as const;
+/** Minimum clearance between printed calibration content and the paper edge. */
+export const TEMPLATE_PRINT_SAFE_MARGIN_MM = 8;
+
+/** Corner assignment, clockwise from top-left, unique to each paper size. */
+export const TEMPLATE_MARKER_IDS: Record<
+  TemplatePaper,
+  readonly [number, number, number, number]
+> = {
+  a4: [0, 1, 2, 3],
+  letter: [4, 5, 6, 7],
+};
+
+export const ALL_TEMPLATE_MARKER_IDS = Object.values(TEMPLATE_MARKER_IDS).flat();
 
 export const TEMPLATE_PAPER_MM: Record<TemplatePaper, { width: number; height: number }> =
   {
@@ -46,12 +63,41 @@ export function templateMarkerCentersMm(
   const cy = page.height / 2;
   const dx = TEMPLATE_SPACING_MM.width / 2;
   const dy = TEMPLATE_SPACING_MM.height / 2;
+  const ids = TEMPLATE_MARKER_IDS[paper];
   return [
-    { id: TEMPLATE_MARKER_IDS[0], x: cx - dx, y: cy - dy },
-    { id: TEMPLATE_MARKER_IDS[1], x: cx + dx, y: cy - dy },
-    { id: TEMPLATE_MARKER_IDS[2], x: cx + dx, y: cy + dy },
-    { id: TEMPLATE_MARKER_IDS[3], x: cx - dx, y: cy + dy },
+    { id: ids[0], x: cx - dx, y: cy - dy },
+    { id: ids[1], x: cx + dx, y: cy - dy },
+    { id: ids[2], x: cx + dx, y: cy + dy },
+    { id: ids[3], x: cx - dx, y: cy + dy },
   ];
+}
+
+/** Known physical corners for every printed marker, in detector order. */
+export function templateMarkerCornersMm(
+  paper: TemplatePaper,
+): { id: number; corners: readonly { x: number; y: number }[] }[] {
+  const half = TEMPLATE_MARKER_SIZE_MM / 2;
+  return templateMarkerCentersMm(paper).map(({ id, x, y }) => ({
+    id,
+    corners: [
+      { x: x - half, y: y - half },
+      { x: x + half, y: y - half },
+      { x: x + half, y: y + half },
+      { x: x - half, y: y + half },
+    ],
+  }));
+}
+
+/** Identifies one Pocketry template from any two or more of its marker ids. */
+export function paperFromTemplateMarkerIds(
+  ids: readonly number[],
+): TemplatePaper | null {
+  const known = [...new Set(ids.filter((id) => ALL_TEMPLATE_MARKER_IDS.includes(id)))];
+  if (known.length < 2) return null;
+  const matches = (Object.keys(TEMPLATE_MARKER_IDS) as TemplatePaper[]).filter(
+    (paper) => known.every((id) => TEMPLATE_MARKER_IDS[paper].includes(id)),
+  );
+  return matches.length === 1 ? matches[0] : null;
 }
 
 /** One marker as SVG: black square with the pattern's white cells punched in. */
@@ -90,12 +136,12 @@ export function calibrationTemplateSvg(paper: TemplatePaper): string {
 
   const markers = centers.map(({ id, x, y }) => markerSvg(id, x, y)).join("\n  ");
 
-  // 100 mm verification bar, centred near the bottom edge.
-  const rulerY = centers[3].y + TEMPLATE_MARKER_SIZE_MM / 2 + 14;
+  // 100 mm verification bar, centred and kept inside common printer margins.
+  const rulerY = page.height - TEMPLATE_PRINT_SAFE_MARGIN_MM;
   const rulerX = cx - 50;
   const ticks = Array.from({ length: 11 }, (_, i) => {
     const x = rulerX + i * 10;
-    return `<line x1="${x}" y1="${rulerY}" x2="${x}" y2="${rulerY + (i % 5 === 0 ? 4 : 2.5)}" stroke="#000" stroke-width="0.3"/>`;
+    return `<line x1="${x}" y1="${rulerY}" x2="${x}" y2="${rulerY - (i % 5 === 0 ? 4 : 2.5)}" stroke="#000" stroke-width="0.3"/>`;
   }).join("");
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${page.width}mm" height="${page.height}mm" viewBox="0 0 ${page.width} ${page.height}">
@@ -106,7 +152,7 @@ export function calibrationTemplateSvg(paper: TemplatePaper): string {
   <g>
     <line x1="${rulerX}" y1="${rulerY}" x2="${rulerX + 100}" y2="${rulerY}" stroke="#000" stroke-width="0.5"/>
     ${ticks}
-    <text x="${cx}" y="${rulerY + 9}" text-anchor="middle" font-size="3.5" font-family="sans-serif" fill="#333">check: this bar is exactly 100 mm — marker centres 150 × 200 mm, diagonals 250 mm</text>
+    <text x="${cx}" y="${rulerY - 6}" text-anchor="middle" font-size="3.5" font-family="sans-serif" fill="#333">check: this bar is exactly 100 mm — marker centres 150 × 200 mm, diagonals 250 mm</text>
   </g>
 </svg>
 `;

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -16,33 +16,68 @@ const RELATED_PROJECTS = [
     name: "Gridfinity Rebuilt OpenSCAD",
     description:
       "Parametric OpenSCAD bins and the upstream geometry foundation directly adapted by Pocketry.",
-    license: "MIT",
+    badge: "MIT",
     url: "https://github.com/kennetek/gridfinity-rebuilt-openscad",
   },
   {
     name: "Gridfinity Extended",
     description:
       "A broad OpenSCAD toolkit for customizable bins, baseplates, drawers, lids, and specialized holders.",
-    license: "GPL-3.0",
+    badge: "GPL-3.0",
     url: "https://github.com/ostat/gridfinity_extended_openscad",
   },
   {
     name: "Gridfinity Layout Tool",
     description:
       "Plan complete drawers in the browser, then generate bins, baseplates, and an optimized print list.",
-    license: "AGPL-3.0",
+    badge: "AGPL-3.0",
     url: "https://github.com/andymai/gridfinity-layout-tool",
   },
   {
     name: "Outline App",
     description:
       "An image-based outline editor and Gridfinity box creator with contour, text, and primitive editing.",
-    license: "AGPL-3.0",
+    badge: "AGPL-3.0",
     url: "https://github.com/georgslazdans/outline-app",
+  },
+  {
+    name: "Tracefinity",
+    description:
+      "A self-hostable photo-to-bin workflow with automatic tool tracing, a reusable tool library, and STL, 3MF, and SVG export.",
+    badge: "MIT",
+    url: "https://github.com/tracefinity/tracefinity",
+  },
+  {
+    name: "ToolTrace.ai",
+    description:
+      "A hosted photo-to-outline service for making custom Gridfinity trays, foam inserts, and shadow-board layouts.",
+    badge: "Web service",
+    url: "https://www.tooltrace.ai",
+  },
+  {
+    name: "Systemax DIY",
+    description:
+      "Photograph tools, build a reusable tool library and drawer layout, then order the resulting Gridfinity organizers or export production files.",
+    badge: "Design service",
+    url: "https://www.systemax.no/diy",
+  },
+  {
+    name: "Gridfinity Rebase",
+    description:
+      "Replace the bases in downloaded Gridfinity STLs with your preferred magnet-hole and attachment setup directly in the browser.",
+    badge: "GPL-3.0",
+    url: "https://gridfinity.tools/rebase",
+  },
+  {
+    name: "GridFlock",
+    description:
+      "Generate large Gridfinity baseplates that split into printable sections and reconnect with open puzzle-style joints.",
+    badge: "MIT / CC-BY",
+    url: "https://github.com/yawkat/GridFlock",
   },
 ] as const;
 
-/** Project background, legal notices, and links to complementary open tools. */
+/** Project background, legal notices, and links to related Gridfinity tools. */
 export default function About(): JSX.Element {
   return (
     <main className="h-full overflow-y-auto">
@@ -125,11 +160,11 @@ export default function About(): JSX.Element {
               id="related-projects-heading"
               className="text-2xl font-semibold tracking-tight"
             >
-              More open-source Gridfinity tools
+              More Gridfinity tools
             </h2>
             <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
-              Pocketry is one option in a healthy ecosystem. These independent
-              projects complement its photo-to-pocket workflow with configurable
+              These independent projects complement Pocketry or provide
+              alternatives to its photo-to-pocket workflow, including configurable
               bins, baseplates, drawer planning, and alternate outline tools.
             </p>
           </div>
@@ -143,7 +178,7 @@ export default function About(): JSX.Element {
                       {project.name}
                     </CardTitle>
                     <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                      {project.license}
+                      {project.badge}
                     </span>
                   </div>
                 </CardHeader>

--- a/client/src/pages/trace.tsx
+++ b/client/src/pages/trace.tsx
@@ -21,7 +21,13 @@ import {
 import { FileUpload } from "@/components/ui/file-upload";
 import { useToast } from "@/hooks/use-toast";
 import { autoCalibrate } from "@/lib/calibrate/auto-calibrate";
+import {
+  correctPerspective,
+  scalePerspectiveProposal,
+  type PerspectiveProposal,
+} from "@/lib/calibrate/perspective";
 import { SKEW_WARN_FRACTION } from "@/lib/calibrate/solve";
+import type { TemplatePaper } from "@/lib/calibrate/template";
 import { downloadBlob } from "@/lib/download";
 import { generateDXF } from "@/lib/export/dxf";
 import { exportScale } from "@/lib/export/scale";
@@ -36,6 +42,16 @@ export default function TracePage(): JSX.Element {
 }
 
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+function imageDataToPngUrl(image: ImageData): string {
+  const canvas = document.createElement("canvas");
+  canvas.width = image.width;
+  canvas.height = image.height;
+  const context = canvas.getContext("2d");
+  if (!context) throw new Error("Could not create the corrected image preview.");
+  context.putImageData(image, 0, 0);
+  return canvas.toDataURL("image/png");
+}
 
 function TraceWorkspace(): JSX.Element {
   const store = useTrace();
@@ -167,14 +183,20 @@ function TraceWorkspace(): JSX.Element {
             endY: result.calibration.endY * frame.toWorking,
             lengthMm: result.calibration.lengthMm,
           };
-          dispatch({ type: "AUTO_CALIBRATION_DETECTED", calibration });
+          dispatch({
+            type: "AUTO_CALIBRATION_DETECTED",
+            calibration,
+            perspective: result.perspectiveProposal
+              ? scalePerspectiveProposal(result.perspectiveProposal, frame.toWorking)
+              : null,
+          });
           const { solution } = result;
           const mmPerPx = mmPerPixel(calibration);
           const summary = `${solution.markerIds.length} markers · ${(mmPerPx ?? solution.mmPerPx).toFixed(3)} mm/px`;
           if (solution.maxDeviation > SKEW_WARN_FRACTION) {
             toast({
               title: "Scale detected — review carefully",
-              description: `${summary}. Marker distances disagree by ${(solution.maxDeviation * 100).toFixed(1)}%; shoot straight down for accurate millimetres, or accept the detected result in Scale.`,
+              description: `${summary}. Marker distances disagree by ${(solution.maxDeviation * 100).toFixed(1)}%. ${result.perspectiveProposal ? "Perspective correction is available in Scale." : "Shoot straight down for accurate millimetres."}`,
               variant: "destructive",
               duration: 8000,
             });
@@ -212,6 +234,58 @@ function TraceWorkspace(): JSX.Element {
             });
           }
           break;
+      }
+    },
+    [getDetectionFrame, dispatch, toast],
+  );
+
+  const applyPerspective = useCallback(
+    async (proposal: PerspectiveProposal, paper: TemplatePaper) => {
+      const frame = getDetectionFrame();
+      if (!frame || frame.toWorking <= 0) {
+        toast({
+          title: "Correction unavailable",
+          description: "The source image is not ready yet.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      dispatch({ type: "SET_PROCESSING", processing: true });
+      try {
+        // Canvas points live in working-image coordinates. Correct from the
+        // larger marker-detection raster so the warp preserves source detail.
+        const detectionProposal = scalePerspectiveProposal(
+          proposal,
+          1 / frame.toWorking,
+        );
+        const corrected = await correctPerspective(
+          frame.imageData,
+          detectionProposal,
+          paper,
+        );
+        const imageUrl = imageDataToPngUrl(corrected.imageData);
+        dispatch({
+          type: "PERSPECTIVE_APPLIED",
+          imageUrl,
+          imageSize: { width: corrected.width, height: corrected.height },
+          calibration: corrected.calibration,
+          source: proposal.source,
+          paper,
+        });
+        toast({
+          title: "Perspective corrected",
+          description: `${paper === "a4" ? "A4" : "US Letter"} plane rectified at ${(1 / corrected.pxPerMm).toFixed(3)} mm/px.`,
+        });
+      } catch (error) {
+        toast({
+          title: "Perspective correction failed",
+          description: error instanceof Error ? error.message : String(error),
+          variant: "destructive",
+          duration: 8000,
+        });
+      } finally {
+        dispatch({ type: "SET_PROCESSING", processing: false });
       }
     },
     [getDetectionFrame, dispatch, toast],
@@ -347,6 +421,9 @@ function TraceWorkspace(): JSX.Element {
             onExport={() => void handleExport()}
             onReprocess={() => void runDetection()}
             onDetectMarkers={() => void detectMarkers(true)}
+            onApplyPerspective={(proposal, paper) =>
+              void applyPerspective(proposal, paper)
+            }
           />
         }
         canvas={

--- a/client/src/pages/trace.tsx
+++ b/client/src/pages/trace.tsx
@@ -192,7 +192,8 @@ function TraceWorkspace(): JSX.Element {
           });
           const { solution } = result;
           const mmPerPx = mmPerPixel(calibration);
-          const summary = `${solution.markerIds.length} markers · ${(mmPerPx ?? solution.mmPerPx).toFixed(3)} mm/px`;
+          const paperName = result.paper === "a4" ? "A4" : "US Letter";
+          const summary = `${paperName} · ${solution.markerIds.length} markers · ${(mmPerPx ?? solution.mmPerPx).toFixed(3)} mm/px`;
           if (solution.maxDeviation > SKEW_WARN_FRACTION) {
             toast({
               title: "Scale detected — review carefully",
@@ -275,7 +276,7 @@ function TraceWorkspace(): JSX.Element {
         });
         toast({
           title: "Perspective corrected",
-          description: `${paper === "a4" ? "A4" : "US Letter"} plane rectified at ${(1 / corrected.pxPerMm).toFixed(3)} mm/px.`,
+          description: `${paper === "a4" ? "A4" : "US Letter"} plane rectified at ${(1 / corrected.pxPerMm).toFixed(3)} mm/px${corrected.reprojectionErrorPx === null ? "" : ` · ${corrected.reprojectionErrorPx.toFixed(2)} px fit residual`}.`,
         });
       } catch (error) {
         toast({

--- a/client/src/state/trace-store.test.ts
+++ b/client/src/state/trace-store.test.ts
@@ -402,6 +402,25 @@ describe("modes and calibration", () => {
     expect(state.margin).toBe(1.5);
   });
 
+  it("removes a pending automatic ruler when manual placement begins", () => {
+    const detected = {
+      startX: 0,
+      startY: 0,
+      endX: 100,
+      endY: 0,
+      lengthMm: 50,
+    };
+    const state = run(
+      initialTraceState,
+      { type: "AUTO_CALIBRATION_DETECTED", calibration: detected },
+      { type: "SET_MODE", mode: "calibrate" },
+    );
+
+    expect(state.mode).toBe("calibrate");
+    expect(state.pendingAutoCalibration).toBeNull();
+    expect(state.calibration).toBeNull();
+  });
+
   it("preserves a chosen margin when the scale is replaced", () => {
     const calibration = {
       startX: 0,

--- a/client/src/state/trace-store.test.ts
+++ b/client/src/state/trace-store.test.ts
@@ -421,6 +421,78 @@ describe("modes and calibration", () => {
     expect(state.calibration).toBeNull();
   });
 
+  it("collects four manual perspective corners and keeps them editable", () => {
+    const points = [
+      { x: 10, y: 10 },
+      { x: 90, y: 12 },
+      { x: 88, y: 90 },
+      { x: 12, y: 88 },
+    ];
+    const selected = run(
+      initialTraceState,
+      { type: "START_PERSPECTIVE_SELECTION" },
+      ...points.map((point) => ({
+        type: "ADD_PERSPECTIVE_POINT" as const,
+        point,
+      })),
+    );
+
+    expect(selected.manualPerspectivePoints).toEqual(points);
+    expect(selected.mode).toBe("pan");
+
+    const adjusted = traceReducer(selected, {
+      type: "SET_PERSPECTIVE_POINTS",
+      points: [{ x: 8, y: 8 }, ...points.slice(1)],
+    });
+    expect(adjusted.manualPerspectivePoints[0]).toEqual({ x: 8, y: 8 });
+  });
+
+  it("applies a reversible metric perspective correction", () => {
+    const loaded = run(
+      initialTraceState,
+      {
+        type: "SOURCE_LOADED",
+        imageUrl: "data:image/png;base64,original",
+        fileName: "tool",
+      },
+      { type: "SOURCE_READY", imageSize: { width: 800, height: 600 } },
+    );
+    const calibration = {
+      startX: 0,
+      startY: 0,
+      endX: 420,
+      endY: 594,
+      lengthMm: Math.hypot(210, 297),
+    };
+    const corrected = traceReducer(loaded, {
+      type: "PERSPECTIVE_APPLIED",
+      imageUrl: "data:image/png;base64,corrected",
+      imageSize: { width: 421, height: 595 },
+      calibration,
+      source: "manual",
+      paper: "a4",
+    });
+
+    expect(corrected.imageUrl).toContain("corrected");
+    expect(corrected.perspectiveOriginalImageUrl).toContain("original");
+    expect(corrected.perspectiveCorrection).toEqual({
+      source: "manual",
+      paper: "a4",
+    });
+    expect(corrected.calibration).toBe(calibration);
+    expect(corrected.calibrationSource).toBe("sheet");
+    expect(corrected.mode).toBe("region");
+
+    const restored = traceReducer(corrected, {
+      type: "RESTORE_PERSPECTIVE_SOURCE",
+    });
+    expect(restored.imageUrl).toContain("original");
+    expect(restored.perspectiveOriginalImageUrl).toBeNull();
+    expect(restored.perspectiveCorrection).toBeNull();
+    expect(restored.calibration).toBeNull();
+    expect(restored.autoCalibrationAttemptedImageUrl).toBe(restored.imageUrl);
+  });
+
   it("preserves a chosen margin when the scale is replaced", () => {
     const calibration = {
       startX: 0,

--- a/client/src/state/trace-store.test.ts
+++ b/client/src/state/trace-store.test.ts
@@ -1,3 +1,4 @@
+import { mmPerPixel } from "@shared/geometry/scale";
 import type { Outline } from "@shared/geometry/types";
 import { describe, expect, it } from "vitest";
 
@@ -416,6 +417,45 @@ describe("modes and calibration", () => {
       { type: "SET_CALIBRATION", calibration: { ...calibration, lengthMm: 75 } },
     );
     expect(state.margin).toBe(2.5);
+  });
+
+  it("updates mm/px when a completed manual ruler length changes", () => {
+    const calibration = {
+      startX: 0,
+      startY: 0,
+      endX: 100,
+      endY: 0,
+      lengthMm: 50,
+    };
+    const state = run(
+      initialTraceState,
+      { type: "SET_CALIBRATION", calibration },
+      { type: "SET_RULER_LENGTH", rulerLengthMm: 75 },
+    );
+
+    expect(state.rulerLengthMm).toBe(75);
+    expect(state.calibration?.lengthMm).toBe(75);
+    expect(mmPerPixel(state.calibration)).toBe(0.75);
+  });
+
+  it("does not overwrite an accepted calibration-sheet scale", () => {
+    const calibration = {
+      startX: 0,
+      startY: 0,
+      endX: 100,
+      endY: 0,
+      lengthMm: 50,
+    };
+    const state = run(
+      initialTraceState,
+      { type: "AUTO_CALIBRATION_DETECTED", calibration },
+      { type: "ACCEPT_AUTO_CALIBRATION" },
+      { type: "SET_RULER_LENGTH", rulerLengthMm: 75 },
+    );
+
+    expect(state.rulerLengthMm).toBe(75);
+    expect(state.calibration?.lengthMm).toBe(50);
+    expect(mmPerPixel(state.calibration)).toBe(0.5);
   });
 
   it("retains the margin preference when scale is cleared", () => {

--- a/client/src/state/trace-store.tsx
+++ b/client/src/state/trace-store.tsx
@@ -9,8 +9,13 @@ import {
 } from "react";
 
 import type { Calibration, DraftCalibration } from "@shared/geometry/scale";
-import type { Outline, Rect, RingRef } from "@shared/geometry/types";
+import type { Outline, Point, Rect, RingRef } from "@shared/geometry/types";
 
+import type {
+  PerspectiveProposal,
+  PerspectiveSource,
+} from "@/lib/calibrate/perspective";
+import type { TemplatePaper } from "@/lib/calibrate/template";
 import { DEFAULT_MARGIN_MM, type Margin } from "@/lib/image-processor";
 
 /**
@@ -30,7 +35,7 @@ import { DEFAULT_MARGIN_MM, type Margin } from "@/lib/image-processor";
  */
 
 /** Exactly one interaction mode is active at a time. */
-export type TraceMode = "pan" | "region" | "edit" | "calibrate";
+export type TraceMode = "pan" | "region" | "edit" | "calibrate" | "perspective";
 
 export type ExportFormat = "svg" | "dxf" | "dwg" | "stl";
 export type CalibrationSource = "manual" | "sheet";
@@ -81,6 +86,18 @@ export interface TraceState {
   draftCalibration: DraftCalibration | null;
   rulerLengthMm: number;
 
+  /** Four detected marker centres awaiting perspective-correction review. */
+  pendingPerspective: PerspectiveProposal | null;
+  /** Page corners placed manually in top-left clockwise order. */
+  manualPerspectivePoints: Point[];
+  /** Original source retained so a correction remains reversible. */
+  perspectiveOriginalImageUrl: string | null;
+  /** How the current working image was rectified, or null for the original. */
+  perspectiveCorrection: {
+    source: PerspectiveSource;
+    paper: TemplatePaper;
+  } | null;
+
   region: Rect | null;
   mode: TraceMode;
   processing: boolean;
@@ -114,6 +131,10 @@ export const initialTraceState: TraceState = {
   calibrationSource: null,
   draftCalibration: null,
   rulerLengthMm: 100,
+  pendingPerspective: null,
+  manualPerspectivePoints: [],
+  perspectiveOriginalImageUrl: null,
+  perspectiveCorrection: null,
   region: null,
   mode: "pan",
   processing: false,
@@ -153,11 +174,28 @@ export type TraceAction =
   | { type: "SET_SMOOTHING"; smoothing: number }
   | { type: "SET_MARGIN"; margin: Margin }
   | { type: "SET_CALIBRATION"; calibration: Calibration | null }
-  | { type: "AUTO_CALIBRATION_DETECTED"; calibration: Calibration }
+  | {
+      type: "AUTO_CALIBRATION_DETECTED";
+      calibration: Calibration;
+      perspective?: PerspectiveProposal | null;
+    }
   | { type: "ACCEPT_AUTO_CALIBRATION" }
   | { type: "AUTO_CALIBRATION_ATTEMPTED"; imageUrl: string }
   | { type: "SET_DRAFT_CALIBRATION"; draftCalibration: DraftCalibration | null }
   | { type: "SET_RULER_LENGTH"; rulerLengthMm: number }
+  | { type: "START_PERSPECTIVE_SELECTION" }
+  | { type: "ADD_PERSPECTIVE_POINT"; point: Point }
+  | { type: "SET_PERSPECTIVE_POINTS"; points: Point[] }
+  | { type: "CANCEL_PERSPECTIVE_SELECTION" }
+  | {
+      type: "PERSPECTIVE_APPLIED";
+      imageUrl: string;
+      imageSize: { width: number; height: number };
+      calibration: Calibration;
+      source: PerspectiveSource;
+      paper: TemplatePaper;
+    }
+  | { type: "RESTORE_PERSPECTIVE_SOURCE" }
   | { type: "SET_EXPORT_FORMAT"; exportFormat: ExportFormat }
   | { type: "SET_EXTRUSION_HEIGHT"; extrusionHeight: number };
 
@@ -307,18 +345,22 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
     case "SELECT_RING":
       return { ...state, selection: action.selection };
 
-    case "SET_MODE":
+    case "SET_MODE": {
       // Leaving calibrate mode abandons a half-placed ruler.
+      // Entering either manual measurement mode rejects an automatic proposal.
+      const rejectsAutomatic =
+        action.mode === "calibrate" || action.mode === "perspective";
       return {
         ...state,
         mode: action.mode,
-        // Choosing the manual ruler is an explicit rejection of an automatic
-        // candidate. Removing it here keeps every manual-entry surface (panel
-        // button and canvas toolbar) from leaving the auto ruler overlaid.
+        // Choosing a manual tool is an explicit rejection of the automatic
+        // candidate, including all of its canvas overlays.
         pendingAutoCalibration:
-          action.mode === "calibrate" ? null : state.pendingAutoCalibration,
+          rejectsAutomatic ? null : state.pendingAutoCalibration,
+        pendingPerspective: rejectsAutomatic ? null : state.pendingPerspective,
         draftCalibration: action.mode === "calibrate" ? state.draftCalibration : null,
       };
+    }
 
     case "SET_REGION":
       if (action.region !== null) return { ...state, region: action.region };
@@ -358,6 +400,7 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
         ...state,
         calibration: action.calibration,
         pendingAutoCalibration: null,
+        pendingPerspective: null,
         calibrationSource: action.calibration === null ? null : "manual",
         margin: state.margin ?? DEFAULT_MARGIN_MM,
         draftCalibration: null,
@@ -368,9 +411,11 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
         ...state,
         calibration: null,
         pendingAutoCalibration: action.calibration,
+        pendingPerspective: action.perspective ?? null,
         calibrationSource: null,
         margin: state.margin ?? DEFAULT_MARGIN_MM,
         draftCalibration: null,
+        manualPerspectivePoints: [],
         mode: "pan",
       };
 
@@ -380,6 +425,7 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
         ...state,
         calibration: state.pendingAutoCalibration,
         pendingAutoCalibration: null,
+        pendingPerspective: null,
         calibrationSource: "sheet",
         margin: state.margin ?? DEFAULT_MARGIN_MM,
         draftCalibration: null,
@@ -406,6 +452,83 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
           state.calibrationSource === "manual" && state.calibration
             ? { ...state.calibration, lengthMm: action.rulerLengthMm }
             : state.calibration,
+      };
+
+    case "START_PERSPECTIVE_SELECTION":
+      return {
+        ...state,
+        mode: "perspective",
+        pendingAutoCalibration: null,
+        pendingPerspective: null,
+        manualPerspectivePoints: [],
+        draftCalibration: null,
+      };
+
+    case "ADD_PERSPECTIVE_POINT": {
+      if (state.manualPerspectivePoints.length >= 4) return state;
+      const manualPerspectivePoints = [
+        ...state.manualPerspectivePoints,
+        action.point,
+      ];
+      return {
+        ...state,
+        manualPerspectivePoints,
+        mode: manualPerspectivePoints.length === 4 ? "pan" : "perspective",
+      };
+    }
+
+    case "SET_PERSPECTIVE_POINTS":
+      return action.points.length === 4
+        ? { ...state, manualPerspectivePoints: action.points }
+        : state;
+
+    case "CANCEL_PERSPECTIVE_SELECTION":
+      return {
+        ...state,
+        mode: "pan",
+        manualPerspectivePoints: [],
+      };
+
+    case "PERSPECTIVE_APPLIED":
+      return {
+        ...initialTraceState,
+        imageUrl: action.imageUrl,
+        sourceRevision: state.sourceRevision + 1,
+        fileName: state.fileName,
+        imageSize: action.imageSize,
+        autoCalibrationAttemptedImageUrl: action.imageUrl,
+        sensitivity: state.sensitivity,
+        tolerancePx: state.tolerancePx,
+        smoothing: state.smoothing,
+        margin: state.margin ?? DEFAULT_MARGIN_MM,
+        calibration: action.calibration,
+        calibrationSource: "sheet",
+        rulerLengthMm: state.rulerLengthMm,
+        perspectiveOriginalImageUrl:
+          state.perspectiveOriginalImageUrl ?? state.imageUrl,
+        perspectiveCorrection: { source: action.source, paper: action.paper },
+        mode: "region",
+        exportFormat: state.exportFormat,
+        extrusionHeight: state.extrusionHeight,
+      };
+
+    case "RESTORE_PERSPECTIVE_SOURCE":
+      if (!state.perspectiveOriginalImageUrl) return state;
+      return {
+        ...initialTraceState,
+        imageUrl: state.perspectiveOriginalImageUrl,
+        sourceRevision: state.sourceRevision + 1,
+        fileName: state.fileName,
+        // Do not immediately propose the same correction again. The explicit
+        // Detect sheet action remains available if the user wants another try.
+        autoCalibrationAttemptedImageUrl: state.perspectiveOriginalImageUrl,
+        sensitivity: state.sensitivity,
+        tolerancePx: state.tolerancePx,
+        smoothing: state.smoothing,
+        margin: state.margin,
+        rulerLengthMm: state.rulerLengthMm,
+        exportFormat: state.exportFormat,
+        extrusionHeight: state.extrusionHeight,
       };
 
     case "SET_EXPORT_FORMAT":

--- a/client/src/state/trace-store.tsx
+++ b/client/src/state/trace-store.tsx
@@ -86,7 +86,7 @@ export interface TraceState {
   draftCalibration: DraftCalibration | null;
   rulerLengthMm: number;
 
-  /** Four detected marker centres awaiting perspective-correction review. */
+  /** Detected sheet geometry awaiting perspective-correction review. */
   pendingPerspective: PerspectiveProposal | null;
   /** Page corners placed manually in top-left clockwise order. */
   manualPerspectivePoints: Point[];

--- a/client/src/state/trace-store.tsx
+++ b/client/src/state/trace-store.tsx
@@ -389,7 +389,19 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
       return { ...state, draftCalibration: action.draftCalibration };
 
     case "SET_RULER_LENGTH":
-      return { ...state, rulerLengthMm: action.rulerLengthMm };
+      return {
+        ...state,
+        rulerLengthMm: action.rulerLengthMm,
+        // A completed manual ruler and its reference-length input describe the
+        // same measurement. Keep them coupled so correcting the known length
+        // immediately corrects mm/px without making the user redraw the line.
+        // Sheet calibration has an independently detected physical scale, so
+        // this preference must not overwrite it.
+        calibration:
+          state.calibrationSource === "manual" && state.calibration
+            ? { ...state.calibration, lengthMm: action.rulerLengthMm }
+            : state.calibration,
+      };
 
     case "SET_EXPORT_FORMAT":
       return { ...state, exportFormat: action.exportFormat };

--- a/client/src/state/trace-store.tsx
+++ b/client/src/state/trace-store.tsx
@@ -312,6 +312,11 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
       return {
         ...state,
         mode: action.mode,
+        // Choosing the manual ruler is an explicit rejection of an automatic
+        // candidate. Removing it here keeps every manual-entry surface (panel
+        // button and canvas toolbar) from leaving the auto ruler overlaid.
+        pendingAutoCalibration:
+          action.mode === "calibrate" ? null : state.pendingAutoCalibration,
         draftCalibration: action.mode === "calibrate" ? state.draftCalibration : null,
       };
 

--- a/docs/gridfinity-plan.md
+++ b/docs/gridfinity-plan.md
@@ -80,7 +80,11 @@ printable calibration sheet sets the scale automatically on image load
 pair disagreement), with a manual "Detect markers" button and a hint toast
 when a non-Pocketry marker sheet (Original ArUco / 5×5 / 6×6 / 7×7 /
 AprilTag) is recognised instead. Detection reads a 1600px frame — small
-markers blur out at the 800×600 working resolution.
+markers blur out at the 800×600 working resolution. A4 and US Letter now use
+distinct marker IDs so paper size is inferred automatically. Perspective
+correction uses subpixel corner refinement and an overdetermined homography
+across all 16 marker corners; the four-page-corner manual fallback remains
+available when markers cannot be used.
 
 G3 delivered the trace → bin integration: "Add to bin" in the trace panel
 (hard-gated on calibration — the uncalibrated-scale footgun stops at the

--- a/docs/open-source-review.md
+++ b/docs/open-source-review.md
@@ -17,7 +17,7 @@ history of files that appeared likely to have been copied or generated.
 
 | Project | How Pocketry uses it | Licence | Attribution location |
 |---|---|---|---|
-| OpenCV 4.11.0 | Bundled OpenCV.js and four ported ArUco marker patterns | Apache-2.0 | `NOTICE`; source header in `client/src/lib/calibrate/aruco-4x4.ts` |
+| OpenCV 4.11.0 | Bundled OpenCV.js and eight ported ArUco marker patterns | Apache-2.0 | `NOTICE`; source header in `client/src/lib/calibrate/aruco-4x4.ts` |
 | manifold-3d 3.5.1 | Geometry API and redistributed WASM binary | Apache-2.0 | `NOTICE` |
 | gridfinity-rebuilt-openscad | Geometry and constants ported from commit `910e22d8607fd7f5f51ad5e5cbc5287a76810bfd` | MIT | `NOTICE`; `client/src/lib/gridfinity/UPSTREAM.md`; port headers |
 | Gridfinity | Upstream basis acknowledged by Gridfinity Rebuilt | MIT | `NOTICE` |

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "generate:calibration-templates": "tsx scripts/generate-calibration-templates.ts",
     "export:bin": "tsx scripts/export-bin.ts",
     "db:push": "drizzle-kit push"
   },

--- a/scripts/generate-calibration-templates.ts
+++ b/scripts/generate-calibration-templates.ts
@@ -1,0 +1,14 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { calibrationTemplatePdf } from "../client/src/lib/calibrate/template-pdf";
+
+const outputDirectory = resolve("output/pdf");
+await mkdir(outputDirectory, { recursive: true });
+
+for (const paper of ["a4", "letter"] as const) {
+  await writeFile(
+    resolve(outputDirectory, `pocketry-calibration-${paper}.pdf`),
+    calibrationTemplatePdf(paper),
+  );
+}

--- a/shared/geometry/scale.ts
+++ b/shared/geometry/scale.ts
@@ -13,7 +13,10 @@ export interface Calibration {
   lengthMm: number;
 }
 
-/** A calibration still being placed — only the start point is known. */
+/**
+ * A calibration still being placed. The first click sets the start; optional
+ * end coordinates track the pointer until the second click commits it.
+ */
 export type DraftCalibration = Partial<Calibration>;
 
 /** Pixel distance between the two calibration points. */


### PR DESCRIPTION
Summary:
- Keep the manual scale ruler synchronized with its reference length, use precise X endpoints, and retain its editable length indicator.
- Hide accepted automatic sheet rulers before tool-region selection while preserving manual rulers.
- Rectify calibration-sheet photos with subpixel marker corners and an overdetermined 16-point homography; retain the manual four-corner fallback.
- Give A4 and US Letter distinct ArUco marker families so Pocketry identifies the paper automatically.
- Download print-ready PDF templates directly from the Scale panel and Help instructions.
- Keep correction reversible, clear stale trace geometry after a warp, and document the remaining thick-tool parallax limitation.
- Expand the About page with ToolTrace.ai, Systemax DIY, Tracefinity, Gridfinity Rebase, and GridFlock after a Reddit and YouTube review.

PDF verification:
- A4 MediaBox/CropBox: 210 x 297 mm.
- US Letter MediaBox/CropBox: 215.9 x 279.4 mm.
- Both: four 30 mm markers, 150 x 200 mm center spacing, 250 mm diagonal, and a 100 mm check bar.
- PrintScaling is disabled; the bar is 8 mm from the edge and footer text has 13.28 mm measured clearance.
- The A4 header uses the extra page height: its instruction line has a measured 10.78 mm visible gap above the markers and the title retains an 11.04 mm top margin.
- Both pages were independently parsed and rendered for visual inspection.

Verification:
- npm run check passed.
- npm test passed: 67 files and 804 tests.
- npm run build passed.
- The local Help dialog and PDF links were inspected at http://localhost:5001/about.