### PR TITLE
Clarify complementary Gridfinity tools

### DIFF
--- a/client/src/app.smoke.test.tsx
+++ b/client/src/app.smoke.test.tsx
@@ -129,6 +129,11 @@ describe("App", () => {
     expect(window.location.pathname).toBe("/about");
     expect(container.textContent).toContain("About Pocketry");
     expect(container.textContent).toContain("AGPL-3.0-only");
+    const openSourceStatement = container.querySelector<HTMLAnchorElement>(
+      'a[aria-label="Pocketry is fully open source under AGPL-3.0-only"]',
+    );
+    expect(openSourceStatement?.textContent).toContain("Fully open source under");
+    expect(openSourceStatement?.getAttribute("href")).toBe("/LICENSE.txt");
     expect(container.textContent).toContain("OpenCV/OpenCV.js");
     expect(container.textContent).toContain("Gridfinity Rebuilt OpenSCAD");
     expect(container.textContent).toContain("Gridfinity Extended");

--- a/client/src/app.smoke.test.tsx
+++ b/client/src/app.smoke.test.tsx
@@ -157,6 +157,15 @@ describe("App", () => {
     expect(closedSourceTools?.textContent).toContain("Perplexing Labs");
     expect(closedSourceTools?.textContent).toContain("ToolTrace.ai");
     expect(closedSourceTools?.textContent).toContain("Systemax DIY");
+    for (const href of [
+      "https://www.tooltrace.ai",
+      "https://www.systemax.no/diy",
+    ]) {
+      const commercialCard = container
+        .querySelector<HTMLAnchorElement>(`a[href="${href}"]`)
+        ?.closest(".rounded-lg");
+      expect(commercialCard?.textContent).toContain("Commercial service");
+    }
     expect(closedSourceTools?.textContent).not.toContain("Tracefinity");
     expect(closedSourceTools?.textContent).toContain(
       "not presented as open-source projects",

--- a/client/src/app.smoke.test.tsx
+++ b/client/src/app.smoke.test.tsx
@@ -140,7 +140,23 @@ describe("App", () => {
     expect(container.textContent).toContain("Gridfinity Rebase");
     expect(container.textContent).toContain("GridFlock");
     expect(container.textContent).toContain(
-      "complement Pocketry or provide alternatives",
+      "complement Pocketry or provide",
+    );
+    const openSourceProjects = container.querySelector<HTMLElement>(
+      '[aria-labelledby="open-source-projects-heading"]',
+    );
+    const closedSourceTools = container.querySelector<HTMLElement>(
+      '[aria-labelledby="closed-source-projects-heading"]',
+    );
+    expect(openSourceProjects?.textContent).toContain("Tracefinity");
+    expect(openSourceProjects?.textContent).toContain("GridFlock");
+    expect(openSourceProjects?.textContent).not.toContain("ToolTrace.ai");
+    expect(openSourceProjects?.textContent).not.toContain("Systemax DIY");
+    expect(closedSourceTools?.textContent).toContain("ToolTrace.ai");
+    expect(closedSourceTools?.textContent).toContain("Systemax DIY");
+    expect(closedSourceTools?.textContent).not.toContain("Tracefinity");
+    expect(closedSourceTools?.textContent).toContain(
+      "not presented as open-source projects",
     );
     expect(
       container.querySelector<HTMLAnchorElement>('a[href="/LICENSE.txt"]'),

--- a/client/src/app.smoke.test.tsx
+++ b/client/src/app.smoke.test.tsx
@@ -135,6 +135,7 @@ describe("App", () => {
     expect(container.textContent).toContain("Gridfinity Layout Tool");
     expect(container.textContent).toContain("Outline App");
     expect(container.textContent).toContain("Tracefinity");
+    expect(container.textContent).toContain("Perplexing Labs Gridfinity Generator");
     expect(container.textContent).toContain("ToolTrace.ai");
     expect(container.textContent).toContain("Systemax DIY");
     expect(container.textContent).toContain("Gridfinity Rebase");
@@ -150,8 +151,10 @@ describe("App", () => {
     );
     expect(openSourceProjects?.textContent).toContain("Tracefinity");
     expect(openSourceProjects?.textContent).toContain("GridFlock");
+    expect(openSourceProjects?.textContent).not.toContain("Perplexing Labs");
     expect(openSourceProjects?.textContent).not.toContain("ToolTrace.ai");
     expect(openSourceProjects?.textContent).not.toContain("Systemax DIY");
+    expect(closedSourceTools?.textContent).toContain("Perplexing Labs");
     expect(closedSourceTools?.textContent).toContain("ToolTrace.ai");
     expect(closedSourceTools?.textContent).toContain("Systemax DIY");
     expect(closedSourceTools?.textContent).not.toContain("Tracefinity");

--- a/client/src/app.smoke.test.tsx
+++ b/client/src/app.smoke.test.tsx
@@ -161,6 +161,21 @@ describe("App", () => {
     expect(closedSourceTools?.textContent).toContain(
       "not presented as open-source projects",
     );
+    expect(container.textContent).not.toContain("Visit open-source project");
+    expect(container.textContent).not.toContain("Visit service");
+    for (const [name, href] of [
+      ["GridFlock", "https://github.com/yawkat/GridFlock"],
+      [
+        "Perplexing Labs Gridfinity Generator",
+        "https://gridfinity.perplexinglabs.com/",
+      ],
+    ] as const) {
+      const titleLink = container.querySelector<HTMLAnchorElement>(
+        `h3 > a[href="${href}"]`,
+      );
+      expect(titleLink?.textContent).toContain(name);
+      expect(titleLink?.target).toBe("_blank");
+    }
     expect(
       container.querySelector<HTMLAnchorElement>('a[href="/LICENSE.txt"]'),
     ).not.toBeNull();

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -94,38 +94,36 @@ const CLOSED_OR_FREEMIUM_TOOLS: readonly RelatedProject[] = [
   },
 ] as const;
 
-function ProjectGrid({
-  projects,
-  linkLabel,
-}: {
-  projects: readonly RelatedProject[];
-  linkLabel: string;
-}): JSX.Element {
+function ProjectGrid({ projects }: { projects: readonly RelatedProject[] }): JSX.Element {
   return (
     <div className="grid gap-4 sm:grid-cols-2">
       {projects.map((project) => (
         <Card key={project.url} className="flex flex-col">
           <CardHeader className="pb-3">
             <div className="flex items-start justify-between gap-3">
-              <CardTitle className="text-lg leading-6">{project.name}</CardTitle>
+              <CardTitle className="text-lg leading-6">
+                <a
+                  href={project.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group inline-flex items-start gap-1.5 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <span>{project.name}</span>
+                  <ExternalLink
+                    className="mt-1 h-3.5 w-3.5 shrink-0 text-muted-foreground transition-colors group-hover:text-primary"
+                    aria-hidden
+                  />
+                </a>
+              </CardTitle>
               <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
                 {project.badge}
               </span>
             </div>
           </CardHeader>
-          <CardContent className="flex flex-1 flex-col gap-4">
-            <p className="flex-1 text-sm leading-6 text-muted-foreground">
+          <CardContent>
+            <p className="text-sm leading-6 text-muted-foreground">
               {project.description}
             </p>
-            <a
-              href={project.url}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex w-fit items-center gap-1.5 text-sm font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            >
-              {linkLabel}
-              <ExternalLink className="h-3.5 w-3.5" aria-hidden />
-            </a>
           </CardContent>
         </Card>
       ))}
@@ -240,10 +238,7 @@ export default function About(): JSX.Element {
                 project.
               </p>
             </div>
-            <ProjectGrid
-              projects={OPEN_SOURCE_PROJECTS}
-              linkLabel="Visit open-source project"
-            />
+            <ProjectGrid projects={OPEN_SOURCE_PROJECTS} />
           </section>
 
           <section
@@ -262,10 +257,7 @@ export default function About(): JSX.Element {
                 but they are not presented as open-source projects.
               </p>
             </div>
-            <ProjectGrid
-              projects={CLOSED_OR_FREEMIUM_TOOLS}
-              linkLabel="Visit service"
-            />
+            <ProjectGrid projects={CLOSED_OR_FREEMIUM_TOOLS} />
           </section>
         </section>
       </div>

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -141,6 +141,17 @@ export default function About(): JSX.Element {
             <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
               About Pocketry
             </h1>
+            <a
+              href="/LICENSE.txt"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Pocketry is fully open source under AGPL-3.0-only"
+              className="inline-flex w-fit flex-wrap items-center gap-x-2 gap-y-1 rounded-full border border-primary/20 bg-primary/5 px-3 py-1.5 text-sm font-semibold text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <Github className="h-4 w-4" aria-hidden />
+              Fully open source under
+              <span className="font-mono text-xs">AGPL-3.0-only</span>
+            </a>
             <p className="max-w-3xl text-base leading-7 text-muted-foreground">
               Pocketry turns tool photos into editable outlines, fit-check files,
               shadow-board layouts, and printable Gridfinity bins. Image processing,

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -82,7 +82,7 @@ const CLOSED_OR_FREEMIUM_TOOLS: readonly RelatedProject[] = [
     name: "ToolTrace.ai",
     description:
       "A hosted photo-to-outline service for making custom Gridfinity trays, foam inserts, and shadow-board layouts.",
-    badge: "Hosted service",
+    badge: "Commercial service",
     url: "https://www.tooltrace.ai",
   },
   {

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -72,6 +72,13 @@ const OPEN_SOURCE_PROJECTS: readonly RelatedProject[] = [
 
 const CLOSED_OR_FREEMIUM_TOOLS: readonly RelatedProject[] = [
   {
+    name: "Perplexing Labs Gridfinity Generator",
+    description:
+      "A hosted interface for configuring bins, baseplates, lids, labels, and other models from several Gridfinity projects.",
+    badge: "Hosted generator",
+    url: "https://gridfinity.perplexinglabs.com/",
+  },
+  {
     name: "ToolTrace.ai",
     description:
       "A hosted photo-to-outline service for making custom Gridfinity trays, foam inserts, and shadow-board layouts.",

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -11,7 +11,14 @@ import {
 
 const SOURCE_URL = "https://github.com/wcscr/pocketry";
 
-const RELATED_PROJECTS = [
+interface RelatedProject {
+  name: string;
+  description: string;
+  badge: string;
+  url: string;
+}
+
+const OPEN_SOURCE_PROJECTS: readonly RelatedProject[] = [
   {
     name: "Gridfinity Rebuilt OpenSCAD",
     description:
@@ -48,20 +55,6 @@ const RELATED_PROJECTS = [
     url: "https://github.com/tracefinity/tracefinity",
   },
   {
-    name: "ToolTrace.ai",
-    description:
-      "A hosted photo-to-outline service for making custom Gridfinity trays, foam inserts, and shadow-board layouts.",
-    badge: "Web service",
-    url: "https://www.tooltrace.ai",
-  },
-  {
-    name: "Systemax DIY",
-    description:
-      "Photograph tools, build a reusable tool library and drawer layout, then order the resulting Gridfinity organizers or export production files.",
-    badge: "Design service",
-    url: "https://www.systemax.no/diy",
-  },
-  {
     name: "Gridfinity Rebase",
     description:
       "Replace the bases in downloaded Gridfinity STLs with your preferred magnet-hole and attachment setup directly in the browser.",
@@ -76,6 +69,62 @@ const RELATED_PROJECTS = [
     url: "https://github.com/yawkat/GridFlock",
   },
 ] as const;
+
+const CLOSED_OR_FREEMIUM_TOOLS: readonly RelatedProject[] = [
+  {
+    name: "ToolTrace.ai",
+    description:
+      "A hosted photo-to-outline service for making custom Gridfinity trays, foam inserts, and shadow-board layouts.",
+    badge: "Hosted service",
+    url: "https://www.tooltrace.ai",
+  },
+  {
+    name: "Systemax DIY",
+    description:
+      "Photograph tools, build a reusable tool library and drawer layout, then order the resulting Gridfinity organizers or export production files.",
+    badge: "Commercial service",
+    url: "https://www.systemax.no/diy",
+  },
+] as const;
+
+function ProjectGrid({
+  projects,
+  linkLabel,
+}: {
+  projects: readonly RelatedProject[];
+  linkLabel: string;
+}): JSX.Element {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {projects.map((project) => (
+        <Card key={project.url} className="flex flex-col">
+          <CardHeader className="pb-3">
+            <div className="flex items-start justify-between gap-3">
+              <CardTitle className="text-lg leading-6">{project.name}</CardTitle>
+              <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                {project.badge}
+              </span>
+            </div>
+          </CardHeader>
+          <CardContent className="flex flex-1 flex-col gap-4">
+            <p className="flex-1 text-sm leading-6 text-muted-foreground">
+              {project.description}
+            </p>
+            <a
+              href={project.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex w-fit items-center gap-1.5 text-sm font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              {linkLabel}
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+            </a>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
 
 /** Project background, legal notices, and links to related Gridfinity tools. */
 export default function About(): JSX.Element {
@@ -154,51 +203,64 @@ export default function About(): JSX.Element {
           </Card>
         </section>
 
-        <section className="space-y-4" aria-labelledby="related-projects-heading">
+        <section className="space-y-7" aria-labelledby="related-projects-heading">
           <div className="space-y-1">
             <h2
               id="related-projects-heading"
               className="text-2xl font-semibold tracking-tight"
             >
-              More Gridfinity tools
+              Complementary and alternative Gridfinity tools
             </h2>
             <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
-              These independent projects complement Pocketry or provide
-              alternatives to its photo-to-pocket workflow, including configurable
-              bins, baseplates, drawer planning, and alternate outline tools.
+              These projects and services complement Pocketry or provide
+              alternatives to its photo-to-pocket workflow. They are grouped by
+              whether their source is available under an open-source license.
             </p>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-2">
-            {RELATED_PROJECTS.map((project) => (
-              <Card key={project.url} className="flex flex-col">
-                <CardHeader className="pb-3">
-                  <div className="flex items-start justify-between gap-3">
-                    <CardTitle className="text-lg leading-6">
-                      {project.name}
-                    </CardTitle>
-                    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                      {project.badge}
-                    </span>
-                  </div>
-                </CardHeader>
-                <CardContent className="flex flex-1 flex-col gap-4">
-                  <p className="flex-1 text-sm leading-6 text-muted-foreground">
-                    {project.description}
-                  </p>
-                  <a
-                    href={project.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="inline-flex w-fit items-center gap-1.5 text-sm font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                  >
-                    Visit project
-                    <ExternalLink className="h-3.5 w-3.5" aria-hidden />
-                  </a>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
+          <section
+            className="space-y-3"
+            aria-labelledby="open-source-projects-heading"
+          >
+            <div>
+              <h3
+                id="open-source-projects-heading"
+                className="text-xl font-semibold tracking-tight"
+              >
+                Open-source projects
+              </h3>
+              <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
+                Public source code is available under the license shown on each
+                project.
+              </p>
+            </div>
+            <ProjectGrid
+              projects={OPEN_SOURCE_PROJECTS}
+              linkLabel="Visit open-source project"
+            />
+          </section>
+
+          <section
+            className="space-y-3 border-t pt-6"
+            aria-labelledby="closed-source-projects-heading"
+          >
+            <div>
+              <h3
+                id="closed-source-projects-heading"
+                className="text-xl font-semibold tracking-tight"
+              >
+                Closed-source and freemium tools
+              </h3>
+              <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
+                These hosted or commercial services may be useful alternatives,
+                but they are not presented as open-source projects.
+              </p>
+            </div>
+            <ProjectGrid
+              projects={CLOSED_OR_FREEMIUM_TOOLS}
+              linkLabel="Visit service"
+            />
+          </section>
         </section>
       </div>
     </main>

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -133,7 +133,6 @@ export default function About(): JSX.Element {
       <div className="mx-auto max-w-5xl space-y-8 px-4 py-8 sm:px-6 lg:py-12">
         <section className="space-y-4">
           <div className="space-y-2">
-            <p className="text-sm font-medium text-primary">Open-source toolmaking</p>
             <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
               About Pocketry
             </h1>


### PR DESCRIPTION
Summary:
- Emphasize near the About heading that Pocketry is fully open source under AGPL-3.0-only, with a direct link to the shipped license.
- Rename the About-page directory to "Complementary and alternative Gridfinity tools".
- Separate licensed open-source projects from hosted, commercial, and freemium alternatives.
- Add Perplexing Labs Gridfinity Generator, ToolTrace.ai, Systemax DIY, Tracefinity, Gridfinity Rebase, and GridFlock.
- Make each project title the outbound link, place its external-link marker alongside the title, and remove repeated footer calls to action.
- Remove the misleading "Open-source toolmaking" tagline from Pocketry's own About header.
- Add smoke coverage for the licensing statement, project classification, and title-link pattern.

Verification:
- npm run check passed.
- npm test passed: 67 files and 804 tests.
- npm run build passed.
- The rendered About page was inspected locally at a narrow viewport; the license badge is prominent, the cards are compact, title links are present, and repeated footer links are absent.