### PR TITLE
Preserve trace edits and default bins to rectangles

### DIFF
--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -70,7 +70,7 @@ import {
 } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
-import { fitFootprintToPlacements } from "@/lib/gridfinity/autoplace";
+import { fitRectangularBinToPlacements } from "@/lib/gridfinity/autoplace";
 import { occupiedCellCount } from "@shared/gridfinity/footprint";
 import {
   binDimensionsMm,
@@ -337,12 +337,16 @@ export function BinControlsPanel({
     nextCutouts: typeof cutouts,
     historyLabel = "Fit bin to contents",
   ) => {
-    const fitted = fitFootprintToPlacements(
+    const fitted = fitRectangularBinToPlacements(
       nextCutouts,
       shapesById,
       spec,
     );
-    dispatch({ type: "REPLACE_LAYOUT", ...fitted, historyLabel });
+    dispatch({
+      type: "REPLACE_LAYOUT",
+      ...fitted,
+      historyLabel,
+    });
   };
 
   return (

--- a/client/src/components/help/help-dialog.tsx
+++ b/client/src/components/help/help-dialog.tsx
@@ -124,11 +124,11 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
                 and is most accurate in the 2D Layout view.
               </li>
               <li>
-                <strong>Fit bin to contents</strong> can shrink or grow the bin
-                around the current tools and trim unused grid cells. Use
-                <strong> Edit footprint</strong> in Layout to add or remove cells
-                manually; the footprint must remain one connected piece without holes.
-                Removing a tool offers the same fitting choice.
+                <strong>Fit bin to contents</strong> shrinks or grows a rectangular
+                bin around the current tools. Use <strong>Edit footprint</strong> in
+                Layout only when you intentionally want an irregular bin; custom
+                footprints must remain one connected piece without holes. Removing a
+                tool offers the same rectangular fitting choice.
               </li>
               <li>
                 Label tabs can attach to any highlighted straight footprint edge.

--- a/client/src/components/trace/trace-controls-panel.test.tsx
+++ b/client/src/components/trace/trace-controls-panel.test.tsx
@@ -421,6 +421,22 @@ describe("TraceControlsPanel guided workflow", () => {
         ?.textContent,
     ).toContain("Adjust Sensitivity and Detail to fine-tune the contour");
     expect(
+      host.querySelector('[data-testid="contour-editing-guidance"]')
+        ?.textContent,
+    ).toContain(
+      "Edit the contour shape: select a shape, then move, add, or delete its detected vertices",
+    );
+    expect(
+      host.querySelector('[data-testid="contour-editing-guidance"]')
+        ?.className,
+    ).toContain("text-base font-bold");
+    expect(
+      host.querySelector('[data-testid="detection-tuning-guidance"]')
+        ?.textContent,
+    ).toContain(
+      "Drag a vertex to move it, click to add one, or right-click a vertex to delete it",
+    );
+    expect(
       host.querySelector('[data-testid="detection-tuning-guidance"]')
         ?.textContent,
     ).toContain(

--- a/client/src/components/trace/trace-controls-panel.tsx
+++ b/client/src/components/trace/trace-controls-panel.tsx
@@ -57,8 +57,12 @@ import { downloadCalibrationTemplate } from "@/lib/calibrate/download-template";
 import type { TemplatePaper } from "@/lib/calibrate/template";
 import { describeScale, exportScale } from "@/lib/export/scale";
 import { normalizeTracedShape } from "@/lib/gridfinity/traced-shape";
-import { MARGIN_MM_OPTIONS } from "@/lib/image-processor";
+import {
+  adjustOutlineMargin,
+  MARGIN_MM_OPTIONS,
+} from "@/lib/image-processor";
 import { cn } from "@/lib/utils";
+import { useToast } from "@/hooks/use-toast";
 import { useShapeLibrary } from "@/state/shape-library";
 import { useTrace, type ExportFormat } from "@/state/trace-store";
 
@@ -132,6 +136,7 @@ export function TraceControlsPanel({
     extrusionHeight,
     processing,
   } = store;
+  const { toast } = useToast();
 
   const scale = exportScale(calibration, imageSize.height);
   const displayedScale = exportScale(
@@ -201,6 +206,60 @@ export function TraceControlsPanel({
   const focusWhenReady = useRef<
     "scale" | "auto" | "length" | "region" | "detection" | null
   >(null);
+  const marginRequest = useRef(0);
+  const latestMarginGeometry = useRef({ outline, margin, calibration });
+  latestMarginGeometry.current = { outline, margin, calibration };
+
+  const handleMarginChange = (nextMargin: number): void => {
+    const request = ++marginRequest.current;
+
+    void (async () => {
+      while (request === marginRequest.current) {
+        const current = latestMarginGeometry.current;
+        if (current.margin === nextMargin) return;
+        if (current.outline.length === 0 || !current.calibration) {
+          dispatch({ type: "SET_MARGIN", margin: nextMargin });
+          return;
+        }
+
+        let adjusted;
+        try {
+          adjusted = await adjustOutlineMargin(
+            current.outline,
+            current.margin,
+            nextMargin,
+            current.calibration,
+          );
+        } catch (cause) {
+          if (request !== marginRequest.current) return;
+          toast({
+            title: "Could not adjust contour margin",
+            description: cause instanceof Error ? cause.message : String(cause),
+            variant: "destructive",
+          });
+          return;
+        }
+
+        if (request !== marginRequest.current) return;
+        const latest = latestMarginGeometry.current;
+        if (
+          latest.outline !== current.outline ||
+          latest.margin !== current.margin ||
+          latest.calibration !== current.calibration
+        ) {
+          // A vertex edit or scale change landed while the offset was running.
+          // Retry against that latest edited contour rather than overwriting it.
+          continue;
+        }
+        dispatch({
+          type: "MARGIN_COMMITTED",
+          outline: adjusted,
+          margin: nextMargin,
+        });
+        return;
+      }
+    })();
+  };
 
   // A new source starts a new guided pass through the controls. Remounting the
   // section body resets every uncontrolled collapsible; once decoding finishes,
@@ -869,11 +928,21 @@ export function TraceControlsPanel({
             className="flex gap-2 rounded-md border border-rose-500/60 bg-rose-500/10 p-3 text-rose-900 ring-2 ring-rose-500/20 dark:text-rose-100"
           >
             <ScanSearch className="mt-0.5 h-4 w-4 shrink-0" />
-            <p className="text-xs leading-relaxed">
-              Adjust <strong>Sensitivity</strong> and <strong>Detail</strong> to
-              fine-tune the contour. Remove any arrant holes / contours by
-              clicking the trash can icon below.
-            </p>
+            <div className="space-y-2">
+              <p
+                data-testid="contour-editing-guidance"
+                className="text-base font-bold leading-snug"
+              >
+                Edit the contour shape: select a shape, then move, add, or delete
+                its detected vertices.
+              </p>
+              <p className="text-xs leading-relaxed">
+                Drag a vertex to move it, click to add one, or right-click a vertex
+                to delete it. Adjust <strong>Sensitivity</strong> and{" "}
+                <strong>Detail</strong> to fine-tune the contour. Remove any arrant
+                holes / contours by clicking the trash can icon below.
+              </p>
+            </div>
           </div>
 
           {/*
@@ -926,9 +995,7 @@ export function TraceControlsPanel({
             </Label>
             <Select
               value={scale.mmPerPx && margin !== null ? String(margin) : undefined}
-              onValueChange={(value) =>
-                dispatch({ type: "SET_MARGIN", margin: Number(value) })
-              }
+              onValueChange={(value) => handleMarginChange(Number(value))}
               disabled={!scale.mmPerPx}
             >
               <SelectTrigger id="margin" className="w-full">
@@ -945,8 +1012,8 @@ export function TraceControlsPanel({
               </SelectContent>
             </Select>
             <p className="text-[11px] text-muted-foreground">
-              Expands the traced contour before it goes to Bin. Defaults to 1.5
-              mm.
+              Offsets the current edited contour without re-detecting it. Margin
+              changes are saved in Edit history. Defaults to 1.5 mm.
             </p>
           </div>
 

--- a/client/src/components/trace/use-outline-refinement.test.tsx
+++ b/client/src/components/trace/use-outline-refinement.test.tsx
@@ -13,6 +13,7 @@ import {
 
 import {
   useOutlineRefinement,
+  type OutlineOffsetter,
   type OutlineRefiner,
 } from "./use-outline-refinement";
 
@@ -28,7 +29,10 @@ const OUTLINE: Outline = [
   },
 ];
 
-function mountHook(refiner: OutlineRefiner): {
+function mountHook(
+  refiner: OutlineRefiner,
+  offsetter: OutlineOffsetter = async (outline) => outline,
+): {
   store: () => TraceStore;
   unmount: () => void;
 } {
@@ -40,7 +44,7 @@ function mountHook(refiner: OutlineRefiner): {
 
   function Probe() {
     latest = useTrace();
-    useOutlineRefinement(refiner);
+    useOutlineRefinement(refiner, offsetter);
     return null;
   }
 
@@ -66,23 +70,22 @@ function mountHook(refiner: OutlineRefiner): {
 }
 
 describe("useOutlineRefinement", () => {
-  it("recomputes a displayed physical margin when reference length changes", async () => {
-    const refiner = vi.fn<OutlineRefiner>(async () => [
-      { ...OUTLINE[0], holes: [[{ x: 2, y: 2 }, { x: 3, y: 2 }, { x: 2, y: 3 }]] },
-    ]);
-    const mounted = mountHook(refiner);
-
-    React.act(() => {
-      mounted.store().dispatch({
-        type: "DETECTED",
-        imageUrl: null,
-        outline: OUTLINE,
-        rawOutline: OUTLINE,
-        svg: "<svg/>",
-        region: null,
-      });
-    });
-    await React.act(async () => Promise.resolve());
+  it("recomputes scale-dependent margin from the edited contour", async () => {
+    const rawWithDeletedHole: Outline = [
+      {
+        ...OUTLINE[0],
+        holes: [[{ x: 2, y: 2 }, { x: 3, y: 2 }, { x: 2, y: 3 }]],
+      },
+    ];
+    const edited: Outline = [
+      { ...OUTLINE[0], outer: [...OUTLINE[0].outer, { x: -2, y: 5 }] },
+    ];
+    const adjusted: Outline = [
+      { ...edited[0], outer: [...edited[0].outer, { x: -3, y: 5 }] },
+    ];
+    const refiner = vi.fn<OutlineRefiner>(async () => rawWithDeletedHole);
+    const offsetter = vi.fn<OutlineOffsetter>(async () => adjusted);
+    const mounted = mountHook(refiner, offsetter);
 
     React.act(() => {
       mounted.store().dispatch({
@@ -98,37 +101,43 @@ describe("useOutlineRefinement", () => {
     });
     await React.act(async () => Promise.resolve());
 
-    expect(refiner).toHaveBeenCalledOnce();
-    expect(refiner).toHaveBeenLastCalledWith(
-      OUTLINE,
-      expect.objectContaining({
-        margin: 1.5,
-        calibration: expect.objectContaining({ lengthMm: 50 }),
-      }),
-    );
+    React.act(() => {
+      mounted.store().dispatch({
+        type: "DETECTED",
+        imageUrl: null,
+        outline: OUTLINE,
+        rawOutline: rawWithDeletedHole,
+        svg: "<svg/>",
+        region: null,
+      });
+      mounted.store().dispatch({
+        type: "OUTLINE_COMMITTED",
+        outline: edited,
+        label: "Delete detected hole and move contour node",
+      });
+    });
+    await React.act(async () => Promise.resolve());
 
     await React.act(async () => {
       mounted.store().dispatch({ type: "SET_RULER_LENGTH", rulerLengthMm: 100 });
       await Promise.resolve();
     });
 
-    expect(refiner).toHaveBeenCalledTimes(2);
-    expect(refiner).toHaveBeenLastCalledWith(
-      OUTLINE,
-      expect.objectContaining({
-        margin: 1.5,
-        calibration: expect.objectContaining({ lengthMm: 100 }),
-      }),
-    );
+    expect(refiner).not.toHaveBeenCalled();
+    expect(offsetter).toHaveBeenCalledOnce();
+    expect(offsetter).toHaveBeenCalledWith(edited, -1.5);
+    expect(mounted.store().outline).toEqual(adjusted);
+    expect(mounted.store().outline[0].holes).toEqual([]);
     mounted.unmount();
   });
 
-  it("still applies an explicit contour-setting change using the current scale", async () => {
+  it("does not route a margin selection through raw-outline refinement", async () => {
     const refined: Outline = [
       { ...OUTLINE[0], outer: [...OUTLINE[0].outer, { x: -1, y: 5 }] },
     ];
     const refiner = vi.fn<OutlineRefiner>(async () => refined);
-    const mounted = mountHook(refiner);
+    const offsetter = vi.fn<OutlineOffsetter>(async () => refined);
+    const mounted = mountHook(refiner, offsetter);
     const calibration = {
       startX: 0,
       startY: 0,
@@ -136,6 +145,11 @@ describe("useOutlineRefinement", () => {
       endY: 0,
       lengthMm: 50,
     };
+
+    React.act(() => {
+      mounted.store().dispatch({ type: "SET_CALIBRATION", calibration });
+    });
+    await React.act(async () => Promise.resolve());
 
     React.act(() => {
       mounted.store().dispatch({
@@ -146,22 +160,20 @@ describe("useOutlineRefinement", () => {
         svg: "<svg/>",
         region: null,
       });
-      mounted.store().dispatch({ type: "SET_CALIBRATION", calibration });
     });
     await React.act(async () => Promise.resolve());
     refiner.mockClear();
+    offsetter.mockClear();
 
     await React.act(async () => {
       mounted.store().dispatch({ type: "SET_MARGIN", margin: 2 });
       await Promise.resolve();
     });
 
-    expect(refiner).toHaveBeenCalledOnce();
-    expect(refiner).toHaveBeenCalledWith(
-      OUTLINE,
-      expect.objectContaining({ calibration, margin: 2 }),
-    );
-    expect(mounted.store().outline).toEqual(refined);
+    expect(refiner).not.toHaveBeenCalled();
+    expect(offsetter).not.toHaveBeenCalled();
+    expect(mounted.store().outline).toEqual(OUTLINE);
+    expect(mounted.store().margin).toBe(2);
     mounted.unmount();
   });
 });

--- a/client/src/components/trace/use-outline-refinement.ts
+++ b/client/src/components/trace/use-outline-refinement.ts
@@ -7,9 +7,11 @@ import {
 import type { Outline } from "@shared/geometry/types";
 
 import {
+  marginToPixels,
   reprocessOutline,
   type Margin,
 } from "@/lib/image-processor";
+import { offsetOutline } from "@/lib/geometry/offset";
 import { useTrace } from "@/state/trace-store";
 
 export type OutlineRefiner = (
@@ -21,6 +23,11 @@ export type OutlineRefiner = (
   },
 ) => Promise<Outline>;
 
+export type OutlineOffsetter = (
+  outline: Outline,
+  deltaPx: number,
+) => Promise<Outline>;
+
 /**
  * Re-derives the displayed outline when an outline-shaping control or its
  * physical scale changes. A margin is stored in millimetres, so changing
@@ -28,8 +35,10 @@ export type OutlineRefiner = (
  */
 export function useOutlineRefinement(
   refineOutline: OutlineRefiner = reprocessOutline,
+  offsetEditedOutline: OutlineOffsetter = offsetOutline,
 ): void {
   const {
+    outline,
     rawOutline,
     tolerancePx,
     smoothing,
@@ -37,28 +46,47 @@ export function useOutlineRefinement(
     calibration,
     dispatch,
   } = useTrace();
-  const refinementSignature = JSON.stringify([
-    tolerancePx,
-    smoothing,
-    margin,
-    margin !== null && margin > 0 ? mmPerPixel(calibration) : null,
-  ]);
-  const previousRefinementSignature = useRef(refinementSignature);
+  const detectionSignature = JSON.stringify([tolerancePx, smoothing]);
+  const scaleMmPerPx = mmPerPixel(calibration);
+  const previousDetectionSignature = useRef(detectionSignature);
+  const previousScaleMmPerPx = useRef(scaleMmPerPx);
 
   useEffect(() => {
-    const settingsChanged =
-      previousRefinementSignature.current !== refinementSignature;
-    previousRefinementSignature.current = refinementSignature;
-    // DETECTED already applies the current settings. Once a physical margin is
-    // visible, however, a scale change is itself an outline-shaping change.
-    if (!settingsChanged || rawOutline.length === 0) return;
+    const detectionSettingsChanged =
+      previousDetectionSignature.current !== detectionSignature;
+    const previousMmPerPx = previousScaleMmPerPx.current;
+    const scaleChanged = previousMmPerPx !== scaleMmPerPx;
+    previousDetectionSignature.current = detectionSignature;
+    previousScaleMmPerPx.current = scaleMmPerPx;
+
+    // DETECTED already applies the current settings. Detail and smoothing are
+    // intentionally re-derived from the dense detector result. Margin changes,
+    // by contrast, are committed directly from the current edited contour in
+    // TraceControlsPanel and must never come through this raw-outline path.
+    if ((!detectionSettingsChanged && !scaleChanged) || rawOutline.length === 0) {
+      return;
+    }
     let cancelled = false;
 
-    void refineOutline(rawOutline, {
-      detect: { tolerancePx, smoothing },
-      margin,
-      calibration,
-    }).then((refined) => {
+    const refinement = detectionSettingsChanged
+      ? refineOutline(rawOutline, {
+          detect: { tolerancePx, smoothing },
+          margin,
+          calibration,
+        })
+      : (() => {
+          const previousMarginPx =
+            margin !== null && margin > 0 && previousMmPerPx !== null
+              ? margin / previousMmPerPx
+              : 0;
+          const nextMarginPx = marginToPixels(margin, calibration);
+          const deltaPx = nextMarginPx - previousMarginPx;
+          return deltaPx === 0
+            ? Promise.resolve(outline)
+            : offsetEditedOutline(outline, deltaPx);
+        })();
+
+    void refinement.then((refined) => {
       if (!cancelled) dispatch({ type: "OUTLINE_REFINED", outline: refined });
     });
 
@@ -67,12 +95,14 @@ export function useOutlineRefinement(
     };
   }, [
     rawOutline,
+    outline,
     tolerancePx,
     smoothing,
     margin,
-    calibration,
-    refinementSignature,
+    detectionSignature,
+    scaleMmPerPx,
     dispatch,
     refineOutline,
+    offsetEditedOutline,
   ]);
 }

--- a/client/src/lib/calibrate/perspective.test.ts
+++ b/client/src/lib/calibrate/perspective.test.ts
@@ -101,7 +101,7 @@ describe("perspective geometry", () => {
     expect(proposalFromTemplateMarkers([...markers, markers[0]], "a4")).toBeNull();
   });
 
-  it("maps an A4 sheet to a uniform two-pixels-per-mm plane", () => {
+  it("maps an A4 sheet to a high-resolution four-pixels-per-mm plane", () => {
     const proposal: PerspectiveProposal = {
       source: "manual",
       points: [
@@ -112,12 +112,12 @@ describe("perspective geometry", () => {
       ],
     };
     const layout = perspectiveLayout(proposal, "a4");
-    expect(layout).toMatchObject({ width: 421, height: 595, pxPerMm: 2 });
+    expect(layout).toMatchObject({ width: 841, height: 1189, pxPerMm: 4 });
     expect(layout.destination).toEqual([
       { x: 0, y: 0 },
-      { x: 420, y: 0 },
-      { x: 420, y: 594 },
-      { x: 0, y: 594 },
+      { x: 840, y: 0 },
+      { x: 840, y: 1188 },
+      { x: 0, y: 1188 },
     ]);
   });
 
@@ -214,14 +214,14 @@ describe("perspective correction with the shipped OpenCV build", () => {
         "a4",
       );
 
-      expect(corrected.width).toBe(421);
-      expect(corrected.height).toBe(595);
-      expect(mmPerPixel(corrected.calibration)).toBeCloseTo(0.5, 9);
+      expect(corrected.width).toBe(841);
+      expect(corrected.height).toBe(1189);
+      expect(mmPerPixel(corrected.calibration)).toBeCloseTo(0.25, 9);
       expect(corrected.reprojectionErrorPx).toBeNull();
-      expect(pixel(corrected.imageData, 210, 290).slice(0, 3)).toEqual([
+      expect(pixel(corrected.imageData, 420, 580).slice(0, 3)).toEqual([
         20, 80, 180,
       ]);
-      expect(pixel(corrected.imageData, 40, 100).slice(0, 3)).toEqual([
+      expect(pixel(corrected.imageData, 80, 200).slice(0, 3)).toEqual([
         255, 255, 255,
       ]);
     } finally {
@@ -311,7 +311,7 @@ describe("perspective correction with the shipped OpenCV build", () => {
 
       expect(corrected.reprojectionErrorPx).not.toBeNull();
       expect(corrected.reprojectionErrorPx!).toBeLessThan(0.01);
-      expect(pixel(corrected.imageData, 210, 290).slice(0, 3)).toEqual([
+      expect(pixel(corrected.imageData, 420, 580).slice(0, 3)).toEqual([
         20, 80, 180,
       ]);
     } finally {

--- a/client/src/lib/calibrate/perspective.ts
+++ b/client/src/lib/calibrate/perspective.ts
@@ -46,14 +46,17 @@ export interface PerspectiveCorrectionResult extends PerspectiveLayout {
 }
 
 /**
- * Two pixels per millimetre nearly fills the existing 800 x 600 working frame
- * for portrait A4 while keeping both A4 and Letter below the cap. More pixels
- * would be discarded by the canvas cap; fewer would throw away source detail.
+ * Perspective correction gets a larger working plane than an ordinary source
+ * image. At four pixels per millimetre A4 is 841 x 1189 and Letter is
+ * 865 x 1119: large enough to retain readable text and sharp marker edges,
+ * while still bounded to roughly one megapixel for interactive tracing.
  */
-export const RECTIFIED_PX_PER_MM = 2;
+export const RECTIFIED_PX_PER_MM = 4;
+export const RECTIFIED_IMAGE_MAX = { width: 1200, height: 1200 } as const;
 
 /** Reject a template fit whose residual exceeds 0.75 mm on the output plane. */
-export const MAX_REPROJECTION_RMS_PX = 1.5;
+export const MAX_REPROJECTION_RMS_PX =
+  0.75 * RECTIFIED_PX_PER_MM;
 export const MAX_TEMPLATE_REPROJECTION_RMS_MM =
   MAX_REPROJECTION_RMS_PX / RECTIFIED_PX_PER_MM;
 
@@ -182,7 +185,7 @@ export function scalePerspectiveProposal(
 export function perspectiveLayout(
   proposal: PerspectiveProposal,
   paper: TemplatePaper,
-  max = { width: 800, height: 600 },
+  max: { width: number; height: number } = RECTIFIED_IMAGE_MAX,
 ): PerspectiveLayout {
   const page = TEMPLATE_PAPER_MM[paper];
   const availableX = Math.max(1, max.width - 1) / page.width;
@@ -237,7 +240,7 @@ export function runPerspectiveCorrection(
   image: ImageData,
   proposal: PerspectiveProposal,
   paper: TemplatePaper,
-  max = { width: 800, height: 600 },
+  max: { width: number; height: number } = RECTIFIED_IMAGE_MAX,
 ): PerspectiveCorrectionResult {
   if (!validPerspectiveQuad(proposal.points)) {
     throw new Error(
@@ -366,6 +369,7 @@ export async function correctPerspective(
   image: ImageData,
   proposal: PerspectiveProposal,
   paper: TemplatePaper,
+  max: { width: number; height: number } = RECTIFIED_IMAGE_MAX,
 ): Promise<PerspectiveCorrectionResult> {
   const cv = await loadOpenCV();
   if (
@@ -374,5 +378,5 @@ export async function correctPerspective(
   ) {
     throw new Error("Perspective correction is unavailable in this browser session.");
   }
-  return runPerspectiveCorrection(cv, image, proposal, paper);
+  return runPerspectiveCorrection(cv, image, proposal, paper, max);
 }

--- a/client/src/lib/gridfinity/autoplace.test.ts
+++ b/client/src/lib/gridfinity/autoplace.test.ts
@@ -9,6 +9,7 @@ import {
   autoPlaceIncremental,
   fitLayoutToPlacements,
   fitFootprintToPlacements,
+  fitRectangularBinToPlacements,
   placementInsetMm,
 } from "./autoplace";
 
@@ -259,6 +260,24 @@ describe("fitFootprintToPlacements", () => {
       footprint: result.footprint,
     });
     expect(validateLayout(fittedSpec, result.cutouts, byId)).toEqual([]);
+  });
+});
+
+describe("fitRectangularBinToPlacements", () => {
+  it("keeps automatic fitting rectangular while irregular footprints remain opt-in", () => {
+    const shape = rectShape("small", 35, 35);
+    const byId = new Map([[shape.id, shape]]);
+    const cutout = {
+      ...autoPlaceFresh([shape], "standard").cutouts[0],
+      position: { x: -20, y: -20 },
+    };
+    const result = fitRectangularBinToPlacements(
+      [cutout],
+      byId,
+      parseBinSpec({ gridX: 2, gridY: 2, heightUnits: 6, fill: "solid" }),
+    );
+
+    expect(result.footprint).toEqual({ kind: "rectangle" });
   });
 });
 

--- a/client/src/lib/gridfinity/autoplace.ts
+++ b/client/src/lib/gridfinity/autoplace.ts
@@ -525,6 +525,31 @@ export function fitFootprintToPlacements(
 }
 
 /**
+ * Fits and recentres the layout without pruning boundary cells. This is the
+ * normal Bin action; irregular masks are opt-in through footprint editing.
+ */
+export function fitRectangularBinToPlacements(
+  cutouts: readonly CutoutPlacement[],
+  shapesById: ReadonlyMap<string, TracedShape>,
+  spec: BinSpec,
+): {
+  cutouts: CutoutPlacement[];
+  gridX: number;
+  gridY: number;
+  footprint: BinFootprint;
+} {
+  return {
+    ...fitLayoutToPlacements(
+      cutouts,
+      shapesById,
+      spec.lip,
+      spec.gridPitch,
+    ),
+    footprint: { kind: "rectangle" },
+  };
+}
+
+/**
  * Re-lays out *existing* cutouts: each one is rotated to its min-area OBB
  * (features included), shelf-packed, and centred in the smallest grid that
  * holds the block. Depth, clearance, features and mirroring are preserved;

--- a/client/src/lib/image-processor.test.ts
+++ b/client/src/lib/image-processor.test.ts
@@ -5,6 +5,7 @@ import type { ImageLike } from "./detect/types";
 import { convexHullForTest, polygonArea } from "./geometry/fixtures";
 import { outlineArea, outlineBounds, pointInOutline } from "./geometry/outline";
 import {
+  adjustOutlineMargin,
   MARGIN_MM_OPTIONS,
   marginToPixels,
   processImage,
@@ -167,6 +168,37 @@ describe("processImage: margins", () => {
       margin: null,
     });
     expect(Math.abs(outlineArea(none.outline))).toBeGreaterThan(0);
+  });
+
+  it("adjusts the edited contour without resurrecting a deleted hole", async () => {
+    const edited = [
+      {
+        outer: [
+          { x: 10, y: 10 },
+          { x: 90, y: 10 },
+          { x: 90, y: 80 },
+          { x: 45, y: 70 }, // a manually moved vertex
+          { x: 10, y: 80 },
+        ],
+        holes: [], // an unwanted detected hole was manually removed
+      },
+    ];
+    const calibration = {
+      startX: 0,
+      startY: 0,
+      endX: 100,
+      endY: 0,
+      lengthMm: 50,
+    };
+
+    const adjusted = await adjustOutlineMargin(edited, 1.5, 2, calibration);
+    const before = outlineBounds(edited)!;
+    const after = outlineBounds(adjusted)!;
+
+    expect(adjusted).not.toBe(edited);
+    expect(adjusted).toHaveLength(1);
+    expect(adjusted[0].holes).toEqual([]);
+    expect(after.maxX - after.minX).toBeGreaterThan(before.maxX - before.minX);
   });
 });
 

--- a/client/src/lib/image-processor.ts
+++ b/client/src/lib/image-processor.ts
@@ -76,6 +76,26 @@ export function marginToPixels(
   return margin / mmPerPx;
 }
 
+/**
+ * Changes only the clearance already applied to an edited contour.
+ *
+ * Applying the difference between the old and new physical margins is what
+ * preserves moved/added/deleted vertices and removed holes. Reprocessing the
+ * detector's cached raw outline here would silently resurrect discarded
+ * geometry and throw away manual contour edits.
+ */
+export async function adjustOutlineMargin(
+  outline: Outline,
+  previousMargin: Margin,
+  nextMargin: Margin,
+  calibration: Calibration | null,
+): Promise<Outline> {
+  const deltaPx =
+    marginToPixels(nextMargin, calibration) -
+    marginToPixels(previousMargin, calibration);
+  return deltaPx === 0 ? outline : offsetOutline(outline, deltaPx);
+}
+
 export interface ProcessOptions {
   /** Region of interest, or a region already cropped from the source. */
   region?: Region | CroppedRegionInfo | null;
@@ -167,8 +187,9 @@ export async function processImage(
 /**
  * Re-derives the presentation outline from the cached dense one.
  *
- * Backs the Detail, Smoothing and Margin controls: changing them costs a few
- * milliseconds of polygon work instead of a full re-segmentation.
+ * Backs the Detail and Smoothing controls: changing them costs a few
+ * milliseconds of polygon work instead of a full re-segmentation. Margin is
+ * deliberately handled by adjustOutlineMargin so manual edits survive.
  */
 export async function reprocessOutline(
   rawOutline: Outline,

--- a/client/src/pages/bin-designer.tsx
+++ b/client/src/pages/bin-designer.tsx
@@ -15,13 +15,11 @@ import {
   type ProjectDoc,
 } from "@shared/gridfinity/project";
 import { placementFootprint } from "@shared/gridfinity/cutout";
-import { parseBinSpec } from "@shared/gridfinity/types";
 
 import {
   autoArrangeLayout,
   autoPlaceFresh,
   autoPlaceIncremental,
-  trimFootprintToPlacements,
 } from "@/lib/gridfinity/autoplace";
 import {
   binDimensionsMm,
@@ -187,23 +185,14 @@ function BinDesignerWorkspace(): JSX.Element {
 
     const gridX = Math.max(result.gridX, cutouts.length > 0 ? spec.gridX : 0);
     const gridY = Math.max(result.gridY, cutouts.length > 0 ? spec.gridY : 0);
-    const nextCutouts = [...cutouts, ...result.cutouts];
-    const footprint = trimFootprintToPlacements(
-      nextCutouts,
-      shapesById,
-      parseBinSpec({
-        ...spec,
-        gridX,
-        gridY,
-        footprint: { kind: "rectangle" },
-      }),
-    );
     dispatch({
       type: "ADD_PLACED",
       cutouts: result.cutouts,
       gridX,
       gridY,
-      footprint,
+      // Automatic placement chooses the smallest rectangular Gridfinity bin.
+      // Irregular footprints require the explicit footprint editor.
+      footprint: { kind: "rectangle" },
     });
     if (spec.fill !== "solid") {
       dispatch({ type: "PATCH_SPEC", patch: { fill: "solid" } });
@@ -307,14 +296,21 @@ function BinDesignerWorkspace(): JSX.Element {
 
   const handleAutoArrange = useCallback(() => {
     const shapesById = new Map(library.shapes.map((shape) => [shape.id, shape]));
-    const result = autoArrangeLayout(cutouts, shapesById, spec.lip, spec.gridPitch, spec);
+    const result = autoArrangeLayout(
+      cutouts,
+      shapesById,
+      spec.lip,
+      spec.gridPitch,
+    );
     if (!result) return;
     dispatch({
       type: "REPLACE_LAYOUT",
       cutouts: result.cutouts,
       gridX: result.gridX,
       gridY: result.gridY,
-      footprint: result.footprint,
+      // Rearranging tools must not silently convert the bin into an irregular
+      // footprint. That remains an explicit Layout editing operation.
+      footprint: { kind: "rectangle" },
       historyLabel: "Auto-arrange tool pockets",
     });
     if (result.overflow) {

--- a/client/src/pages/trace.test.tsx
+++ b/client/src/pages/trace.test.tsx
@@ -59,6 +59,7 @@ vi.mock("@/components/trace/use-image-source", () => {
   };
 
   return {
+    IMAGE_CANVAS_MAX: { width: 800, height: 600 },
     useImageSource: (url: string | null) => (url ? ready : empty),
   };
 });

--- a/client/src/pages/trace.tsx
+++ b/client/src/pages/trace.tsx
@@ -7,7 +7,10 @@ import { usePanelState } from "@/components/layout/panel-context";
 import { WorkspaceLayout } from "@/components/layout/workspace-layout";
 import { TraceCanvas } from "@/components/trace/trace-canvas";
 import { TraceControlsPanel } from "@/components/trace/trace-controls-panel";
-import { useImageSource } from "@/components/trace/use-image-source";
+import {
+  IMAGE_CANVAS_MAX,
+  useImageSource,
+} from "@/components/trace/use-image-source";
 import { useOutlineRefinement } from "@/components/trace/use-outline-refinement";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,6 +26,7 @@ import { useToast } from "@/hooks/use-toast";
 import { autoCalibrate } from "@/lib/calibrate/auto-calibrate";
 import {
   correctPerspective,
+  RECTIFIED_IMAGE_MAX,
   scalePerspectiveProposal,
   type PerspectiveProposal,
 } from "@/lib/calibrate/perspective";
@@ -67,6 +71,7 @@ function TraceWorkspace(): JSX.Element {
   const { source, getImageData, getDetectionFrame } = useImageSource(
     store.imageUrl,
     store.fileName,
+    store.perspectiveCorrection ? RECTIFIED_IMAGE_MAX : IMAGE_CANVAS_MAX,
   );
   useOutlineRefinement();
 

--- a/client/src/state/trace-store.test.ts
+++ b/client/src/state/trace-store.test.ts
@@ -162,6 +162,31 @@ describe("undo / redo", () => {
     expect(state.outline).toBe(ringB);
     expect(state.history.stack[0].outline).toBe(ringB);
   });
+
+  it("keeps margin changes in history with the edited contour", () => {
+    const changed = run(
+      initialTraceState,
+      detected(ringA),
+      { type: "OUTLINE_COMMITTED", outline: ringB, label: "Move contour node" },
+      { type: "MARGIN_COMMITTED", outline: ringC, margin: 2.5 },
+    );
+
+    expect(changed.outline).toBe(ringC);
+    expect(changed.margin).toBe(2.5);
+    expect(changed.history.stack.map((entry) => entry.label)).toEqual([
+      "Detected outline",
+      "Move contour node",
+      "Set contour margin to 2.5 mm",
+    ]);
+
+    const undone = traceReducer(changed, { type: "UNDO" });
+    expect(undone.outline).toBe(ringB);
+    expect(undone.margin).toBe(1.5);
+
+    const redone = traceReducer(undone, { type: "REDO" });
+    expect(redone.outline).toBe(ringC);
+    expect(redone.margin).toBe(2.5);
+  });
 });
 
 describe("loading a new image", () => {
@@ -326,7 +351,9 @@ describe("modes and calibration", () => {
     expect(state.rawOutline).toEqual([]);
     expect(state.svg).toBeNull();
     expect(state.detectedImageUrl).toBeNull();
-    expect(state.history.stack).toEqual([{ outline: [], label: "Start" }]);
+    expect(state.history.stack).toEqual([
+      { outline: [], label: "Start", margin: 1.5 },
+    ]);
   });
 
   it("ignores a detection result from a region that was replaced", () => {

--- a/client/src/state/trace-store.tsx
+++ b/client/src/state/trace-store.tsx
@@ -48,6 +48,8 @@ export interface TraceHistoryEntry {
   outline: Outline;
   /** Human-readable operation that produced this state. */
   label: string;
+  /** Physical clearance paired with this exact contour state. */
+  margin: Margin;
 }
 
 export interface TraceState {
@@ -123,7 +125,10 @@ export const initialTraceState: TraceState = {
   detectedImageUrl: null,
   autoCalibrationAttemptedImageUrl: null,
   selection: null,
-  history: { stack: [{ outline: [], label: "Start" }], index: 0 },
+  history: {
+    stack: [{ outline: [], label: "Start", margin: DEFAULT_MARGIN_MM }],
+    index: 0,
+  },
   sensitivity: 128,
   tolerancePx: 1.2,
   smoothing: 1,
@@ -162,6 +167,8 @@ export type TraceAction =
   | { type: "OUTLINE_REFINED"; outline: Outline }
   /** A committed edit: pushes onto the undo stack. */
   | { type: "OUTLINE_COMMITTED"; outline: Outline; label?: string }
+  /** An offset of the current edited contour and its physical setting. */
+  | { type: "MARGIN_COMMITTED"; outline: Outline; margin: Margin }
   /** A mid-drag update: previews without touching the committed history. */
   | { type: "OUTLINE_DRAGGING"; outline: Outline }
   | { type: "UNDO" }
@@ -212,11 +219,12 @@ function pushHistory(
   history: TraceState["history"],
   outline: Outline,
   label: string,
+  margin: Margin,
 ): TraceState["history"] {
   // Anything redone-past is discarded, as in every undo stack.
   const stack = [
     ...history.stack.slice(0, history.index + 1),
-    { outline, label },
+    { outline, label, margin },
   ];
   const trimmed = stack.length > HISTORY_LIMIT ? stack.slice(-HISTORY_LIMIT) : stack;
   return { stack: trimmed, index: trimmed.length - 1 };
@@ -274,7 +282,13 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
         detectedImageUrl: action.imageUrl,
         selection: null,
         history: {
-          stack: [{ outline: action.outline, label: "Detected outline" }],
+          stack: [
+            {
+              outline: action.outline,
+              label: "Detected outline",
+              margin: state.margin,
+            },
+          ],
           index: 0,
         },
       };
@@ -305,9 +319,26 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
           state.history,
           action.outline,
           action.label ?? "Edit contour",
+          state.margin,
         ),
       };
     }
+
+    case "MARGIN_COMMITTED":
+      if (state.margin === action.margin && state.outline === action.outline) {
+        return state;
+      }
+      return {
+        ...state,
+        margin: action.margin,
+        outline: action.outline,
+        history: pushHistory(
+          state.history,
+          action.outline,
+          `Set contour margin to ${action.margin ?? 0} mm`,
+          action.margin,
+        ),
+      };
 
     case "OUTLINE_DRAGGING":
       return { ...state, outline: action.outline };
@@ -318,6 +349,7 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
       return {
         ...state,
         outline: state.history.stack[index].outline,
+        margin: state.history.stack[index].margin,
         selection: null,
         history: { ...state.history, index },
       };
@@ -329,6 +361,7 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
       return {
         ...state,
         outline: state.history.stack[index].outline,
+        margin: state.history.stack[index].margin,
         selection: null,
         history: { ...state.history, index },
       };
@@ -346,6 +379,7 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
       return {
         ...state,
         outline: state.history.stack[action.index].outline,
+        margin: state.history.stack[action.index].margin,
         selection: null,
         history: { ...state.history, index: action.index },
       };
@@ -388,7 +422,10 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
         svg: null,
         detectedImageUrl: null,
         selection: null,
-        history: { stack: [{ outline: [], label: "Start" }], index: 0 },
+        history: {
+          stack: [{ outline: [], label: "Start", margin: state.margin }],
+          index: 0,
+        },
       };
 
     case "REGION_COMMITTED":

--- a/docs/gridfinity-plan.md
+++ b/docs/gridfinity-plan.md
@@ -8,13 +8,14 @@ the pocket. Optional server persistence remains deferred.
 Nonrectangular bin footprints landed on 2026-08-27. A bin can now use a
 connected, hole-free mask at the selected full/half/quarter pitch, so a 2×2
 three-cell mask produces a true L-shaped base, body, wall, and stacking lip.
-**Fit bin to contents** preserves relative pocket placement while pruning safe
-unused boundary cells; Auto-arrange trims after placement, and Layout exposes a
-manual cell editor. The exact footprint is shared by live validation, the 2D
-editor, worker geometry, and layout DXF/SVG export. Label tabs can anchor to a
-specific exterior or re-entrant boundary edge. Rectangular projects retain the
-original geometry path, and schema-v1–v3 projects migrate to an explicit
-rectangular footprint. A shaped-bin physical gate remains: print a full-pitch
+**Fit bin to contents** preserves relative pocket placement while choosing the
+smallest rectangular grid, and Auto-arrange also returns a rectangle. Irregular
+connected, hole-free masks are an explicit Layout → Edit footprint option. The
+exact footprint is shared by live validation, the 2D editor, worker geometry,
+and layout DXF/SVG export. Label tabs can anchor to a specific exterior or
+re-entrant boundary edge. Rectangular projects retain the original geometry
+path, and schema-v1–v3 projects migrate to an explicit rectangular footprint. A
+shaped-bin physical gate remains: print a full-pitch
 2×2/three-cell L, verify baseplate fit and the concave wall/lip, stack a matching
 footprint, then print an L-tool pocket and check its fit.
 


### PR DESCRIPTION
## Summary
- preserve image detail during perspective correction with a higher-resolution rectified working plane
- keep automatic bin placement, fitting, and arrangement rectangular while retaining irregular footprints as an explicit editor option
- make contour-editing guidance prominent and apply margin changes to the current edited contour without restoring deleted holes or re-running detection
- record margin changes atomically in trace undo/redo history

## Verification
- npm run check
- npm test (841 tests)
- npm run build
- live app responds on port 5001