### PR TITLE
Link calibration templates from upload guidance

### DIFF
--- a/client/src/app.smoke.test.tsx
+++ b/client/src/app.smoke.test.tsx
@@ -212,6 +212,9 @@ describe("App", () => {
     renderApp();
     // The dropzone belongs in the empty canvas, not in the controls panel.
     expect(container.textContent).toContain("Trace a tool from a photo");
+    expect(container.textContent).toContain(
+      "Photograph the tool on the provided A4 or US Letter template or plain background",
+    );
     expect(container.textContent).toContain("Drag & drop an image here");
     expect(container.textContent).not.toContain("Untitled");
     expect(container.textContent).not.toContain("0 × 0 px");

--- a/client/src/pages/trace.test.tsx
+++ b/client/src/pages/trace.test.tsx
@@ -8,10 +8,12 @@ import { TraceProvider, useTrace } from "@/state/trace-store";
 
 import TracePage from "./trace";
 
-const { getImageDataMock, processImageMock } = vi.hoisted(() => ({
-  getImageDataMock: vi.fn(),
-  processImageMock: vi.fn(),
-}));
+const { downloadCalibrationTemplateMock, getImageDataMock, processImageMock } =
+  vi.hoisted(() => ({
+    downloadCalibrationTemplateMock: vi.fn(),
+    getImageDataMock: vi.fn(),
+    processImageMock: vi.fn(),
+  }));
 
 vi.mock("@/components/layout/workspace-layout", () => ({
   WorkspaceLayout: ({
@@ -33,10 +35,19 @@ vi.mock("@/components/trace/trace-controls-panel", () => ({
 }));
 
 vi.mock("@/components/trace/trace-canvas", () => ({
-  TraceCanvas: ({ onReprocess }: { onReprocess: () => void }) => (
-    <button data-testid="run-detection" onClick={onReprocess}>
-      Run detection
-    </button>
+  TraceCanvas: ({
+    emptyState,
+    onReprocess,
+  }: {
+    emptyState?: React.ReactNode;
+    onReprocess: () => void;
+  }) => (
+    <>
+      {emptyState}
+      <button data-testid="run-detection" onClick={onReprocess}>
+        Run detection
+      </button>
+    </>
   ),
 }));
 
@@ -68,6 +79,10 @@ vi.mock("@/lib/image-processor", async (importOriginal) => {
   const original = await importOriginal<typeof import("@/lib/image-processor")>();
   return { ...original, processImage: processImageMock };
 });
+
+vi.mock("@/lib/calibrate/download-template", () => ({
+  downloadCalibrationTemplate: downloadCalibrationTemplateMock,
+}));
 
 function WorkflowController(): JSX.Element {
   const { dispatch } = useTrace();
@@ -123,6 +138,40 @@ describe("Trace detection workflow", () => {
     host.remove();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  it("links both calibration-sheet downloads above the empty drop zone", async () => {
+    await React.act(async () => {
+      root.render(
+        <PanelProvider>
+          <TraceProvider>
+            <TracePage />
+          </TraceProvider>
+        </PanelProvider>,
+      );
+    });
+
+    expect(host.textContent).toContain(
+      "Photograph the tool on the provided A4 or US Letter template or plain background",
+    );
+    const emphasizedOr = [...host.querySelectorAll("strong")].find(
+      (candidate) => candidate.textContent === "or",
+    );
+    expect(emphasizedOr?.className).toContain("italic");
+
+    await React.act(async () => {
+      host
+        .querySelector<HTMLButtonElement>('[data-testid="empty-state-template-a4"]')
+        ?.click();
+      host
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="empty-state-template-letter"]',
+        )
+        ?.click();
+    });
+
+    expect(downloadCalibrationTemplateMock).toHaveBeenNthCalledWith(1, "a4");
+    expect(downloadCalibrationTemplateMock).toHaveBeenNthCalledWith(2, "letter");
   });
 
   it("waits for a detection region instead of tracing immediately on image load", async () => {

--- a/client/src/pages/trace.tsx
+++ b/client/src/pages/trace.tsx
@@ -24,6 +24,7 @@ import {
 import { FileUpload } from "@/components/ui/file-upload";
 import { useToast } from "@/hooks/use-toast";
 import { autoCalibrate } from "@/lib/calibrate/auto-calibrate";
+import { downloadCalibrationTemplate } from "@/lib/calibrate/download-template";
 import {
   correctPerspective,
   RECTIFIED_IMAGE_MAX,
@@ -479,8 +480,28 @@ function TraceWorkspace(): JSX.Element {
               <div className="w-full max-w-lg space-y-3 text-center">
                 <h2 className="text-lg font-medium">Trace a tool from a photo</h2>
                 <p className="text-sm text-muted-foreground">
-                  Photograph the tool on a plain background that contrasts with
-                  it, and keep the whole tool in frame.
+                  Photograph the tool on the provided{" "}
+                  <button
+                    type="button"
+                    className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                    onClick={() => downloadCalibrationTemplate("a4")}
+                    data-testid="empty-state-template-a4"
+                  >
+                    A4
+                  </button>{" "}
+                  or{" "}
+                  <button
+                    type="button"
+                    className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                    onClick={() => downloadCalibrationTemplate("letter")}
+                    data-testid="empty-state-template-letter"
+                  >
+                    US Letter
+                  </button>{" "}
+                  template{" "}
+                  <strong className="font-semibold italic">or</strong>{" "}
+                  plain background that contrasts with it, and keep the whole
+                  tool in frame.
                 </p>
                 {dropzone}
               </div>


### PR DESCRIPTION
## Summary

- update the empty Trace workspace guidance to mention the provided calibration sheets
- make A4 and US Letter download their respective PDF templates
- emphasize the alternative plain-background option
- cover the copy, styling, and both download actions in UI tests

## Verification

- npm run check
- npm test (842 tests)
- npm run build
- git diff --check