### PR TITLE
Fix manual scale editing and image replacement

### DIFF
--- a/client/src/components/trace/trace-canvas-history.test.tsx
+++ b/client/src/components/trace/trace-canvas-history.test.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Outline } from "@shared/geometry/types";
+import { mmPerPixel } from "@shared/geometry/scale";
 
 import { TraceProvider, useTrace } from "@/state/trace-store";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -98,6 +99,12 @@ function ScaleStateProbe(): JSX.Element {
         {calibration ? "committed" : "pending"}
       </output>
       <output data-testid="scale-draft">{JSON.stringify(draftCalibration)}</output>
+      <output data-testid="scale-calibration">
+        {calibration ? JSON.stringify(calibration) : "none"}
+      </output>
+      <output data-testid="scale-mm-per-pixel">
+        {mmPerPixel(calibration)?.toFixed(6) ?? "none"}
+      </output>
     </>
   );
 }
@@ -248,7 +255,7 @@ describe("TraceCanvas edit history", () => {
         ?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
       await Promise.resolve();
     });
-    const inlineLength = host.querySelector<HTMLInputElement>(
+    const inlineLength = document.querySelector<HTMLInputElement>(
       '[data-testid="ruler-length-inline-input"]',
     );
     expect(inlineLength).not.toBeNull();
@@ -261,13 +268,16 @@ describe("TraceCanvas edit history", () => {
       )!.set!;
       setter.call(inlineLength, "75");
       inlineLength?.dispatchEvent(new Event("input", { bubbles: true }));
+      await Promise.resolve();
+    });
+    await React.act(async () => {
       inlineLength?.dispatchEvent(
         new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
       );
       await Promise.resolve();
     });
     expect(
-      host.querySelector('[data-testid="ruler-length-inline-input"]'),
+      document.querySelector('[data-testid="ruler-length-inline-input"]'),
     ).toBeNull();
     expect(
       host.querySelector('[data-testid="ruler-length-label"]')?.textContent,
@@ -349,9 +359,7 @@ describe("TraceCanvas edit history", () => {
       expect(line?.getAttribute("x2")).toBe("70");
       expect(line?.getAttribute("y2")).toBe("80");
       expect(host.querySelectorAll('[data-testid="ruler-marker"]')).toHaveLength(2);
-      expect(host.querySelector('[data-testid="ruler-length-label"]')?.textContent).toBe(
-        "100 mm",
-      );
+      expect(host.querySelector('[data-testid="ruler-length-label"]')).toBeNull();
       expect(host.querySelector('[data-testid="scale-mode"]')?.textContent).toBe(
         "calibrate",
       );
@@ -387,6 +395,138 @@ describe("TraceCanvas edit history", () => {
           "data-ruler-preview",
         ),
       ).toBe("true");
+      expect(
+        host.querySelector('[data-testid="ruler-length-label"]')?.textContent,
+      ).toContain("100 mm");
+    } finally {
+      React.act(() => root.unmount());
+      restoreSvgCoordinates();
+    }
+  });
+
+  it("drags either completed ruler endpoint and recalculates the scale", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("ResizeObserver", NoopResizeObserver);
+    const restoreSvgCoordinates = installIdentitySvgCoordinates();
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    try {
+      await React.act(async () => {
+        root.render(
+          <TraceProvider>
+            <SeedTrace />
+            <ScaleStateProbe />
+            <TooltipProvider>
+              <TraceCanvas onReprocess={() => {}} />
+            </TooltipProvider>
+          </TraceProvider>,
+        );
+        await Promise.resolve();
+      });
+
+      const canvas = host.querySelector("svg");
+      expect(canvas).not.toBeNull();
+      Object.defineProperties(canvas!, {
+        setPointerCapture: { configurable: true, value: vi.fn() },
+        hasPointerCapture: { configurable: true, value: () => false },
+        releasePointerCapture: { configurable: true, value: vi.fn() },
+      });
+
+      const startHandle = host.querySelector(
+        '[data-ruler-handle="start"] [data-testid="ruler-handle-hit-area"]',
+      );
+      expect(startHandle).not.toBeNull();
+      expect(host.querySelector('[data-testid="scale-mm-per-pixel"]')?.textContent).toBe(
+        "0.441942",
+      );
+
+      await React.act(async () => {
+        startHandle?.dispatchEvent(
+          new MouseEvent("pointerdown", {
+            bubbles: true,
+            button: 0,
+            clientX: 10,
+            clientY: 10,
+          }),
+        );
+        canvas?.dispatchEvent(
+          new MouseEvent("pointermove", {
+            bubbles: true,
+            button: 0,
+            clientX: 25,
+            clientY: 30,
+          }),
+        );
+        canvas?.dispatchEvent(
+          new MouseEvent("pointerup", {
+            bubbles: true,
+            button: 0,
+            clientX: 25,
+            clientY: 30,
+          }),
+        );
+      });
+
+      expect(host.querySelector('[data-testid="scale-calibration"]')?.textContent).toBe(
+        JSON.stringify({
+          startX: 25,
+          startY: 30,
+          endX: 90,
+          endY: 90,
+          lengthMm: 50,
+        }),
+      );
+      expect(host.querySelector('[data-testid="scale-mm-per-pixel"]')?.textContent).toBe(
+        "0.565233",
+      );
+      expect(host.querySelector('[data-testid="ruler-line"]')?.getAttribute("x1")).toBe(
+        "25",
+      );
+      expect(host.querySelector('[data-testid="ruler-line"]')?.getAttribute("y1")).toBe(
+        "30",
+      );
+
+      const endHandle = host.querySelector(
+        '[data-ruler-handle="end"] [data-testid="ruler-handle-hit-area"]',
+      );
+      await React.act(async () => {
+        endHandle?.dispatchEvent(
+          new MouseEvent("pointerdown", {
+            bubbles: true,
+            button: 0,
+            clientX: 90,
+            clientY: 90,
+          }),
+        );
+        canvas?.dispatchEvent(
+          new MouseEvent("pointermove", {
+            bubbles: true,
+            button: 0,
+            clientX: 130,
+            clientY: -20,
+          }),
+        );
+        canvas?.dispatchEvent(
+          new MouseEvent("pointerup", {
+            bubbles: true,
+            button: 0,
+            clientX: 130,
+            clientY: -20,
+          }),
+        );
+      });
+
+      expect(host.querySelector('[data-testid="scale-calibration"]')?.textContent).toBe(
+        JSON.stringify({
+          startX: 25,
+          startY: 30,
+          endX: 99,
+          endY: 0,
+          lengthMm: 50,
+        }),
+      );
     } finally {
       React.act(() => root.unmount());
       restoreSvgCoordinates();

--- a/client/src/components/trace/trace-canvas.tsx
+++ b/client/src/components/trace/trace-canvas.tsx
@@ -304,7 +304,11 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
 
     // Ruler handles stay draggable except while the page-corner tool owns the
     // pointer; its markers may legitimately overlap the scale ruler.
-    if (displayedCalibration && mode !== "perspective") {
+    if (
+      event.button === 0 &&
+      displayedCalibration &&
+      mode !== "perspective"
+    ) {
       const target = event.target as Element;
       const handle = target
         .closest?.("[data-ruler-handle]")
@@ -469,12 +473,13 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
     }
 
     if (drag.kind === "ruler" && displayedCalibration) {
+      const point = clampPointToImage(image, imageSize);
       dispatch({
         type: "SET_CALIBRATION",
         calibration:
           drag.end === "start"
-            ? { ...displayedCalibration, startX: image.x, startY: image.y }
-            : { ...displayedCalibration, endX: image.x, endY: image.y },
+            ? { ...displayedCalibration, startX: point.x, startY: point.y }
+            : { ...displayedCalibration, endX: point.x, endY: point.y },
       });
       return;
     }

--- a/client/src/components/trace/trace-scene.test.tsx
+++ b/client/src/components/trace/trace-scene.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { Calibration, DraftCalibration } from "@shared/geometry/scale";
 import type { Point } from "@shared/geometry/types";
@@ -61,6 +62,11 @@ describe("TraceScene ruler overlay", () => {
 
     expect(count(markup, 'data-testid="ruler-marker"')).toBe(2);
     expect(count(markup, "data-ruler-handle=")).toBe(2);
+    expect(count(markup, 'data-testid="ruler-handle-hit-area"')).toBe(2);
+    expect(markup).toContain('r="18"');
+    expect(markup).toContain("cursor-grab");
+    expect(markup).toContain("Drag the start scale point");
+    expect(markup).toContain("Drag the end scale point");
     expect(markup).toContain('data-testid="ruler-line"');
     expect(markup).toContain('data-testid="ruler-length-label"');
     expect(markup).toContain("50 mm");
@@ -92,7 +98,59 @@ describe("TraceScene ruler overlay", () => {
     expect(count(markup, "data-ruler-handle=")).toBe(0);
     expect(markup).toContain('data-ruler-preview="true"');
     expect(markup).toContain('stroke-dasharray="6 4"');
-    expect(markup).toContain("125.5 mm");
+    expect(markup).not.toContain('data-testid="ruler-length-label"');
+    expect(markup).not.toContain("125.5 mm");
+  });
+
+  it("keeps inline-editor text screen-sized while the scene is zoomed", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    try {
+      await React.act(async () => {
+        root.render(
+          <TraceScene
+            imageUrl="data:image/png;base64,AA=="
+            imageSize={{ width: 200, height: 100 }}
+            transform={{ scale: 4, translateX: 0, translateY: 0 }}
+            outline={[]}
+            selection={null}
+            region={null}
+            calibration={calibration}
+            draftCalibration={null}
+            rulerLengthMm={100}
+            rulerEditable
+          />,
+        );
+      });
+
+      await React.act(async () => {
+        host
+          .querySelector<SVGGElement>('[data-testid="ruler-length-label"]')
+          ?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+      });
+
+      const input = document.querySelector<HTMLInputElement>(
+        '[data-testid="ruler-length-inline-input"]',
+      );
+      const editor = document.querySelector<HTMLElement>(
+        '[data-testid="ruler-length-inline-editor"]',
+      );
+      expect(editor?.parentElement).toBe(document.body);
+      expect(editor?.style.position || editor?.className).toContain("fixed");
+      expect(editor?.style.width).toBe("96px");
+      expect(editor?.style.height).toBe("30px");
+      expect(input?.type).toBe("text");
+      expect(input?.className).toContain("text-xs");
+      expect(input?.className).toContain("text-foreground");
+      expect(document.activeElement).toBe(input);
+    } finally {
+      React.act(() => root.unmount());
+      host.remove();
+      vi.unstubAllGlobals();
+    }
   });
 
   it("shows only the first X before the pointer supplies a preview endpoint", () => {

--- a/client/src/components/trace/trace-scene.tsx
+++ b/client/src/components/trace/trace-scene.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from "react";
+import { createPortal } from "react-dom";
 
 import type { Calibration, DraftCalibration } from "@shared/geometry/scale";
 import {
@@ -37,7 +38,7 @@ export interface TraceSceneProps {
   regionActive?: boolean;
   calibration: Calibration | null;
   draftCalibration: DraftCalibration | null;
-  /** Known physical length shown beside both preview and completed rulers. */
+  /** Known physical length shown after both manual-ruler points are placed. */
   rulerLengthMm: number;
   /** Enables the on-image reference-length editor after endpoint placement. */
   rulerEditable?: boolean;
@@ -71,10 +72,14 @@ export interface TraceSceneProps {
 /** Screen-space sizes, divided by the scale so they stay constant when zooming. */
 const HANDLE_RADIUS = 5;
 const HANDLE_RADIUS_SELECTED = 7;
-const RULER_HIT_RADIUS = 12;
+const RULER_HIT_RADIUS = 18;
 const RULER_MARKER_HALF_SIZE = 7;
 const RULER_LABEL_OFFSET = 18;
 const RULER_LABEL_HEIGHT = 22;
+const RULER_LABEL_FONT_SIZE = 12;
+const RULER_LABEL_RADIUS = 6;
+const RULER_EDITOR_MIN_WIDTH = 96;
+const RULER_EDITOR_HEIGHT = 30;
 const PERSPECTIVE_MARKER_RADIUS = 10;
 const PERSPECTIVE_HIT_RADIUS = 15;
 
@@ -359,14 +364,16 @@ function RulerOverlay({
             data-testid="ruler-line"
             data-ruler-preview={calibration ? undefined : "true"}
           />
-          <RulerLengthLabel
-            start={start}
-            end={end}
-            lengthMm={lengthMm}
-            editable={editable}
-            onLengthCommit={onLengthCommit}
-            inv={inv}
-          />
+          {(calibration || editable) && (
+            <RulerLengthLabel
+              start={start}
+              end={end}
+              lengthMm={lengthMm}
+              editable={editable}
+              onLengthCommit={onLengthCommit}
+              inv={inv}
+            />
+          )}
         </>
       )}
       {[start, end].map((point, index) =>
@@ -380,12 +387,18 @@ function RulerOverlay({
             }
           >
             {calibration && (
-              <circle
-                cx={point.x}
-                cy={point.y}
-                r={RULER_HIT_RADIUS * inv}
-                fill="transparent"
-              />
+              <>
+                <title>{`Drag the ${index === 0 ? "start" : "end"} scale point`}</title>
+                <circle
+                  cx={point.x}
+                  cy={point.y}
+                  r={RULER_HIT_RADIUS * inv}
+                  className="cursor-grab fill-transparent stroke-transparent transition-colors hover:fill-amber-500/15 hover:stroke-amber-500/70 active:cursor-grabbing"
+                  strokeWidth={2}
+                  vectorEffect="non-scaling-stroke"
+                  data-testid="ruler-handle-hit-area"
+                />
+              </>
             )}
             <path
               d={rulerMarkerPath(point, markerHalfSize)}
@@ -427,12 +440,14 @@ function RulerLengthLabel({
   inv: number;
 }): JSX.Element {
   const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(formatRulerLength(lengthMm));
+  const [editorRect, setEditorRect] = useState<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  } | null>(null);
+  const labelRef = useRef<SVGGElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
-
-  useEffect(() => {
-    if (!editing) setDraft(formatRulerLength(lengthMm));
-  }, [editing, lengthMm]);
 
   useEffect(() => {
     if (!editing) return;
@@ -442,16 +457,26 @@ function RulerLengthLabel({
 
   const startEditing = () => {
     if (!editable) return;
-    setDraft(formatRulerLength(lengthMm));
+    const bounds = labelRef.current?.getBoundingClientRect();
+    const width = Math.max(RULER_EDITOR_MIN_WIDTH, bounds?.width ?? 0);
+    const centreX = bounds ? bounds.left + bounds.width / 2 : 0;
+    const centreY = bounds ? bounds.top + bounds.height / 2 : 0;
+    setEditorRect({
+      left: centreX - width / 2,
+      top: centreY - RULER_EDITOR_HEIGHT / 2,
+      width,
+      height: RULER_EDITOR_HEIGHT,
+    });
     setEditing(true);
   };
 
   const finishEditing = (commit: boolean) => {
     if (commit) {
-      const value = Number(draft);
+      const value = Number(inputRef.current?.value);
       if (Number.isFinite(value) && value > 0) onLengthCommit?.(value);
     }
     setEditing(false);
+    setEditorRect(null);
   };
 
   const dx = end.x - start.x;
@@ -463,11 +488,13 @@ function RulerLengthLabel({
   const x = (start.x + end.x) / 2 + normal.x * offset;
   const y = (start.y + end.y) / 2 + normal.y * offset;
   const label = `${formatRulerLength(lengthMm)} mm`;
-  const width = Math.max(46, label.length * 7 + 14) * inv;
+  const displayWidthPx = Math.max(46, label.length * 7 + 14);
+  const width = displayWidthPx * inv;
   const height = RULER_LABEL_HEIGHT * inv;
 
   return (
     <g
+      ref={labelRef}
       data-testid="ruler-length-label"
       pointerEvents={editable ? "all" : "none"}
       role={editable ? "button" : undefined}
@@ -510,59 +537,69 @@ function RulerLengthLabel({
         y={y - height / 2}
         width={width}
         height={height}
-        rx={6 * inv}
+        rx={RULER_LABEL_RADIUS * inv}
         className="fill-background/95 stroke-amber-500"
         strokeWidth={1.5}
         vectorEffect="non-scaling-stroke"
       />
-      {editing ? (
-        <foreignObject
-          x={x - width / 2}
-          y={y - height / 2}
-          width={width}
-          height={height}
-          data-testid="ruler-length-inline-editor"
-        >
-          <div className="flex h-full w-full items-center overflow-hidden rounded-md border border-amber-500 bg-background px-1 text-foreground shadow-sm">
-            <input
-              ref={inputRef}
-              type="number"
-              min={1}
-              step="any"
-              value={draft}
-              aria-label="Ruler length in millimetres"
-              data-testid="ruler-length-inline-input"
-              className="h-full min-w-0 flex-1 bg-transparent text-center text-xs font-semibold outline-none"
-              onPointerDown={(event) => event.stopPropagation()}
-              onDoubleClick={(event) => event.stopPropagation()}
-              onChange={(event) => setDraft(event.target.value)}
-              onBlur={() => finishEditing(true)}
-              onKeyDown={(event) => {
-                event.stopPropagation();
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  finishEditing(true);
-                } else if (event.key === "Escape") {
-                  event.preventDefault();
-                  finishEditing(false);
-                }
+      {editing && editorRect && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              className="fixed z-[60] flex items-center overflow-hidden rounded-md border border-amber-500 bg-background px-2 text-foreground shadow-md"
+              style={{
+                left: editorRect.left,
+                top: editorRect.top,
+                width: editorRect.width,
+                height: editorRect.height,
               }}
-            />
-            <span className="shrink-0 text-[10px] font-medium">mm</span>
-          </div>
-        </foreignObject>
-      ) : (
+              data-testid="ruler-length-inline-editor"
+            >
+              <input
+                ref={inputRef}
+                type="text"
+                inputMode="decimal"
+                defaultValue={formatRulerLength(lengthMm)}
+                aria-label="Ruler length in millimetres"
+                data-testid="ruler-length-inline-input"
+                className="h-full min-w-0 flex-1 bg-transparent text-center text-xs font-semibold text-foreground caret-amber-500 outline-none selection:bg-amber-200 selection:text-slate-950"
+                onPointerDown={(event) => event.stopPropagation()}
+                onDoubleClick={(event) => event.stopPropagation()}
+                onBlur={() => finishEditing(true)}
+                onKeyDown={(event) => {
+                  // Portal events still bubble through the owning SVG <g> in
+                  // React. Stop Enter from reopening the editor immediately.
+                  event.stopPropagation();
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    finishEditing(true);
+                  } else if (event.key === "Escape") {
+                    event.preventDefault();
+                    finishEditing(false);
+                  }
+                }}
+              />
+              <span
+                className="shrink-0 text-[10px] font-medium text-foreground"
+                data-testid="ruler-length-inline-unit"
+              >
+                mm
+              </span>
+            </div>,
+            document.body,
+          )
+        : null}
+      {!editing ? (
         <text
           x={x}
           y={y}
           textAnchor="middle"
           dominantBaseline="central"
-          fontSize={12 * inv}
+          fontSize={RULER_LABEL_FONT_SIZE * inv}
           className="fill-foreground font-semibold"
         >
           {label}
         </text>
-      )}
+      ) : null}
     </g>
   );
 }

--- a/client/src/components/trace/use-image-source.test.ts
+++ b/client/src/components/trace/use-image-source.test.ts
@@ -3,10 +3,49 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   DETECTION_CANVAS_MAX,
+  decodeImageFile,
   detectionGeometry,
   fitWithin,
   IMAGE_CANVAS_MAX,
 } from "./use-image-source";
+
+describe("decodeImageFile", () => {
+  it("validates a file and reports its natural dimensions before replacement", async () => {
+    class TestFileReader {
+      result: string | ArrayBuffer | null = null;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      readAsDataURL(): void {
+        this.result = "data:image/png;base64,replacement";
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+
+    class TestImage {
+      naturalWidth = 1600;
+      naturalHeight = 1200;
+      width = 1600;
+      height = 1200;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      set src(_value: string) {
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+
+    vi.stubGlobal("FileReader", TestFileReader);
+    vi.stubGlobal("Image", TestImage);
+
+    await expect(
+      decodeImageFile(new File(["image"], "replacement.png")),
+    ).resolves.toEqual({
+      imageUrl: "data:image/png;base64,replacement",
+      naturalSize: { width: 1600, height: 1200 },
+    });
+  });
+});
 
 describe("fitWithin", () => {
   it("leaves an image smaller than the cap alone", () => {
@@ -91,4 +130,5 @@ describe("IMAGE_CANVAS_MAX", () => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });

--- a/client/src/components/trace/use-image-source.ts
+++ b/client/src/components/trace/use-image-source.ts
@@ -58,6 +58,47 @@ export interface DetectionFrame {
   sourceImageUrl: string;
 }
 
+export interface DecodedImageFile {
+  imageUrl: string;
+  naturalSize: Size;
+}
+
+/**
+ * Reads and validates an image before it replaces the current Trace source.
+ *
+ * Keeping this separate from {@link useImageSource} lets replacement commit
+ * its URL and dimensions together. A slow or invalid second file therefore
+ * cannot clear a perfectly usable first photo and leave the drop zone behind.
+ */
+export function decodeImageFile(file: File): Promise<DecodedImageFile> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error("That file could not be read."));
+    reader.onload = () => {
+      if (typeof reader.result !== "string") {
+        reject(new Error("That file could not be read as an image."));
+        return;
+      }
+
+      const imageUrl = reader.result;
+      const image = new Image();
+      image.onerror = () =>
+        reject(new Error("That file could not be decoded as an image."));
+      image.onload = () => {
+        const width = image.naturalWidth || image.width;
+        const height = image.naturalHeight || image.height;
+        if (width <= 0 || height <= 0) {
+          reject(new Error("That image has invalid dimensions."));
+          return;
+        }
+        resolve({ imageUrl, naturalSize: { width, height } });
+      };
+      image.src = imageUrl;
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
 /** Sizes the detection frame and the factor back into working space. */
 export function detectionGeometry(
   natural: Size,

--- a/client/src/pages/trace.test.tsx
+++ b/client/src/pages/trace.test.tsx
@@ -8,8 +8,13 @@ import { TraceProvider, useTrace } from "@/state/trace-store";
 
 import TracePage from "./trace";
 
-const { downloadCalibrationTemplateMock, getImageDataMock, processImageMock } =
-  vi.hoisted(() => ({
+const {
+  decodeImageFileMock,
+  downloadCalibrationTemplateMock,
+  getImageDataMock,
+  processImageMock,
+} = vi.hoisted(() => ({
+    decodeImageFileMock: vi.fn(),
     downloadCalibrationTemplateMock: vi.fn(),
     getImageDataMock: vi.fn(),
     processImageMock: vi.fn(),
@@ -70,6 +75,8 @@ vi.mock("@/components/trace/use-image-source", () => {
   };
 
   return {
+    decodeImageFile: decodeImageFileMock,
+    fitWithin: () => ({ width: 800, height: 600 }),
     IMAGE_CANVAS_MAX: { width: 800, height: 600 },
     useImageSource: (url: string | null) => (url ? ready : empty),
   };
@@ -107,6 +114,29 @@ function WorkflowController(): JSX.Element {
     >
       Set region
     </button>
+  );
+}
+
+function SeedReadySource(): null {
+  const { dispatch } = useTrace();
+
+  React.useEffect(() => {
+    dispatch({
+      type: "SOURCE_LOADED",
+      imageUrl: "data:image/png;base64,original",
+      fileName: "original",
+    });
+    dispatch({ type: "SOURCE_READY", imageSize: { width: 400, height: 300 } });
+  }, [dispatch]);
+  return null;
+}
+
+function SourceStateProbe(): JSX.Element {
+  const { imageSize, imageUrl } = useTrace();
+  return (
+    <output data-testid="source-state">
+      {imageUrl ?? "none"}|{imageSize.width}x{imageSize.height}
+    </output>
   );
 }
 
@@ -172,6 +202,64 @@ describe("Trace detection workflow", () => {
 
     expect(downloadCalibrationTemplateMock).toHaveBeenNthCalledWith(1, "a4");
     expect(downloadCalibrationTemplateMock).toHaveBeenNthCalledWith(2, "letter");
+  });
+
+  it("keeps the current photo visible until its replacement is decoded", async () => {
+    let resolveReplacement:
+      | ((value: {
+          imageUrl: string;
+          naturalSize: { width: number; height: number };
+        }) => void)
+      | undefined;
+    decodeImageFileMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveReplacement = resolve;
+      }),
+    );
+
+    await React.act(async () => {
+      root.render(
+        <PanelProvider>
+          <TraceProvider>
+            <SeedReadySource />
+            <SourceStateProbe />
+            <TracePage />
+          </TraceProvider>
+        </PanelProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    const file = new File(["replacement"], "replacement.png", {
+      type: "image/png",
+    });
+    const input = host.querySelector<HTMLInputElement>('input[type="file"]');
+    Object.defineProperty(input, "files", {
+      configurable: true,
+      value: [file],
+    });
+
+    await React.act(async () => {
+      input?.dispatchEvent(new Event("change", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(decodeImageFileMock).toHaveBeenCalledWith(file);
+    expect(host.querySelector('[data-testid="source-state"]')?.textContent).toBe(
+      "data:image/png;base64,original|800x600",
+    );
+
+    await React.act(async () => {
+      resolveReplacement?.({
+        imageUrl: "data:image/png;base64,replacement",
+        naturalSize: { width: 1600, height: 1200 },
+      });
+      await Promise.resolve();
+    });
+
+    expect(host.querySelector('[data-testid="source-state"]')?.textContent).toBe(
+      "data:image/png;base64,replacement|800x600",
+    );
   });
 
   it("waits for a detection region instead of tracing immediately on image load", async () => {

--- a/client/src/pages/trace.tsx
+++ b/client/src/pages/trace.tsx
@@ -8,6 +8,8 @@ import { WorkspaceLayout } from "@/components/layout/workspace-layout";
 import { TraceCanvas } from "@/components/trace/trace-canvas";
 import { TraceControlsPanel } from "@/components/trace/trace-controls-panel";
 import {
+  decodeImageFile,
+  fitWithin,
   IMAGE_CANVAS_MAX,
   useImageSource,
 } from "@/components/trace/use-image-source";
@@ -63,6 +65,7 @@ function TraceWorkspace(): JSX.Element {
   const { dispatch } = store;
   const activeImageUrlRef = useRef(store.imageUrl);
   activeImageUrlRef.current = store.imageUrl;
+  const fileSelectionRevisionRef = useRef(0);
   const { toast } = useToast();
   const { panelOpen, setPanelOpen } = usePanelState();
 
@@ -351,7 +354,8 @@ function TraceWorkspace(): JSX.Element {
     store.autoCalibrationAttemptedImageUrl,
   ]);
 
-  const handleFileSelected = (file: File) => {
+  const handleFileSelected = async (file: File) => {
+    const selectionRevision = ++fileSelectionRevisionRef.current;
     if (file.size > MAX_FILE_BYTES) {
       toast({
         title: "File too large",
@@ -361,10 +365,11 @@ function TraceWorkspace(): JSX.Element {
       return;
     }
 
-    const reader = new FileReader();
-    reader.onload = (event) => {
-      if (!event.target?.result) return;
-      const imageUrl = event.target.result as string;
+    setUploadOpen(false);
+    try {
+      const { imageUrl, naturalSize } = await decodeImageFile(file);
+      if (selectionRevision !== fileSelectionRevisionRef.current) return;
+
       // Invalidate outstanding work before React processes the reducer queue;
       // the reducer carries the same guard as the final backstop.
       activeImageUrlRef.current = imageUrl;
@@ -373,9 +378,21 @@ function TraceWorkspace(): JSX.Element {
         imageUrl,
         fileName: file.name.replace(/\.[^/.]+$/, ""),
       });
-      setUploadOpen(false);
-    };
-    reader.readAsDataURL(file);
+      // Publish a non-empty canvas in the same React batch as SOURCE_LOADED.
+      // useImageSource will independently decode and confirm the same size,
+      // but the replacement never flashes or gets stranded at the drop zone.
+      dispatch({
+        type: "SOURCE_READY",
+        imageSize: fitWithin(naturalSize, IMAGE_CANVAS_MAX),
+      });
+    } catch (error) {
+      if (selectionRevision !== fileSelectionRevisionRef.current) return;
+      toast({
+        title: "Could not open that image",
+        description: error instanceof Error ? error.message : String(error),
+        variant: "destructive",
+      });
+    }
   };
 
   const handleExport = async () => {


### PR DESCRIPTION
## Summary
- hide the length label while manually placing scale points and make the completed endpoints easy to drag
- keep inline length editing readable at any canvas zoom
- decode replacement photos before swapping canvas state so rapid or failed replacements cannot leave a blank canvas
- emphasize the template guidance and retain direct A4 and US Letter downloads

## Verification
- npm run check
- npm test (846 tests)
- npm run build
- live browser verification at localhost:5001, including endpoint drag scale recalculation and successive image replacement