### PR TITLE
Add trace image rotation and harden ruler redraw

### DIFF
--- a/client/src/components/trace/trace-canvas-history.test.tsx
+++ b/client/src/components/trace/trace-canvas-history.test.tsx
@@ -318,6 +318,81 @@ describe("TraceCanvas edit history", () => {
     React.act(() => root.unmount());
   });
 
+  it("replaces completed ruler points instead of restoring the old ruler", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("ResizeObserver", NoopResizeObserver);
+    const restoreSvgCoordinates = installIdentitySvgCoordinates();
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    try {
+      await React.act(async () => {
+        root.render(
+          <TraceProvider>
+            <SeedTrace />
+            <ScaleStateProbe />
+            <TooltipProvider>
+              <TraceCanvas onReprocess={() => {}} />
+            </TooltipProvider>
+          </TraceProvider>,
+        );
+        await Promise.resolve();
+      });
+
+      const canvas = host.querySelector("svg");
+      const setScale = host.querySelector<HTMLButtonElement>(
+        '[aria-label="Set scale"]',
+      );
+      expect(canvas).not.toBeNull();
+      expect(setScale).not.toBeNull();
+      expect(host.querySelectorAll('[data-testid="ruler-marker"]')).toHaveLength(2);
+
+      await React.act(async () => {
+        setScale?.click();
+      });
+      expect(host.querySelector('[data-testid="scale-mode"]')?.textContent).toBe(
+        "calibrate",
+      );
+      expect(host.querySelectorAll('[data-testid="ruler-marker"]')).toHaveLength(0);
+
+      for (const [clientX, clientY] of [
+        [20, 30],
+        [75, 85],
+      ]) {
+        await React.act(async () => {
+          canvas?.dispatchEvent(
+            new MouseEvent("pointerdown", {
+              bubbles: true,
+              button: 0,
+              clientX,
+              clientY,
+            }),
+          );
+        });
+      }
+
+      expect(host.querySelector('[data-testid="scale-mode"]')?.textContent).toBe(
+        "pan",
+      );
+      expect(
+        host.querySelector('[data-testid="scale-committed"]')?.textContent,
+      ).toBe("pending");
+      expect(host.querySelector('[data-testid="scale-draft"]')?.textContent).toBe(
+        JSON.stringify({ startX: 20, startY: 30, endX: 75, endY: 85 }),
+      );
+      const line = host.querySelector('[data-testid="ruler-line"]');
+      expect(line?.getAttribute("x1")).toBe("20");
+      expect(line?.getAttribute("y1")).toBe("30");
+      expect(line?.getAttribute("x2")).toBe("75");
+      expect(line?.getAttribute("y2")).toBe("85");
+      expect(line?.getAttribute("data-ruler-preview")).toBe("true");
+    } finally {
+      React.act(() => root.unmount());
+      restoreSvgCoordinates();
+    }
+  });
+
   it("extends the draft ruler to follow the pointer after its first marker", async () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     vi.stubGlobal("ResizeObserver", NoopResizeObserver);

--- a/client/src/components/trace/trace-canvas.tsx
+++ b/client/src/components/trace/trace-canvas.tsx
@@ -87,6 +87,7 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
   const {
     imageUrl,
     imageSize,
+    imageRotation,
     outline,
     selection,
     region,
@@ -229,6 +230,15 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
   // the start of a (failed) drag.
   const clickRef = useRef<{ clientX: number; clientY: number } | null>(null);
   const CLICK_SLOP_PX = 4;
+
+  useEffect(() => {
+    // Pointer previews and active drags belong to the previous image frame;
+    // committed geometry is rotated atomically by the store.
+    dragRef.current = null;
+    clickRef.current = null;
+    setRulerPointer(null);
+    setPerspectivePointer(null);
+  }, [imageRotation]);
 
   /**
    * The vertex currently under the cursor, on the selected ring. Feedback
@@ -613,6 +623,7 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
           sceneRef={sceneRef}
           imageUrl={imageUrl}
           imageSize={imageSize}
+          imageRotation={imageRotation}
           transform={viewport.transform}
           outline={outline}
           selection={selection}

--- a/client/src/components/trace/trace-controls-panel.test.tsx
+++ b/client/src/components/trace/trace-controls-panel.test.tsx
@@ -23,6 +23,7 @@ const CALIBRATION: Calibration = {
 };
 
 const applyPerspective = vi.fn();
+const rotateImage = vi.fn();
 
 class NoopResizeObserver implements ResizeObserver {
   observe() {}
@@ -131,6 +132,7 @@ function Harness(): JSX.Element {
       </button>
       <TraceControlsPanel
         onReplaceImage={() => {}}
+        onRotateImage={rotateImage}
         onExport={() => {}}
         onReprocess={() => {}}
         onDetectMarkers={() => {}}
@@ -145,6 +147,7 @@ let root: Root;
 
 beforeEach(() => {
   applyPerspective.mockReset();
+  rotateImage.mockReset();
   vi.mocked(downloadBlob).mockReset();
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   vi.stubGlobal("ResizeObserver", NoopResizeObserver);
@@ -218,6 +221,13 @@ function sectionTrigger(id: string): HTMLButtonElement | null {
   );
 }
 
+async function clickSection(id: string): Promise<void> {
+  await React.act(async () => {
+    sectionTrigger(id)?.click();
+    await new Promise((resolve) => window.setTimeout(resolve, 10));
+  });
+}
+
 describe("TraceControlsPanel guided workflow", () => {
   it("collapses every section, opens Scale, and pulses its action after source load", async () => {
     expect(host.textContent).toContain("Choose or drop an image");
@@ -280,6 +290,18 @@ describe("TraceControlsPanel guided workflow", () => {
     expect(
       document.body.querySelector('[data-testid="button-template-letter"]'),
     ).not.toBeNull();
+  });
+
+  it("offers clockwise and counterclockwise rotation for a loaded source", async () => {
+    await click("load-source");
+    await clickSection("source");
+
+    expect(section("source")?.textContent).toContain("Rotate left 90°");
+    expect(section("source")?.textContent).toContain("Rotate right 90°");
+    await click("button-rotate-image-counterclockwise");
+    await click("button-rotate-image-clockwise");
+    expect(rotateImage).toHaveBeenNthCalledWith(1, "counterclockwise");
+    expect(rotateImage).toHaveBeenNthCalledWith(2, "clockwise");
   });
 
   it("makes an auto-detected sheet scale explicit and waits for acceptance", async () => {
@@ -474,6 +496,47 @@ describe("TraceControlsPanel guided workflow", () => {
     expect(host.textContent).toContain(
       "Click and drag on the image",
     );
+  });
+
+  it("keeps Scale active when Redraw ruler is clicked from the length field", async () => {
+    await click("load-source");
+    await click("complete-manual-scale");
+    await changeNumber("ruler-length", "50");
+
+    const input = host.querySelector<HTMLInputElement>("#ruler-length");
+    const redraw = host.querySelector<HTMLButtonElement>(
+      '[data-testid="button-set-scale"]',
+    );
+    expect(document.activeElement).toBe(input);
+    expect(redraw?.textContent).toBe("Redraw ruler");
+
+    // A real pointer click transfers focus before `click`, so the input's blur
+    // fires first. The redraw intent must suppress that stale scale commit or
+    // the guided workflow advances and remounts the button mid-interaction.
+    await React.act(async () => {
+      const pointerDown = new MouseEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+      });
+      redraw?.dispatchEvent(pointerDown);
+      input?.blur();
+      await Promise.resolve();
+    });
+    await React.act(async () => {
+      redraw?.dispatchEvent(new MouseEvent("pointerup", { bubbles: true }));
+      redraw?.click();
+      await new Promise((resolve) => window.setTimeout(resolve, 10));
+    });
+
+    expect(section("scale")?.dataset.state).toBe("open");
+    expect(section("crop")?.dataset.state).toBe("closed");
+    expect(sectionTrigger("crop")?.disabled).toBe(true);
+    expect(
+      host.querySelector('[data-testid="button-set-scale"]')?.textContent,
+    ).toBe("Placing ruler");
+    expect(
+      host.querySelector('[data-testid="manual-scale-guidance"]'),
+    ).not.toBeNull();
   });
 
   it("updates the displayed manual scale when the reference length changes", async () => {

--- a/client/src/components/trace/trace-controls-panel.tsx
+++ b/client/src/components/trace/trace-controls-panel.tsx
@@ -7,6 +7,7 @@ import {
   Image as ImageIcon,
   Ruler,
   RotateCcw,
+  RotateCw,
   ScanLine,
   ScanSearch,
   Sparkles,
@@ -57,6 +58,7 @@ import { downloadCalibrationTemplate } from "@/lib/calibrate/download-template";
 import type { TemplatePaper } from "@/lib/calibrate/template";
 import { describeScale, exportScale } from "@/lib/export/scale";
 import { normalizeTracedShape } from "@/lib/gridfinity/traced-shape";
+import type { ImageRotationDirection } from "@/lib/geometry/image-rotation";
 import {
   adjustOutlineMargin,
   MARGIN_MM_OPTIONS,
@@ -73,6 +75,7 @@ const RESPONSIVE_PANEL_ACTION =
 
 export interface TraceControlsPanelProps {
   onReplaceImage: () => void;
+  onRotateImage: (direction: ImageRotationDirection) => void;
   onExport: () => void;
   onReprocess: () => void;
   /** Re-run ArUco marker detection on the full frame, with feedback. */
@@ -105,6 +108,7 @@ const TRACE_SETTINGS_SECTION_DETAILS = [
  */
 export function TraceControlsPanel({
   onReplaceImage,
+  onRotateImage,
   onExport,
   onReprocess,
   onDetectMarkers,
@@ -203,6 +207,10 @@ export function TraceControlsPanel({
   const previousAutoPending = useRef(pendingAutoCalibration !== null);
   const previousManualRulerPending = useRef(manualRulerPending);
   const previousMode = useRef(store.mode);
+  // Pointer-down precedes the reference-length input's blur. Remember that
+  // Redraw owns this particular blur so it cannot confirm the ruler the user
+  // is explicitly trying to replace.
+  const redrawRulerRequested = useRef(false);
   const focusWhenReady = useRef<
     "scale" | "auto" | "length" | "region" | "detection" | null
   >(null);
@@ -388,13 +396,16 @@ export function TraceControlsPanel({
   };
 
   const handleSetScale = () => {
-    if (manualRulerPending) {
-      dispatch({ type: "SET_DRAFT_CALIBRATION", draftCalibration: null });
+    const nextMode = store.mode === "calibrate" ? "pan" : "calibrate";
+    if (nextMode === "calibrate") {
+      setGuidedSection("scale");
+      focusWhenReady.current = null;
     }
     dispatch({
       type: "SET_MODE",
-      mode: store.mode === "calibrate" ? "pan" : "calibrate",
+      mode: nextMode,
     });
+    redrawRulerRequested.current = false;
   };
 
   return (
@@ -434,6 +445,28 @@ export function TraceControlsPanel({
               >
                 Choose Source Image
               </Button>
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={processing}
+                  onClick={() => onRotateImage("counterclockwise")}
+                  data-testid="button-rotate-image-counterclockwise"
+                >
+                  <RotateCcw className="mr-1.5 h-4 w-4" />
+                  Rotate left 90°
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={processing}
+                  onClick={() => onRotateImage("clockwise")}
+                  data-testid="button-rotate-image-clockwise"
+                >
+                  <RotateCw className="mr-1.5 h-4 w-4" />
+                  Rotate right 90°
+                </Button>
+              </div>
             </>
           ) : (
             <div className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
@@ -536,6 +569,16 @@ export function TraceControlsPanel({
             )}
             data-testid="button-set-scale"
             disabled={!hasImage}
+            onPointerDown={() => {
+              redrawRulerRequested.current =
+                store.mode !== "calibrate" && manualRulerPending;
+            }}
+            onPointerCancel={() => {
+              redrawRulerRequested.current = false;
+            }}
+            onPointerLeave={() => {
+              redrawRulerRequested.current = false;
+            }}
             onClick={handleSetScale}
           >
             {store.mode === "calibrate"
@@ -597,6 +640,7 @@ export function TraceControlsPanel({
                 dispatch({ type: "SET_RULER_LENGTH", rulerLengthMm: value })
               }
               onValueCommit={(value) => {
+                if (redrawRulerRequested.current) return;
                 const completed = calibrationFromDraft(
                   draftCalibration,
                   value,

--- a/client/src/components/trace/trace-scene.test.tsx
+++ b/client/src/components/trace/trace-scene.test.tsx
@@ -24,6 +24,7 @@ function renderRuler({
   perspectivePoints = [],
   perspectiveEditable = false,
   perspectivePreview = null,
+  imageRotation = 0,
 }: {
   completed?: Calibration | null;
   draft?: DraftCalibration | null;
@@ -32,11 +33,13 @@ function renderRuler({
   perspectivePoints?: readonly Point[];
   perspectiveEditable?: boolean;
   perspectivePreview?: Point | null;
+  imageRotation?: 0 | 1 | 2 | 3;
 }): string {
   return renderToStaticMarkup(
     <TraceScene
       imageUrl="data:image/png;base64,AA=="
       imageSize={{ width: 200, height: 100 }}
+      imageRotation={imageRotation}
       transform={{ scale: 1, translateX: 0, translateY: 0 }}
       outline={[]}
       selection={null}
@@ -57,6 +60,17 @@ function count(markup: string, fragment: string): number {
 }
 
 describe("TraceScene ruler overlay", () => {
+  it("rotates the displayed source image into the working frame", () => {
+    const clockwise = renderRuler({ imageRotation: 1 });
+    expect(clockwise).toContain('data-testid="trace-source-image"');
+    expect(clockwise).toContain('width="100"');
+    expect(clockwise).toContain('height="200"');
+    expect(clockwise).toContain('transform="translate(200 0) rotate(90)"');
+
+    const counterclockwise = renderRuler({ imageRotation: 3 });
+    expect(counterclockwise).toContain('transform="translate(0 100) rotate(-90)"');
+  });
+
   it("renders completed endpoints as persistent X markers with a length label", () => {
     const markup = renderRuler({ completed: calibration });
 

--- a/client/src/components/trace/trace-scene.tsx
+++ b/client/src/components/trace/trace-scene.tsx
@@ -19,6 +19,7 @@ import {
 
 import { iterateRings, sameRingRef } from "@/lib/geometry/outline";
 import { outlineToPathData } from "@/lib/export/svg";
+import type { ImageQuarterTurns } from "@/lib/geometry/image-rotation";
 
 /** The viewport transform applied to the whole scene. */
 export interface SceneTransform {
@@ -30,6 +31,7 @@ export interface SceneTransform {
 export interface TraceSceneProps {
   imageUrl: string;
   imageSize: { width: number; height: number };
+  imageRotation?: ImageQuarterTurns;
   transform: SceneTransform;
   outline: Outline;
   selection: RingRef | null;
@@ -108,6 +110,7 @@ const PERSPECTIVE_HIT_RADIUS = 15;
 export function TraceScene({
   imageUrl,
   imageSize,
+  imageRotation = 0,
   transform,
   outline,
   selection,
@@ -160,7 +163,12 @@ export function TraceScene({
         ref={sceneRef}
         transform={`translate(${translateX} ${translateY}) scale(${scale})`}
       >
-        <SourceImage url={imageUrl} width={imageSize.width} height={imageSize.height} />
+        <SourceImage
+          url={imageUrl}
+          width={imageSize.width}
+          height={imageSize.height}
+          rotation={imageRotation}
+        />
 
         {/* The traced material, with holes punched out by the even-odd rule. */}
         {fillPath && (
@@ -286,20 +294,35 @@ const SourceImage = memo(function SourceImage({
   url,
   width,
   height,
+  rotation,
 }: {
   url: string;
   width: number;
   height: number;
+  rotation: ImageQuarterTurns;
 }) {
   if (width <= 0 || height <= 0) return null;
+  const turned = rotation % 2 === 1;
+  const sourceWidth = turned ? height : width;
+  const sourceHeight = turned ? width : height;
+  const imageTransform =
+    rotation === 1
+      ? `translate(${width} 0) rotate(90)`
+      : rotation === 2
+        ? `translate(${width} ${height}) rotate(180)`
+        : rotation === 3
+          ? `translate(0 ${height}) rotate(-90)`
+          : undefined;
   return (
     <image
       href={url}
       x={0}
       y={0}
-      width={width}
-      height={height}
+      width={sourceWidth}
+      height={sourceHeight}
+      transform={imageTransform}
       preserveAspectRatio="none"
+      data-testid="trace-source-image"
     />
   );
 });

--- a/client/src/components/trace/use-image-source.test.ts
+++ b/client/src/components/trace/use-image-source.test.ts
@@ -5,6 +5,7 @@ import {
   DETECTION_CANVAS_MAX,
   decodeImageFile,
   detectionGeometry,
+  drawImageWithRotation,
   fitWithin,
   IMAGE_CANVAS_MAX,
 } from "./use-image-source";
@@ -125,6 +126,43 @@ describe("IMAGE_CANVAS_MAX", () => {
     // calibration. If it ever tracked the display size, exports would silently
     // change dimensions with no visible symptom.
     expect(IMAGE_CANVAS_MAX).toEqual({ width: 800, height: 600 });
+  });
+});
+
+describe("drawImageWithRotation", () => {
+  it("rotates the working raster clockwise into swapped dimensions", () => {
+    const context = {
+      save: vi.fn(),
+      translate: vi.fn(),
+      rotate: vi.fn(),
+      drawImage: vi.fn(),
+      restore: vi.fn(),
+    } as unknown as CanvasRenderingContext2D;
+    const image = {} as CanvasImageSource;
+
+    drawImageWithRotation(context, image, { width: 300, height: 400 }, 1);
+
+    expect(context.translate).toHaveBeenCalledWith(300, 0);
+    expect(context.rotate).toHaveBeenCalledWith(Math.PI / 2);
+    expect(context.drawImage).toHaveBeenCalledWith(image, 0, 0, 400, 300);
+    expect(context.restore).toHaveBeenCalledOnce();
+  });
+
+  it("rotates the detection raster counterclockwise", () => {
+    const context = {
+      save: vi.fn(),
+      translate: vi.fn(),
+      rotate: vi.fn(),
+      drawImage: vi.fn(),
+      restore: vi.fn(),
+    } as unknown as CanvasRenderingContext2D;
+    const image = {} as CanvasImageSource;
+
+    drawImageWithRotation(context, image, { width: 300, height: 400 }, 3);
+
+    expect(context.translate).toHaveBeenCalledWith(0, 400);
+    expect(context.rotate).toHaveBeenCalledWith(-Math.PI / 2);
+    expect(context.drawImage).toHaveBeenCalledWith(image, 0, 0, 400, 300);
   });
 });
 

--- a/client/src/components/trace/use-image-source.ts
+++ b/client/src/components/trace/use-image-source.ts
@@ -2,6 +2,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { Rect } from "@shared/geometry/types";
 
+import {
+  fitImageWithin,
+  rotatedImageDimensions,
+  type ImageQuarterTurns,
+} from "@/lib/geometry/image-rotation";
+
 /**
  * Owns image decoding and the offscreen canvas that pixels are read from.
  *
@@ -132,22 +138,44 @@ export interface UseImageSourceResult {
 
 /** Fits `natural` inside `max` without changing its aspect ratio. */
 export function fitWithin(natural: Size, max: Size): Size {
-  let { width, height } = natural;
-  if (width > max.width) {
-    height = (max.width / width) * height;
-    width = max.width;
+  return fitImageWithin(natural, max);
+}
+
+/** Draws the decoded source into a canvas using its selected quarter-turn. */
+export function drawImageWithRotation(
+  context: CanvasRenderingContext2D,
+  image: CanvasImageSource,
+  target: Size,
+  rotation: ImageQuarterTurns,
+): void {
+  context.save();
+  switch (rotation) {
+    case 1:
+      context.translate(target.width, 0);
+      context.rotate(Math.PI / 2);
+      context.drawImage(image, 0, 0, target.height, target.width);
+      break;
+    case 2:
+      context.translate(target.width, target.height);
+      context.rotate(Math.PI);
+      context.drawImage(image, 0, 0, target.width, target.height);
+      break;
+    case 3:
+      context.translate(0, target.height);
+      context.rotate(-Math.PI / 2);
+      context.drawImage(image, 0, 0, target.height, target.width);
+      break;
+    default:
+      context.drawImage(image, 0, 0, target.width, target.height);
   }
-  if (height > max.height) {
-    width = (max.height / height) * width;
-    height = max.height;
-  }
-  return { width: Math.max(1, Math.round(width)), height: Math.max(1, Math.round(height)) };
+  context.restore();
 }
 
 export function useImageSource(
   url: string | null,
   fileName = "",
   max: Size = IMAGE_CANVAS_MAX,
+  rotation: ImageQuarterTurns = 0,
 ): UseImageSourceResult {
   const [source, setSource] = useState<ImageSource>({ status: "empty" });
   // Created imperatively: it is a pixel buffer, not part of the view.
@@ -178,7 +206,7 @@ export function useImageSource(
       if (cancelled) return;
 
       const naturalSize = { width: image.width, height: image.height };
-      const size = fitWithin(naturalSize, max);
+      const size = fitWithin(rotatedImageDimensions(naturalSize, rotation), max);
 
       const canvas = canvasRef.current ?? document.createElement("canvas");
       canvasRef.current = canvas;
@@ -196,7 +224,7 @@ export function useImageSource(
         return;
       }
 
-      ctx.drawImage(image, 0, 0, size.width, size.height);
+      drawImageWithRotation(ctx, image, size, rotation);
       imageRef.current = image;
       setSource({ status: "ready", url, fileName, size, naturalSize });
     };
@@ -217,7 +245,7 @@ export function useImageSource(
     return () => {
       cancelled = true;
     };
-  }, [url, fileName, max]);
+  }, [url, fileName, max, rotation]);
 
   const getImageData = useCallback(
     (region?: Rect | null): ImageData | null => {
@@ -247,20 +275,24 @@ export function useImageSource(
     const image = imageRef.current;
     if (!image || source.status !== "ready") return null;
 
-    const { detect, toWorking } = detectionGeometry(source.naturalSize, max);
+    const orientedNaturalSize = rotatedImageDimensions(
+      source.naturalSize,
+      rotation,
+    );
+    const { detect, toWorking } = detectionGeometry(orientedNaturalSize, max);
     const canvas = document.createElement("canvas");
     canvas.width = detect.width;
     canvas.height = detect.height;
     const ctx = canvas.getContext("2d", { willReadFrequently: true });
     if (!ctx) return null;
 
-    ctx.drawImage(image, 0, 0, detect.width, detect.height);
+    drawImageWithRotation(ctx, image, detect, rotation);
     return {
       imageData: ctx.getImageData(0, 0, detect.width, detect.height),
       toWorking,
       sourceImageUrl: source.url,
     };
-  }, [source, max]);
+  }, [source, max, rotation]);
 
   return { source, getImageData, getDetectionFrame };
 }

--- a/client/src/components/trace/use-outline-refinement.test.tsx
+++ b/client/src/components/trace/use-outline-refinement.test.tsx
@@ -176,4 +176,64 @@ describe("useOutlineRefinement", () => {
     expect(mounted.store().margin).toBe(2);
     mounted.unmount();
   });
+
+  it("does not apply the scale-dependent margin a second time after rotation", async () => {
+    const refiner = vi.fn<OutlineRefiner>(async (outline) => outline);
+    const offsetter = vi.fn<OutlineOffsetter>(async (outline) => outline);
+    const mounted = mountHook(refiner, offsetter);
+
+    React.act(() => {
+      mounted.store().dispatch({
+        type: "SOURCE_LOADED",
+        imageUrl: "data:image/png;base64,AA==",
+        fileName: "tool",
+      });
+      mounted.store().dispatch({
+        type: "SOURCE_READY",
+        imageSize: { width: 20, height: 10 },
+      });
+      mounted.store().dispatch({
+        type: "SET_CALIBRATION",
+        calibration: {
+          startX: 0,
+          startY: 0,
+          endX: 20,
+          endY: 0,
+          lengthMm: 10,
+        },
+      });
+      mounted.store().dispatch({
+        type: "DETECTED",
+        imageUrl: "data:image/png;base64,AA==",
+        outline: OUTLINE,
+        rawOutline: OUTLINE,
+        svg: "<svg/>",
+        region: null,
+      });
+    });
+    await React.act(async () => Promise.resolve());
+    refiner.mockClear();
+    offsetter.mockClear();
+
+    await React.act(async () => {
+      mounted.store().dispatch({
+        type: "ROTATE_SOURCE",
+        direction: "clockwise",
+        naturalSize: { width: 20, height: 10 },
+        maxSize: { width: 800, height: 600 },
+      });
+      await Promise.resolve();
+    });
+
+    expect(refiner).not.toHaveBeenCalled();
+    expect(offsetter).not.toHaveBeenCalled();
+    expect(mounted.store().imageSize).toEqual({ width: 10, height: 20 });
+    expect(mounted.store().outline[0].outer).toEqual([
+      { x: 10, y: 0 },
+      { x: 10, y: 20 },
+      { x: 0, y: 20 },
+      { x: 0, y: 0 },
+    ]);
+    mounted.unmount();
+  });
 });

--- a/client/src/components/trace/use-outline-refinement.ts
+++ b/client/src/components/trace/use-outline-refinement.ts
@@ -44,20 +44,29 @@ export function useOutlineRefinement(
     smoothing,
     margin,
     calibration,
+    imageRotation,
     dispatch,
   } = useTrace();
   const detectionSignature = JSON.stringify([tolerancePx, smoothing]);
   const scaleMmPerPx = mmPerPixel(calibration);
   const previousDetectionSignature = useRef(detectionSignature);
   const previousScaleMmPerPx = useRef(scaleMmPerPx);
+  const previousImageRotation = useRef(imageRotation);
 
   useEffect(() => {
     const detectionSettingsChanged =
       previousDetectionSignature.current !== detectionSignature;
     const previousMmPerPx = previousScaleMmPerPx.current;
     const scaleChanged = previousMmPerPx !== scaleMmPerPx;
+    const imageRotated = previousImageRotation.current !== imageRotation;
     previousDetectionSignature.current = detectionSignature;
     previousScaleMmPerPx.current = scaleMmPerPx;
+    previousImageRotation.current = imageRotation;
+
+    // ROTATE_SOURCE already transforms the margin-bearing edited outline and
+    // its calibration into the new pixel scale atomically. Applying the usual
+    // scale-change offset again would double-adjust the physical margin.
+    if (imageRotated) return;
 
     // DETECTED already applies the current settings. Detail and smoothing are
     // intentionally re-derived from the dense detector result. Margin changes,
@@ -101,6 +110,7 @@ export function useOutlineRefinement(
     margin,
     detectionSignature,
     scaleMmPerPx,
+    imageRotation,
     dispatch,
     refineOutline,
     offsetEditedOutline,

--- a/client/src/lib/geometry/image-rotation.test.ts
+++ b/client/src/lib/geometry/image-rotation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  combineImageRotations,
+  fitImageWithin,
+  nextImageRotation,
+  rotateImageOutline,
+  rotateImagePoint,
+  rotateImageRect,
+  rotatedImageDimensions,
+} from "./image-rotation";
+
+describe("image quarter-turn geometry", () => {
+  it("tracks clockwise and counterclockwise orientations", () => {
+    expect(nextImageRotation(0, "clockwise")).toBe(1);
+    expect(nextImageRotation(0, "counterclockwise")).toBe(3);
+    expect(nextImageRotation(3, "clockwise")).toBe(0);
+    expect(nextImageRotation(1, "counterclockwise")).toBe(0);
+    expect(combineImageRotations(3, 2)).toBe(1);
+    expect(rotatedImageDimensions({ width: 800, height: 600 }, 1)).toEqual({
+      width: 600,
+      height: 800,
+    });
+  });
+
+  it("rotates points and regions in both directions", () => {
+    const source = { width: 200, height: 100 };
+    const target = { width: 100, height: 200 };
+    expect(rotateImagePoint({ x: 20, y: 30 }, source, target, "clockwise")).toEqual({
+      x: 70,
+      y: 20,
+    });
+    expect(
+      rotateImagePoint({ x: 20, y: 30 }, source, target, "counterclockwise"),
+    ).toEqual({ x: 30, y: 180 });
+    expect(
+      rotateImageRect(
+        { x: 10, y: 20, width: 40, height: 30 },
+        source,
+        target,
+        "clockwise",
+      ),
+    ).toEqual({ x: 50, y: 10, width: 30, height: 40 });
+  });
+
+  it("includes a changed fit-to-cap scale in the geometry transform", () => {
+    const source = fitImageWithin(
+      { width: 4000, height: 3000 },
+      { width: 800, height: 600 },
+    );
+    const target = fitImageWithin(
+      { width: 3000, height: 4000 },
+      { width: 800, height: 600 },
+    );
+    expect(source).toEqual({ width: 800, height: 600 });
+    expect(target).toEqual({ width: 450, height: 600 });
+    expect(
+      rotateImageOutline(
+        [{ outer: [{ x: 0, y: 0 }, { x: 800, y: 0 }, { x: 800, y: 600 }], holes: [] }],
+        source,
+        target,
+        "clockwise",
+      )[0].outer,
+    ).toEqual([
+      { x: 450, y: 0 },
+      { x: 450, y: 600 },
+      { x: 0, y: 600 },
+    ]);
+  });
+});

--- a/client/src/lib/geometry/image-rotation.ts
+++ b/client/src/lib/geometry/image-rotation.ts
@@ -1,0 +1,187 @@
+import type { Calibration, DraftCalibration } from "@shared/geometry/scale";
+import type { Outline, Point, Rect } from "@shared/geometry/types";
+
+import { mapOutline } from "./outline";
+
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+/** Clockwise quarter-turns from the decoded source image. */
+export type ImageQuarterTurns = 0 | 1 | 2 | 3;
+export type ImageRotationDirection = "clockwise" | "counterclockwise";
+
+/** Advances a source-image orientation by exactly 90 degrees. */
+export function nextImageRotation(
+  current: ImageQuarterTurns,
+  direction: ImageRotationDirection,
+): ImageQuarterTurns {
+  return ((current + (direction === "clockwise" ? 1 : 3)) % 4) as ImageQuarterTurns;
+}
+
+/** Applies a relative orientation to an already-oriented source. */
+export function combineImageRotations(
+  base: ImageQuarterTurns,
+  relative: ImageQuarterTurns,
+): ImageQuarterTurns {
+  return ((base + relative) % 4) as ImageQuarterTurns;
+}
+
+/** Dimensions after applying an orientation to the decoded source. */
+export function rotatedImageDimensions(
+  size: ImageDimensions,
+  rotation: ImageQuarterTurns,
+): ImageDimensions {
+  return rotation % 2 === 0
+    ? { width: size.width, height: size.height }
+    : { width: size.height, height: size.width };
+}
+
+/** Fits dimensions inside a cap without changing their aspect ratio. */
+export function fitImageWithin(
+  natural: ImageDimensions,
+  max: ImageDimensions,
+): ImageDimensions {
+  let { width, height } = natural;
+  if (width > max.width) {
+    height = (max.width / width) * height;
+    width = max.width;
+  }
+  if (height > max.height) {
+    width = (max.height / height) * width;
+    height = max.height;
+  }
+  return {
+    width: Math.max(1, Math.round(width)),
+    height: Math.max(1, Math.round(height)),
+  };
+}
+
+/**
+ * Rotates a point between two working-resolution image frames.
+ *
+ * The target may use a different fit-to-cap scale after width and height swap,
+ * so the transform includes the exact per-axis ratios rather than assuming the
+ * new frame is merely the old dimensions reversed.
+ */
+export function rotateImagePoint(
+  point: Point,
+  source: ImageDimensions,
+  target: ImageDimensions,
+  direction: ImageRotationDirection,
+): Point {
+  if (
+    source.width <= 0 ||
+    source.height <= 0 ||
+    target.width <= 0 ||
+    target.height <= 0
+  ) {
+    return point;
+  }
+
+  const scaleX = target.width / source.height;
+  const scaleY = target.height / source.width;
+  return direction === "clockwise"
+    ? {
+        x: (source.height - point.y) * scaleX,
+        y: point.x * scaleY,
+      }
+    : {
+        x: point.y * scaleX,
+        y: (source.width - point.x) * scaleY,
+      };
+}
+
+/** Rotates every ring without changing its shell/hole winding. */
+export function rotateImageOutline(
+  outline: Outline,
+  source: ImageDimensions,
+  target: ImageDimensions,
+  direction: ImageRotationDirection,
+): Outline {
+  return mapOutline(outline, (point) =>
+    rotateImagePoint(point, source, target, direction),
+  );
+}
+
+/** Rotates an axis-aligned detection region into the new image frame. */
+export function rotateImageRect(
+  rect: Rect,
+  source: ImageDimensions,
+  target: ImageDimensions,
+  direction: ImageRotationDirection,
+): Rect {
+  const corners = [
+    { x: rect.x, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y + rect.height },
+    { x: rect.x, y: rect.y + rect.height },
+  ].map((point) => rotateImagePoint(point, source, target, direction));
+  const xs = corners.map(({ x }) => x);
+  const ys = corners.map(({ y }) => y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+/** Rotates the endpoints while preserving their known physical length. */
+export function rotateImageCalibration(
+  calibration: Calibration,
+  source: ImageDimensions,
+  target: ImageDimensions,
+  direction: ImageRotationDirection,
+): Calibration {
+  const start = rotateImagePoint(
+    { x: calibration.startX, y: calibration.startY },
+    source,
+    target,
+    direction,
+  );
+  const end = rotateImagePoint(
+    { x: calibration.endX, y: calibration.endY },
+    source,
+    target,
+    direction,
+  );
+  return {
+    startX: start.x,
+    startY: start.y,
+    endX: end.x,
+    endY: end.y,
+    lengthMm: calibration.lengthMm,
+  };
+}
+
+/** Rotates whichever complete endpoint pairs an in-progress ruler contains. */
+export function rotateDraftCalibration(
+  draft: DraftCalibration,
+  source: ImageDimensions,
+  target: ImageDimensions,
+  direction: ImageRotationDirection,
+): DraftCalibration {
+  const rotated = { ...draft };
+  if (draft.startX !== undefined && draft.startY !== undefined) {
+    const start = rotateImagePoint(
+      { x: draft.startX, y: draft.startY },
+      source,
+      target,
+      direction,
+    );
+    rotated.startX = start.x;
+    rotated.startY = start.y;
+  }
+  if (draft.endX !== undefined && draft.endY !== undefined) {
+    const end = rotateImagePoint(
+      { x: draft.endX, y: draft.endY },
+      source,
+      target,
+      direction,
+    );
+    rotated.endX = end.x;
+    rotated.endY = end.y;
+  }
+  return rotated;
+}

--- a/client/src/pages/trace.tsx
+++ b/client/src/pages/trace.tsx
@@ -40,6 +40,7 @@ import { generateDXF } from "@/lib/export/dxf";
 import { exportScale } from "@/lib/export/scale";
 import { generateSTL } from "@/lib/export/stl";
 import { generateOutlineSVG } from "@/lib/export/svg";
+import type { ImageRotationDirection } from "@/lib/geometry/image-rotation";
 import { processImage } from "@/lib/image-processor";
 import { useTrace } from "@/state/trace-store";
 
@@ -72,10 +73,14 @@ function TraceWorkspace(): JSX.Element {
   const [uploadOpen, setUploadOpen] = useState(false);
   const [dwgDialogOpen, setDwgDialogOpen] = useState(false);
 
+  const workingImageMax = store.perspectiveCorrection
+    ? RECTIFIED_IMAGE_MAX
+    : IMAGE_CANVAS_MAX;
   const { source, getImageData, getDetectionFrame } = useImageSource(
     store.imageUrl,
     store.fileName,
-    store.perspectiveCorrection ? RECTIFIED_IMAGE_MAX : IMAGE_CANVAS_MAX,
+    workingImageMax,
+    store.imageRotation,
   );
   useOutlineRefinement();
 
@@ -184,92 +189,99 @@ function TraceWorkspace(): JSX.Element {
       const frame = getDetectionFrame();
       if (!frame) return;
 
-      const result = await autoCalibrate(frame.imageData);
-      // OpenCV work cannot be cancelled once running. Bind its result to the
-      // pixels it actually read so an old sheet can never paint overlays or
-      // toasts over a replacement image.
-      if (activeImageUrlRef.current !== frame.sourceImageUrl) return;
-      if (!manual && result.kind !== "calibrated") {
-        dispatch({
-          type: "AUTO_CALIBRATION_FAILED",
-          sourceImageUrl: frame.sourceImageUrl,
-        });
-      }
-      switch (result.kind) {
-        case "calibrated": {
-          const calibration = {
-            startX: result.calibration.startX * frame.toWorking.x,
-            startY: result.calibration.startY * frame.toWorking.y,
-            endX: result.calibration.endX * frame.toWorking.x,
-            endY: result.calibration.endY * frame.toWorking.y,
-            lengthMm: result.calibration.lengthMm,
-          };
+      dispatch({ type: "SET_PROCESSING", processing: true });
+      try {
+        const result = await autoCalibrate(frame.imageData);
+        // OpenCV work cannot be cancelled once running. Bind its result to the
+        // pixels it actually read so an old sheet can never paint overlays or
+        // toasts over a replacement image.
+        if (activeImageUrlRef.current !== frame.sourceImageUrl) return;
+        if (!manual && result.kind !== "calibrated") {
           dispatch({
-            type: "AUTO_CALIBRATION_DETECTED",
+            type: "AUTO_CALIBRATION_FAILED",
             sourceImageUrl: frame.sourceImageUrl,
-            calibration,
-            perspective: result.perspectiveProposal
-              ? scalePerspectiveProposal(
-                  result.perspectiveProposal,
-                  frame.toWorking.x,
-                  frame.toWorking.y,
-                )
-              : null,
           });
-          const { solution } = result;
-          const mmPerPx = mmPerPixel(calibration);
-          const paperName = result.paper === "a4" ? "A4" : "US Letter";
-          const summary = `${paperName} · ${solution.markerIds.length} markers · ${(mmPerPx ?? solution.mmPerPx).toFixed(3)} mm/px`;
-          if (solution.maxDeviation > SKEW_WARN_FRACTION) {
+        }
+        switch (result.kind) {
+          case "calibrated": {
+            const calibration = {
+              startX: result.calibration.startX * frame.toWorking.x,
+              startY: result.calibration.startY * frame.toWorking.y,
+              endX: result.calibration.endX * frame.toWorking.x,
+              endY: result.calibration.endY * frame.toWorking.y,
+              lengthMm: result.calibration.lengthMm,
+            };
+            dispatch({
+              type: "AUTO_CALIBRATION_DETECTED",
+              sourceImageUrl: frame.sourceImageUrl,
+              calibration,
+              perspective: result.perspectiveProposal
+                ? scalePerspectiveProposal(
+                    result.perspectiveProposal,
+                    frame.toWorking.x,
+                    frame.toWorking.y,
+                  )
+                : null,
+            });
+            const { solution } = result;
+            const mmPerPx = mmPerPixel(calibration);
+            const paperName = result.paper === "a4" ? "A4" : "US Letter";
+            const summary = `${paperName} · ${solution.markerIds.length} markers · ${(mmPerPx ?? solution.mmPerPx).toFixed(3)} mm/px`;
+            if (solution.maxDeviation > SKEW_WARN_FRACTION) {
+              toast({
+                title: "Scale detected — review carefully",
+                description: `${summary}. Marker distances disagree by ${(solution.maxDeviation * 100).toFixed(1)}%. ${result.perspectiveProposal ? "Perspective correction is available in Scale." : "Shoot straight down for accurate millimetres."}`,
+                variant: "destructive",
+                duration: 8000,
+              });
+            } else {
+              toast({
+                title: "Scale detected from calibration sheet",
+                description: `${summary}. Review and accept it in Scale.`,
+              });
+            }
+            break;
+          }
+          case "foreign-sheet":
             toast({
-              title: "Scale detected — review carefully",
-              description: `${summary}. Marker distances disagree by ${(solution.maxDeviation * 100).toFixed(1)}%. ${result.perspectiveProposal ? "Perspective correction is available in Scale." : "Shoot straight down for accurate millimetres."}`,
-              variant: "destructive",
+              title:
+                result.reason === "incomplete-signature"
+                  ? "Incomplete Pocketry sheet detected"
+                  : result.reason === "invalid-geometry"
+                    ? "Calibration sheet rejected"
+                    : "Different marker sheet detected",
+              description:
+                result.reason === "incomplete-signature"
+                  ? `Pocketry found ${result.markerIds.length} of the 4 required v2 signature markers. Keep the complete current sheet visible and try again.`
+                  : result.reason === "invalid-geometry"
+                    ? "The v2 marker IDs were present, but their 16 corners do not fit Pocketry's signed sheet geometry. No scale was proposed."
+                    : "These are stock or third-party markers, not the Pocketry v2 signature. Print the current Pocketry sheet or set scale manually.",
               duration: 8000,
             });
-          } else {
-            toast({
-              title: "Scale detected from calibration sheet",
-              description: `${summary}. Review and accept it in Scale.`,
-            });
-          }
-          break;
+            break;
+          case "no-markers":
+            if (manual) {
+              toast({
+                title: "No markers found",
+                description:
+                  "Include the printed calibration sheet in the photo, flat and unobstructed.",
+              });
+            }
+            break;
+          case "unsupported":
+            if (manual) {
+              toast({
+                title: "Marker detection unavailable",
+                description: "OpenCV failed to load in this browser session.",
+                variant: "destructive",
+              });
+            }
+            break;
         }
-        case "foreign-sheet":
-          toast({
-            title:
-              result.reason === "incomplete-signature"
-                ? "Incomplete Pocketry sheet detected"
-                : result.reason === "invalid-geometry"
-                  ? "Calibration sheet rejected"
-                  : "Different marker sheet detected",
-            description:
-              result.reason === "incomplete-signature"
-                ? `Pocketry found ${result.markerIds.length} of the 4 required v2 signature markers. Keep the complete current sheet visible and try again.`
-                : result.reason === "invalid-geometry"
-                  ? "The v2 marker IDs were present, but their 16 corners do not fit Pocketry's signed sheet geometry. No scale was proposed."
-                  : "These are stock or third-party markers, not the Pocketry v2 signature. Print the current Pocketry sheet or set scale manually.",
-            duration: 8000,
-          });
-          break;
-        case "no-markers":
-          if (manual) {
-            toast({
-              title: "No markers found",
-              description:
-                "Include the printed calibration sheet in the photo, flat and unobstructed.",
-            });
-          }
-          break;
-        case "unsupported":
-          if (manual) {
-            toast({
-              title: "Marker detection unavailable",
-              description: "OpenCV failed to load in this browser session.",
-              variant: "destructive",
-            });
-          }
-          break;
+      } finally {
+        if (activeImageUrlRef.current === frame.sourceImageUrl) {
+          dispatch({ type: "SET_PROCESSING", processing: false });
+        }
       }
     },
     [getDetectionFrame, dispatch, toast],
@@ -395,6 +407,18 @@ function TraceWorkspace(): JSX.Element {
     }
   };
 
+  const handleRotateImage = useCallback(
+    (direction: ImageRotationDirection) => {
+      if (source.status !== "ready" || store.processing) return;
+      dispatch({
+        type: "ROTATE_SOURCE",
+        direction,
+        naturalSize: source.naturalSize,
+        maxSize: workingImageMax,
+      });
+    }, [source, store.processing, dispatch, workingImageMax],
+  );
+
   const handleExport = async () => {
     const { outline, imageSize, exportFormat, extrusionHeight, fileName } = store;
     if (outline.length === 0) {
@@ -482,6 +506,7 @@ function TraceWorkspace(): JSX.Element {
         panel={
           <TraceControlsPanel
             onReplaceImage={() => setUploadOpen(true)}
+            onRotateImage={handleRotateImage}
             onExport={() => void handleExport()}
             onReprocess={() => void runDetection()}
             onDetectMarkers={() => void detectMarkers(true)}

--- a/client/src/state/trace-store.test.ts
+++ b/client/src/state/trace-store.test.ts
@@ -293,6 +293,77 @@ describe("loading a new image", () => {
     expect(replaced.detectedImageUrl).toBeNull();
     expect(replaced.autoCalibrationAttemptedImageUrl).toBeNull();
   });
+
+  it("rotates the working image, trace geometry, ruler, region, and history", () => {
+    const calibration = {
+      startX: 10,
+      startY: 20,
+      endX: 110,
+      endY: 20,
+      lengthMm: 50,
+    };
+    const ready = run(
+      initialTraceState,
+      { type: "SOURCE_LOADED", imageUrl: "image-a", fileName: "a" },
+      { type: "SOURCE_READY", imageSize: { width: 200, height: 100 } },
+      {
+        type: "DETECTED",
+        imageUrl: "image-a",
+        outline: ringA,
+        rawOutline: ringA,
+        svg: "<svg/>",
+        region: null,
+      },
+      { type: "OUTLINE_COMMITTED", outline: ringB },
+      { type: "SET_CALIBRATION", calibration },
+      { type: "SET_REGION", region: { x: 10, y: 20, width: 40, height: 30 } },
+    );
+
+    const clockwise = traceReducer(ready, {
+      type: "ROTATE_SOURCE",
+      direction: "clockwise",
+      naturalSize: { width: 200, height: 100 },
+      maxSize: { width: 800, height: 600 },
+    });
+
+    expect(clockwise.imageRotation).toBe(1);
+    expect(clockwise.imageSize).toEqual({ width: 100, height: 200 });
+    expect(clockwise.outline[0].outer).toEqual([
+      { x: 100, y: 0 },
+      { x: 100, y: 20 },
+      { x: 80, y: 20 },
+    ]);
+    expect(clockwise.rawOutline[0].outer).toEqual([
+      { x: 100, y: 0 },
+      { x: 100, y: 10 },
+      { x: 90, y: 10 },
+    ]);
+    expect(clockwise.calibration).toEqual({
+      startX: 80,
+      startY: 10,
+      endX: 80,
+      endY: 110,
+      lengthMm: 50,
+    });
+    expect(clockwise.region).toEqual({ x: 50, y: 10, width: 30, height: 40 });
+    expect(clockwise.history.stack[0].outline).toEqual(clockwise.rawOutline);
+    expect(clockwise.history.stack[1].outline).toEqual(clockwise.outline);
+    expect(clockwise.svg).toBeNull();
+
+    const restored = traceReducer(clockwise, {
+      type: "ROTATE_SOURCE",
+      direction: "counterclockwise",
+      naturalSize: { width: 200, height: 100 },
+      maxSize: { width: 800, height: 600 },
+    });
+    expect(restored.imageRotation).toBe(0);
+    expect(restored.imageSize).toEqual({ width: 200, height: 100 });
+    expect(restored.outline).toEqual(ready.outline);
+    expect(restored.rawOutline).toEqual(ready.rawOutline);
+    expect(restored.calibration).toEqual(ready.calibration);
+    expect(restored.region).toEqual(ready.region);
+    expect(restored.history).toEqual(ready.history);
+  });
 });
 
 describe("modes and calibration", () => {
@@ -422,6 +493,44 @@ describe("modes and calibration", () => {
     expect(state.calibration?.endX).toBe(9);
     expect(state.calibrationSource).toBe("manual");
     expect(state.margin).toBe(1.5);
+  });
+
+  it("starts a fresh ruler when replacing a completed manual calibration", () => {
+    const state = run(
+      initialTraceState,
+      {
+        type: "SET_CALIBRATION",
+        calibration: {
+          startX: 1,
+          startY: 2,
+          endX: 9,
+          endY: 2,
+          lengthMm: 10,
+        },
+      },
+      { type: "SET_MODE", mode: "calibrate" },
+    );
+
+    expect(state.mode).toBe("calibrate");
+    expect(state.calibration).toBeNull();
+    expect(state.calibrationSource).toBeNull();
+    expect(state.draftCalibration).toBeNull();
+  });
+
+  it("discards completed draft endpoints when the ruler is redrawn", () => {
+    const state = run(
+      initialTraceState,
+      { type: "SET_MODE", mode: "calibrate" },
+      {
+        type: "SET_DRAFT_CALIBRATION",
+        draftCalibration: { startX: 1, startY: 2, endX: 9, endY: 2 },
+      },
+      { type: "SET_MODE", mode: "pan" },
+      { type: "SET_MODE", mode: "calibrate" },
+    );
+
+    expect(state.mode).toBe("calibrate");
+    expect(state.draftCalibration).toBeNull();
   });
 
   it("holds a sheet-detected scale for explicit acceptance", () => {
@@ -581,13 +690,20 @@ describe("modes and calibration", () => {
     expect(corrected.calibrationSource).toBe("sheet");
     expect(corrected.mode).toBe("region");
 
-    const restored = traceReducer(corrected, {
+    const rotatedCorrected = traceReducer(corrected, {
+      type: "ROTATE_SOURCE",
+      direction: "clockwise",
+      naturalSize: { width: 421, height: 595 },
+      maxSize: { width: 1600, height: 1600 },
+    });
+    const restored = traceReducer(rotatedCorrected, {
       type: "RESTORE_PERSPECTIVE_SOURCE",
     });
     expect(restored.imageUrl).toContain("original");
     expect(restored.perspectiveOriginalImageUrl).toBeNull();
     expect(restored.perspectiveCorrection).toBeNull();
     expect(restored.calibration).toBeNull();
+    expect(restored.imageRotation).toBe(1);
     expect(restored.autoCalibrationAttemptedImageUrl).toBe(restored.imageUrl);
   });
 

--- a/client/src/state/trace-store.tsx
+++ b/client/src/state/trace-store.tsx
@@ -17,9 +17,24 @@ import type { Outline, Point, Rect, RingRef } from "@shared/geometry/types";
 
 import type {
   PerspectiveProposal,
+  PerspectiveQuad,
   PerspectiveSource,
 } from "@/lib/calibrate/perspective";
 import type { TemplatePaper } from "@/lib/calibrate/template";
+import {
+  combineImageRotations,
+  fitImageWithin,
+  nextImageRotation,
+  rotateDraftCalibration,
+  rotateImageCalibration,
+  rotateImageOutline,
+  rotateImagePoint,
+  rotateImageRect,
+  rotatedImageDimensions,
+  type ImageDimensions,
+  type ImageQuarterTurns,
+  type ImageRotationDirection,
+} from "@/lib/geometry/image-rotation";
 import { DEFAULT_MARGIN_MM, type Margin } from "@/lib/image-processor";
 
 /**
@@ -60,6 +75,8 @@ export interface TraceState {
   fileName: string;
   /** Working-resolution image size; the coordinate space of everything below. */
   imageSize: { width: number; height: number };
+  /** Clockwise quarter-turns applied to the decoded source image. */
+  imageRotation: ImageQuarterTurns;
 
   /** Presentation rings, after simplification, smoothing and margin. */
   outline: Outline;
@@ -98,6 +115,8 @@ export interface TraceState {
   manualPerspectivePoints: Point[];
   /** Original source retained so a correction remains reversible. */
   perspectiveOriginalImageUrl: string | null;
+  /** Orientation of the retained source before perspective correction. */
+  perspectiveOriginalImageRotation: ImageQuarterTurns | null;
   /** How the current working image was rectified, or null for the original. */
   perspectiveCorrection: {
     source: PerspectiveSource;
@@ -119,6 +138,7 @@ export const initialTraceState: TraceState = {
   sourceRevision: 0,
   fileName: "",
   imageSize: { width: 0, height: 0 },
+  imageRotation: 0,
   outline: [],
   rawOutline: [],
   svg: null,
@@ -143,6 +163,7 @@ export const initialTraceState: TraceState = {
   pendingPerspective: null,
   manualPerspectivePoints: [],
   perspectiveOriginalImageUrl: null,
+  perspectiveOriginalImageRotation: null,
   perspectiveCorrection: null,
   region: null,
   mode: "pan",
@@ -155,6 +176,13 @@ export type TraceAction =
   | { type: "SOURCE_LOADED"; imageUrl: string; fileName: string }
   | { type: "SOURCE_READY"; imageSize: { width: number; height: number } }
   | { type: "SOURCE_CLEARED" }
+  | {
+      type: "ROTATE_SOURCE";
+      direction: ImageRotationDirection;
+      /** Decoded dimensions before the selected orientation and working cap. */
+      naturalSize: ImageDimensions;
+      maxSize: ImageDimensions;
+    }
   | {
       type: "DETECTED";
       outline: Outline;
@@ -230,6 +258,51 @@ function pushHistory(
   return { stack: trimmed, index: trimmed.length - 1 };
 }
 
+function rotatePerspectiveProposal(
+  proposal: PerspectiveProposal,
+  source: ImageDimensions,
+  target: ImageDimensions,
+  direction: ImageRotationDirection,
+): PerspectiveProposal {
+  let points = proposal.points.map((point) =>
+    rotateImagePoint(point, source, target, direction),
+  ) as PerspectiveQuad;
+  // Manual proposals map array positions to TL/TR/BR/BL destination corners.
+  // A visual quarter-turn changes which original corner is now top-left.
+  if (proposal.source === "manual") {
+    points = (direction === "clockwise"
+      ? [points[3], points[0], points[1], points[2]]
+      : [points[1], points[2], points[3], points[0]]) as PerspectiveQuad;
+  }
+  return {
+    ...proposal,
+    points,
+    correspondences: proposal.correspondences
+      ? {
+          ...proposal.correspondences,
+          source: proposal.correspondences.source.map((point) =>
+            rotateImagePoint(point, source, target, direction),
+          ),
+        }
+      : undefined,
+  };
+}
+
+function rotateManualPerspectivePoints(
+  points: Point[],
+  source: ImageDimensions,
+  target: ImageDimensions,
+  direction: ImageRotationDirection,
+): Point[] {
+  const rotated = points.map((point) =>
+    rotateImagePoint(point, source, target, direction),
+  );
+  if (rotated.length !== 4) return [];
+  return direction === "clockwise"
+    ? [rotated[3], rotated[0], rotated[1], rotated[2]]
+    : [rotated[1], rotated[2], rotated[3], rotated[0]];
+}
+
 export function traceReducer(state: TraceState, action: TraceAction): TraceState {
   switch (action.type) {
     case "SOURCE_LOADED":
@@ -251,6 +324,112 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
 
     case "SOURCE_READY":
       return { ...state, imageSize: action.imageSize };
+
+    case "ROTATE_SOURCE": {
+      if (
+        !state.imageUrl ||
+        state.processing ||
+        state.imageSize.width <= 0 ||
+        state.imageSize.height <= 0
+      ) {
+        return state;
+      }
+      const imageRotation = nextImageRotation(
+        state.imageRotation,
+        action.direction,
+      );
+      const imageSize = fitImageWithin(
+        rotatedImageDimensions(action.naturalSize, imageRotation),
+        action.maxSize,
+      );
+      const rotateCalibration = (calibration: Calibration | null) =>
+        calibration
+          ? rotateImageCalibration(
+              calibration,
+              state.imageSize,
+              imageSize,
+              action.direction,
+            )
+          : null;
+      const hasPartialPerspectiveSelection =
+        state.manualPerspectivePoints.length > 0 &&
+        state.manualPerspectivePoints.length < 4;
+
+      return {
+        ...state,
+        imageSize,
+        imageRotation,
+        outline: rotateImageOutline(
+          state.outline,
+          state.imageSize,
+          imageSize,
+          action.direction,
+        ),
+        rawOutline: rotateImageOutline(
+          state.rawOutline,
+          state.imageSize,
+          imageSize,
+          action.direction,
+        ),
+        // This legacy detector preview is not consumed by the current UI.
+        // Never retain pixel-space markup whose viewBox no longer matches.
+        svg: null,
+        history: {
+          ...state.history,
+          stack: state.history.stack.map((entry) => ({
+            ...entry,
+            outline: rotateImageOutline(
+              entry.outline,
+              state.imageSize,
+              imageSize,
+              action.direction,
+            ),
+          })),
+        },
+        calibration: rotateCalibration(state.calibration),
+        pendingAutoCalibration: rotateCalibration(
+          state.pendingAutoCalibration,
+        ),
+        draftCalibration: state.draftCalibration
+          ? rotateDraftCalibration(
+              state.draftCalibration,
+              state.imageSize,
+              imageSize,
+              action.direction,
+            )
+          : null,
+        region: state.region
+          ? rotateImageRect(
+              state.region,
+              state.imageSize,
+              imageSize,
+              action.direction,
+            )
+          : null,
+        pendingPerspective: state.pendingPerspective
+          ? rotatePerspectiveProposal(
+              state.pendingPerspective,
+              state.imageSize,
+              imageSize,
+              action.direction,
+            )
+          : null,
+        manualPerspectivePoints: rotateManualPerspectivePoints(
+          state.manualPerspectivePoints,
+          state.imageSize,
+          imageSize,
+          action.direction,
+        ),
+        mode:
+          hasPartialPerspectiveSelection && state.mode === "perspective"
+            ? "pan"
+            : state.mode,
+        // Marker detection is rotation-invariant, and any accepted/pending
+        // geometry above has already been turned with the source.
+        autoCalibrationAttemptedImageUrl:
+          state.autoCalibrationAttemptedImageUrl,
+      };
+    }
 
     case "SOURCE_CLEARED":
       return {
@@ -394,19 +573,29 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
       // Entering either manual measurement mode rejects an automatic proposal.
       const rejectsAutomatic =
         action.mode === "calibrate" || action.mode === "perspective";
+      const startsCalibration =
+        action.mode === "calibrate" && state.mode !== "calibrate";
       return {
         ...state,
         mode: action.mode,
+        // Redrawing is a replacement, not a second ruler layered over the
+        // accepted one. Invalidate both the old scale and any completed draft
+        // when manual placement starts; repeat clicks on the active tool leave
+        // the ruler currently being placed alone.
+        calibration: startsCalibration ? null : state.calibration,
+        calibrationSource: startsCalibration ? null : state.calibrationSource,
         // Choosing a manual tool is an explicit rejection of the automatic
         // candidate, including all of its canvas overlays.
         pendingAutoCalibration:
           rejectsAutomatic ? null : state.pendingAutoCalibration,
         pendingPerspective: rejectsAutomatic ? null : state.pendingPerspective,
         draftCalibration:
-          action.mode === "calibrate" ||
-          hasCalibrationEndpoints(state.draftCalibration)
-            ? state.draftCalibration
-            : null,
+          startsCalibration
+            ? null
+            : action.mode === "calibrate" ||
+                hasCalibrationEndpoints(state.draftCalibration)
+              ? state.draftCalibration
+              : null,
       };
     }
 
@@ -570,6 +759,8 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
         rulerLengthMm: state.rulerLengthMm,
         perspectiveOriginalImageUrl:
           state.perspectiveOriginalImageUrl ?? state.imageUrl,
+        perspectiveOriginalImageRotation:
+          state.perspectiveOriginalImageRotation ?? state.imageRotation,
         perspectiveCorrection: { source: action.source, paper: action.paper },
         mode: "region",
         exportFormat: state.exportFormat,
@@ -583,6 +774,12 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
         imageUrl: state.perspectiveOriginalImageUrl,
         sourceRevision: state.sourceRevision + 1,
         fileName: state.fileName,
+        // A corrected raster starts at rotation 0 even when its source was
+        // already oriented. Carry any later turns back onto the raw source.
+        imageRotation: combineImageRotations(
+          state.perspectiveOriginalImageRotation ?? 0,
+          state.imageRotation,
+        ),
         // Do not immediately propose the same correction again. The explicit
         // Detect sheet action remains available if the user wants another try.
         autoCalibrationAttemptedImageUrl: state.perspectiveOriginalImageUrl,


### PR DESCRIPTION
## Summary

- add 90-degree clockwise and counterclockwise source-image controls
- rotate the display raster, detection pixels, dimensions, contours, ruler, crop region, perspective geometry, and undo history as one coordinate-frame operation
- preserve orientation across perspective correction restore and block rotation while image processing is active
- make Redraw Ruler replace the previous endpoints while keeping the Scale section active and avoiding a stale blur commit

## Validation

- npm run check
- npm test (69 files, 859 tests)
- npm run build
- git diff --check