### PR TITLE
Support half-unit bin dimensions

### DIFF
--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -25,8 +25,9 @@ import type { FingerHole, TracedShape } from "@shared/gridfinity/cutout";
 import {
   binFootprintMm,
   GRID_PITCH_DIVISOR,
-  gridPitchMm,
+  resizeGridToStandardCellSpan,
   STACKING_LIP_HEIGHT_ACTUAL,
+  standardCellSpan,
   type GridPitch,
 } from "@shared/gridfinity/standard";
 import { MAX_GRID, type BinSpecInput } from "@shared/gridfinity/types";
@@ -89,6 +90,9 @@ const MAX_HEIGHT_UNITS_UI = 12;
 /** Slider ceiling: at most eight full cells, within the schema hard cap. */
 const maxGridUi = (pitch: GridPitch): number =>
   Math.min(MAX_GRID, 8 * GRID_PITCH_DIVISOR[pitch]);
+
+const formatUnitCount = (value: number): string =>
+  Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/0$/, "");
 
 function MaterialColorSwatch({
   id,
@@ -287,6 +291,8 @@ export function BinControlsPanel({
   );
 
   const dims = useMemo(() => binDimensionsMm(spec), [spec]);
+  const widthCellSpan = standardCellSpan(spec.gridX, spec.gridPitch);
+  const lengthCellSpan = standardCellSpan(spec.gridY, spec.gridPitch);
   const issues = useMemo(
     () => [
       ...validateBinSpec(spec).issues,
@@ -320,8 +326,36 @@ export function BinControlsPanel({
   const activeColorCount =
     1 + Number(hasSelectedFloorColor) + Number(hasSelectedRimColor);
 
-  const patchSpec = (patch: Partial<BinSpecInput>, transient = false) =>
-    dispatch({ type: "PATCH_SPEC", patch, transient });
+  const patchSpec = (
+    patch: Partial<BinSpecInput>,
+    transient = false,
+    historyLabel?: string,
+  ) => dispatch({ type: "PATCH_SPEC", patch, transient, historyLabel });
+
+  const setRectangularCellSpan = (
+    axis: "x" | "y",
+    span: number,
+    transient: boolean,
+  ) => {
+    const resized = resizeGridToStandardCellSpan(spec, axis, span);
+    if (resized.gridX > MAX_GRID || resized.gridY > MAX_GRID) return;
+    const promotedToFractionalPitch =
+      resized.gridPitch !== spec.gridPitch && resized.gridPitch !== "full";
+    patchSpec(
+      {
+        ...resized,
+        ...(promotedToFractionalPitch
+          ? {
+              magnetHoles: false,
+              magnetCrushRibs: false,
+              screwHoles: false,
+            }
+          : {}),
+      },
+      transient,
+      axis === "x" ? "Change bin width" : "Change bin length",
+    );
+  };
 
   const selectedCutout = cutouts.find((cutout) => cutout.id === selectedCutoutId) ?? null;
   const selectedShape = selectedCutout
@@ -388,7 +422,7 @@ export function BinControlsPanel({
           title="Bin size"
           icon={Ruler}
           tone="blue"
-          summary={`${spec.gridX} × ${spec.gridY} × ${spec.heightUnits}u`}
+          summary={`${formatUnitCount(widthCellSpan)} × ${formatUnitCount(lengthCellSpan)} × ${formatUnitCount(spec.heightUnits)}u`}
           className="scroll-mt-16"
         >
           <div className="flex items-center gap-2">
@@ -425,13 +459,17 @@ export function BinControlsPanel({
                 label="Width"
                 cells={spec.gridX}
                 pitch={spec.gridPitch}
-                onChange={(gridX, transient) => patchSpec({ gridX }, transient)}
+                onChange={(span, transient) =>
+                  setRectangularCellSpan("x", span, transient)
+                }
               />
               <CellSlider
                 label="Length"
                 cells={spec.gridY}
                 pitch={spec.gridPitch}
-                onChange={(gridY, transient) => patchSpec({ gridY }, transient)}
+                onChange={(span, transient) =>
+                  setRectangularCellSpan("y", span, transient)
+                }
               />
             </>
           ) : (
@@ -444,7 +482,7 @@ export function BinControlsPanel({
             <div className="flex items-baseline justify-between">
               <Label className="text-xs">Height</Label>
               <span className="text-xs tabular-nums text-muted-foreground">
-                {spec.heightUnits} u · {spec.heightUnits * 7} mm
+                {formatUnitCount(spec.heightUnits)} u · {spec.heightUnits * 7} mm
               </span>
             </div>
             <Slider
@@ -455,8 +493,8 @@ export function BinControlsPanel({
               onValueCommit={([heightUnits]) => patchSpec({ heightUnits })}
               min={1}
               max={MAX_HEIGHT_UNITS_UI}
-              step={1}
-              aria-label="Height in 7 mm units"
+              step={0.5}
+              aria-label="Height in 0.5u increments"
             />
           </div>
           <p className="text-xs text-muted-foreground">
@@ -1960,23 +1998,26 @@ function CellSlider({
   pitch: GridPitch;
   onChange: (cells: number, transient: boolean) => void;
 }): JSX.Element {
-  const pitchMm = gridPitchMm(pitch);
+  const divisor = GRID_PITCH_DIVISOR[pitch];
+  const standardCells = standardCellSpan(cells, pitch);
+  const step = pitch === "quarter" ? 0.25 : 0.5;
   return (
     <div className="space-y-1.5">
       <div className="flex items-baseline justify-between">
         <Label className="text-xs">{label}</Label>
         <span className="text-xs tabular-nums text-muted-foreground">
-          {cells} {cells === 1 ? "cell" : "cells"} · {binFootprintMm(cells, pitch).toFixed(1)} mm
+          {formatUnitCount(standardCells)} {standardCells === 1 ? "cell" : "cells"} ·{" "}
+          {binFootprintMm(cells, pitch).toFixed(1)} mm
         </span>
       </div>
       <Slider
-        value={[cells]}
+        value={[standardCells]}
         onValueChange={([value]) => onChange(value, true)}
         onValueCommit={([value]) => onChange(value, false)}
-        min={1}
-        max={maxGridUi(pitch)}
-        step={1}
-        aria-label={`${label} in ${pitchMm} mm cells`}
+        min={step}
+        max={maxGridUi(pitch) / divisor}
+        step={step}
+        aria-label={`${label} in standard Gridfinity cells`}
       />
     </div>
   );

--- a/client/src/lib/gridfinity/bin.test.ts
+++ b/client/src/lib/gridfinity/bin.test.ts
@@ -91,6 +91,13 @@ describe("buildWallRing", () => {
   it("is null for a 1u bin (zero wall height)", () => {
     expect(buildWallRing(kernel, spec({ heightUnits: 1 }), SEGMENTS)).toBeNull();
   });
+
+  it("builds a wall at a half-unit height", () => {
+    const ring = buildWallRing(kernel, spec({ heightUnits: 2.5 }), SEGMENTS)!;
+    const box = ring.boundingBox();
+    expect(box.min[2]).toBeCloseTo(7, 9);
+    expect(box.max[2]).toBeCloseTo(17.5, 9);
+  });
 });
 
 describe("buildStackingLip", () => {
@@ -124,6 +131,13 @@ describe("buildStackingLip", () => {
 });
 
 describe("buildBin", () => {
+  it("builds a complete half-unit-height bin", () => {
+    const { solid } = buildBin(kernel, spec({ heightUnits: 2.5 }), QUALITY);
+    const box = solid.boundingBox();
+    expect(solid.status()).toBe("NoError");
+    expect(box.max[2]).toBeCloseTo(17.5 + STACKING_LIP_HEIGHT_ACTUAL, 7);
+  });
+
   it("builds a connected, watertight three-cell L bin with a stacking lip", () => {
     const { solid, parts } = buildBin(
       kernel,

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -265,6 +265,63 @@ describe("BinDesignerPage", () => {
     unmount();
   });
 
+  it("sets width, length, and height in half-unit increments", async () => {
+    const { container, unmount } = renderPage();
+    await flushHydration();
+
+    const width = container.querySelector<HTMLElement>(
+      '[aria-label="Width in standard Gridfinity cells"]',
+    );
+    expect(width).not.toBeNull();
+    React.act(() => {
+      width!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      );
+      width!.dispatchEvent(
+        new KeyboardEvent("keyup", { key: "ArrowLeft", bubbles: true }),
+      );
+    });
+
+    const sizeSection = container.querySelector("#bin-settings-size");
+    expect(sizeSection?.textContent).toContain("1.5 cells · 62.5 mm");
+    expect(sizeSection?.textContent).toContain("2 cells · 83.5 mm");
+    expect(sizeSection?.textContent).toContain("1.5 × 2 × 6u");
+    expect(
+      container.querySelector('[data-testid="select-grid-pitch"]')?.textContent,
+    ).toContain("Half");
+
+    const length = container.querySelector<HTMLElement>(
+      '[aria-label="Length in standard Gridfinity cells"]',
+    );
+    expect(length).not.toBeNull();
+    React.act(() => {
+      length!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      );
+      length!.dispatchEvent(
+        new KeyboardEvent("keyup", { key: "ArrowLeft", bubbles: true }),
+      );
+    });
+    expect(sizeSection?.textContent).toContain("1.5 × 1.5 × 6u");
+
+    const height = container.querySelector<HTMLElement>(
+      '[aria-label="Height in 0.5u increments"]',
+    );
+    expect(height).not.toBeNull();
+    React.act(() => {
+      height!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+      height!.dispatchEvent(
+        new KeyboardEvent("keyup", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    expect(sizeSection?.textContent).toContain("6.5 u · 45.5 mm");
+    expect(sizeSection?.textContent).toContain("1.5 × 1.5 × 6.5u");
+    unmount();
+  });
+
   it("restores a custom L footprint and exposes its cell editor", async () => {
     vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
       ...EMPTY_PROJECT,

--- a/docs/gridfinity-plan.md
+++ b/docs/gridfinity-plan.md
@@ -54,6 +54,10 @@ the saved model. A local Node 22 real-WASM probe with two 150-point pockets and
 both top and bottom fillets fell from about 9.1 s to 0.59 s (roughly 15×
 faster). During any remaining rebuild, the last valid model stays visible and
 prominent progress appears both over the 3D view and beside the size controls.
+Width and length are shown in standard 42 mm cells and accept half-cell steps;
+selecting a fractional span promotes a rectangular bin to the existing 21 mm
+half-pitch socket lattice without changing its untouched axis. Height accepts
+0.5u steps (3.5 mm) while retaining the 1u minimum required by the base.
 
 The Bin Layout view also supports **selected-pocket contour editing** without a
 round trip through Trace: drag vertices, click an edge to insert a point, and

--- a/shared/gridfinity/standard.test.ts
+++ b/shared/gridfinity/standard.test.ts
@@ -18,6 +18,8 @@ import {
   D_WALL,
   GRID_PITCH_DIVISOR,
   gridPitchMm,
+  resizeGridToStandardCellSpan,
+  standardCellSpan,
   R_F2,
   STACKING_LIP_DEPTH,
   STACKING_LIP_FILLET_RADIUS,
@@ -108,6 +110,25 @@ describe("gridfinity standard constants", () => {
     expect(binFootprintMm(2, "half")).toBe(41.5);
     expect(binFootprintMm(4, "quarter")).toBe(41.5);
     expect(binFootprintMm(1, "quarter")).toBe(10);
+  });
+
+  it("expresses rectangular dimensions in standard cells and promotes fractional spans", () => {
+    expect(standardCellSpan(3, "half")).toBe(1.5);
+    expect(standardCellSpan(5, "quarter")).toBe(1.25);
+    expect(
+      resizeGridToStandardCellSpan(
+        { gridX: 2, gridY: 3, gridPitch: "full" },
+        "x",
+        1.5,
+      ),
+    ).toEqual({ gridX: 3, gridY: 6, gridPitch: "half" });
+    expect(
+      resizeGridToStandardCellSpan(
+        { gridX: 3, gridY: 6, gridPitch: "half" },
+        "y",
+        2.5,
+      ),
+    ).toEqual({ gridX: 3, gridY: 5, gridPitch: "half" });
   });
 });
 

--- a/shared/gridfinity/standard.ts
+++ b/shared/gridfinity/standard.ts
@@ -38,6 +38,59 @@ export function gridPitchMm(pitch: GridPitch = "full"): number {
   return GRID_DIMENSIONS_MM / GRID_PITCH_DIVISOR[pitch];
 }
 
+/** Selected-pitch grid count expressed in standard 42 mm cells. */
+export function standardCellSpan(
+  gridCount: number,
+  pitch: GridPitch = "full",
+): number {
+  return gridCount / GRID_PITCH_DIVISOR[pitch];
+}
+
+export interface RectangularGridDimensions {
+  gridX: number;
+  gridY: number;
+  gridPitch: GridPitch;
+}
+
+/**
+ * Changes one rectangular dimension in standard-cell units.
+ *
+ * Grid geometry remains an integer lattice internally. When a full-pitch bin
+ * first receives a half-cell dimension, both axes are promoted to half pitch
+ * so the untouched physical span stays fixed. Existing half/quarter pitch is
+ * retained rather than silently changing the socket pattern.
+ */
+export function resizeGridToStandardCellSpan(
+  grid: RectangularGridDimensions,
+  axis: "x" | "y",
+  span: number,
+): RectangularGridDimensions {
+  if (!Number.isFinite(span) || span <= 0) {
+    throw new Error(`Grid span must be positive, got ${span}`);
+  }
+
+  const pitches: readonly GridPitch[] = ["full", "half", "quarter"];
+  const currentIndex = pitches.indexOf(grid.gridPitch);
+  const targetPitch = pitches
+    .slice(currentIndex)
+    .find((pitch) => Number.isInteger(span * GRID_PITCH_DIVISOR[pitch]));
+  if (!targetPitch) {
+    throw new Error(`Grid span must align to a quarter cell, got ${span}`);
+  }
+
+  const currentDivisor = GRID_PITCH_DIVISOR[grid.gridPitch];
+  const targetDivisor = GRID_PITCH_DIVISOR[targetPitch];
+  const promotion = targetDivisor / currentDivisor;
+  const resized = {
+    gridX: grid.gridX * promotion,
+    gridY: grid.gridY * promotion,
+    gridPitch: targetPitch,
+  };
+  if (axis === "x") resized.gridX = Math.round(span * targetDivisor);
+  else resized.gridY = Math.round(span * targetDivisor);
+  return resized;
+}
+
 /** Height of one Gridfinity height unit ("u"). A "6u" bin is 42 mm tall. */
 export const HEIGHT_UNIT_MM = 7;
 

--- a/shared/gridfinity/types.ts
+++ b/shared/gridfinity/types.ts
@@ -40,16 +40,16 @@ const boundaryEdgeSchema = z.object({
 
 export const binSpecSchema = z
   .object({
-    /** Number of 42 mm grid cells along x. */
+    /** Number of selected-pitch grid cells along x. */
     gridX: z.number().int().min(1).max(MAX_GRID),
-    /** Number of 42 mm grid cells along y. */
+    /** Number of selected-pitch grid cells along y. */
     gridY: z.number().int().min(1).max(MAX_GRID),
     /** Standard 42 mm cells, or equal half/quarter-pitch subdivisions. */
     gridPitch: z.enum(["full", "half", "quarter"]).default("full"),
     /** Rectangular legacy footprint or a canonical connected cell mask. */
     footprint: footprintSchema.default({ kind: "rectangle" }),
     /** Height in 7 mm units, including the base, excluding the stacking lip. */
-    heightUnits: z.number().int().min(1).max(MAX_HEIGHT_UNITS),
+    heightUnits: z.number().min(1).max(MAX_HEIGHT_UNITS).multipleOf(0.5),
     /** Stacking lip on the rim. `none` gives a flush top. */
     lip: z.enum(["standard", "none"]).default("standard"),
     /**

--- a/shared/gridfinity/validate.test.ts
+++ b/shared/gridfinity/validate.test.ts
@@ -22,10 +22,12 @@ describe("binSpecSchema", () => {
     expect(() => spec({ gridPitch: "eighth" as never })).toThrow();
   });
 
-  it("rejects non-integer and out-of-range sizes", () => {
+  it("accepts half-unit heights and rejects unsupported or out-of-range sizes", () => {
+    expect(spec({ heightUnits: 6.5 }).heightUnits).toBe(6.5);
     expect(() => spec({ gridX: 0 })).toThrow();
     expect(() => spec({ gridX: 2.5 })).toThrow();
     expect(() => spec({ gridY: 17 })).toThrow();
+    expect(() => spec({ heightUnits: 6.25 })).toThrow();
     expect(() => spec({ heightUnits: 0 })).toThrow();
     expect(() => spec({ heightUnits: 43 })).toThrow();
   });

--- a/shared/gridfinity/validate.ts
+++ b/shared/gridfinity/validate.ts
@@ -39,9 +39,9 @@ import type { BinSpec } from "./types";
 
 /**
  * Pure validation of a bin specification — no WASM, cheap enough to run on
- * every keystroke. Schema-level shape errors (non-integer grid, out-of-range
- * height) are zod's job in `types.ts`; this module judges *geometry* that is
- * representable but unwise or unbuildable.
+ * every keystroke. Schema-level shape errors (non-integer grid, unsupported
+ * height step, or out-of-range size) are zod's job in `types.ts`; this module
+ * judges *geometry* that is representable but unwise or unbuildable.
  *
  * Severity contract (from the plan): errors block export, warnings do not.
  * The issue list will grow substantially with cutouts (out-of-bounds,


### PR DESCRIPTION
## Summary
- allow standard-pitch bin width and length in 0.5-cell increments
- allow bin height in 0.5u increments (3.5 mm)
- preserve physical dimensions when promoting rectangular footprints to half pitch
- validate and document the expanded dimension ranges

## Verification
- npm run check
- npm test (68 files, 850 tests)
- npm run build
- git diff --check