### PR TITLE
Add vertical deep finger scoops

### DIFF
--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -853,7 +853,7 @@ export function BinControlsPanel({
                   <div>
                     <Label className="text-xs">Finger holes</Label>
                     <p className="text-[11px] text-muted-foreground">
-                      Straight cut or top scoop
+                      Straight cut, top scoop, or deep scoop
                     </p>
                   </div>
                   <Button
@@ -900,7 +900,16 @@ export function BinControlsPanel({
                             patch: {
                               fingerHoles: selectedCutout.fingerHoles.map((h) =>
                                 h.id === hole.id
-                                  ? { ...h, kind: kind as FingerHole["kind"] }
+                                  ? {
+                                      ...h,
+                                      kind: kind as FingerHole["kind"],
+                                      depthMm:
+                                        kind === "scoop"
+                                          ? Math.min(h.depthMm, h.diameterMm / 2)
+                                          : kind === "deep-scoop"
+                                            ? Math.max(h.depthMm, h.diameterMm)
+                                            : h.depthMm,
+                                    }
                                   : h,
                               ),
                             },
@@ -909,7 +918,7 @@ export function BinControlsPanel({
                         }
                       >
                         <SelectTrigger
-                          className="h-7 w-28 px-2 text-xs"
+                          className="h-7 w-36 px-2 text-xs"
                           aria-label={`Finger hole ${index + 1} type`}
                           data-testid={`finger-hole-kind-${index + 1}`}
                         >
@@ -917,7 +926,8 @@ export function BinControlsPanel({
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem value="straight">Straight</SelectItem>
-                          <SelectItem value="scoop">Scoop</SelectItem>
+                          <SelectItem value="scoop">Round scoop</SelectItem>
+                          <SelectItem value="deep-scoop">Deep scoop</SelectItem>
                         </SelectContent>
                       </Select>
                       <button
@@ -952,7 +962,18 @@ export function BinControlsPanel({
                           id: selectedCutout.id,
                           patch: {
                             fingerHoles: selectedCutout.fingerHoles.map((h) =>
-                              h.id === hole.id ? { ...h, diameterMm } : h,
+                              h.id === hole.id
+                                ? {
+                                    ...h,
+                                    diameterMm,
+                                    depthMm:
+                                      h.kind === "scoop"
+                                        ? Math.min(h.depthMm, diameterMm / 2)
+                                        : h.kind === "deep-scoop"
+                                          ? Math.max(h.depthMm, diameterMm / 2)
+                                          : h.depthMm,
+                                  }
+                                : h,
                             ),
                           },
                           historyLabel: "Resize finger hole",
@@ -960,10 +981,65 @@ export function BinControlsPanel({
                         })
                       }
                     />
+                    {hole.kind === "scoop" && (
+                      <MmSlider
+                        label="Depth"
+                        value={Math.min(hole.depthMm, hole.diameterMm / 2)}
+                        min={1}
+                        max={Math.min(30, hole.diameterMm / 2)}
+                        step={0.5}
+                        onChange={(depthMm, transient) =>
+                          dispatch({
+                            type: "UPDATE_CUTOUT",
+                            id: selectedCutout.id,
+                            patch: {
+                              fingerHoles: selectedCutout.fingerHoles.map((h) =>
+                                h.id === hole.id ? { ...h, depthMm } : h,
+                              ),
+                            },
+                            historyLabel: "Change finger scoop depth",
+                            transient,
+                          })
+                        }
+                      />
+                    )}
+                    {hole.kind === "deep-scoop" && (
+                      <div className="space-y-1">
+                        <MmSlider
+                          label="Total depth"
+                          value={Math.max(hole.depthMm, hole.diameterMm / 2)}
+                          min={hole.diameterMm / 2}
+                          max={120}
+                          step={0.5}
+                          onChange={(depthMm, transient) =>
+                            dispatch({
+                              type: "UPDATE_CUTOUT",
+                              id: selectedCutout.id,
+                              patch: {
+                                fingerHoles: selectedCutout.fingerHoles.map((h) =>
+                                  h.id === hole.id ? { ...h, depthMm } : h,
+                                ),
+                              },
+                              historyLabel: "Change deep scoop depth",
+                              transient,
+                            })
+                          }
+                        />
+                        <p className="pl-16 text-[11px] text-muted-foreground">
+                          Straight shaft: {Math.max(
+                            0,
+                            hole.depthMm - hole.diameterMm / 2,
+                          ).toFixed(1)} mm · hemispherical bottom: {(
+                            hole.diameterMm / 2
+                          ).toFixed(1)} mm
+                        </p>
+                      </div>
+                    )}
                   </div>
                 ))}
                 <p className="text-[11px] text-muted-foreground">
-                  Drag each circle in Layout to position it.
+                  Drag a feature in Layout to position its round mouth. A deep
+                  scoop runs straight down, then ends in a hemisphere.
                 </p>
               </div>
 

--- a/client/src/components/gridfinity/layout-canvas.tsx
+++ b/client/src/components/gridfinity/layout-canvas.tsx
@@ -17,6 +17,7 @@ import {
   transformPointPlacement,
   untransformPointPlacement,
   type CutoutPlacement,
+  type FingerHole,
   type TracedShape,
 } from "@shared/gridfinity/cutout";
 import {
@@ -31,6 +32,7 @@ import {
   type Ring,
   type RingRef,
 } from "@shared/geometry/types";
+import { pointInRing } from "@shared/geometry/rings";
 import { validateLayout, type IssueSeverity } from "@shared/gridfinity/validate";
 import {
   boundaryEdges,
@@ -241,11 +243,11 @@ function LayoutStage(): JSX.Element {
             ? { ...storedShape, outlineMm: draftContour.outline }
             : storedShape;
         const footprint = placementFootprint(shape, cutout);
-        const features = cutout.fingerHoles.map((hole) => ({
+        const features = cutout.fingerHoles.map((hole, index) => ({
           kind: hole.kind,
           id: hole.id,
           center: transformPointPlacement(hole.center, cutout),
-          radius: hole.diameterMm / 2,
+          ring: footprint.features[index],
         }));
         return [{ cutout, shape, outline: footprint.outline, features }];
       }),
@@ -290,7 +292,7 @@ function LayoutStage(): JSX.Element {
     | {
         kind: "feature";
         id: string;
-        feature: { kind: "straight" | "scoop"; id: string };
+        feature: { kind: FingerHole["kind"]; id: string };
         grabOffset: Point;
       }
     | {
@@ -316,11 +318,11 @@ function LayoutStage(): JSX.Element {
   }, [hasPlacedCutouts]);
 
   const hitCutout = (point: Point): CutoutPlacement | null => {
-    // Topmost = later in the list; feature circles count as their pocket.
+    // Topmost = later in the list; finger-access rims count as their pocket.
     for (let i = placed.length - 1; i >= 0; i--) {
       if (pointInOutline(placed[i].outline, point)) return placed[i].cutout;
       for (const feature of placed[i].features) {
-        if (Math.hypot(point.x - feature.center.x, point.y - feature.center.y) <= feature.radius) {
+        if (pointInRing(feature.ring, point)) {
           return placed[i].cutout;
         }
       }
@@ -587,14 +589,18 @@ function LayoutStage(): JSX.Element {
       return;
     }
 
-    // Feature circles of the selected pocket grab before the body does, so
-    // a hole overlapping its own outline stays draggable.
+    // Finger-access features of the selected pocket grab before the body does,
+    // so a feature overlapping its own outline stays draggable.
     if (selected) {
       for (const feature of selected.features) {
-        if (
-          Math.hypot(point.x - feature.center.x, point.y - feature.center.y) <=
-          feature.radius + pickRadius / 2
-        ) {
+        const nearEdge = feature.ring.some((vertex, index) =>
+          pointSegmentDistance(
+            point,
+            vertex,
+            feature.ring[(index + 1) % feature.ring.length],
+          ) <= pickRadius / 2,
+        );
+        if (pointInRing(feature.ring, point) || nearEdge) {
           dragRef.current = {
             kind: "feature",
             id: selected.cutout.id,
@@ -1028,23 +1034,18 @@ function LayoutStage(): JSX.Element {
                   data-cutout-id={cutout.id}
                 />
                 {features.map((feature) => {
-                  const centre = binToCanvas(feature.center, spec);
                   return (
-                    <circle
-                      key={`${cutout.id}-${feature.kind}-${feature.id}`}
-                      cx={centre.x}
-                      cy={centre.y}
-                      r={feature.radius}
-                      className={cn(
-                        tone,
-                        isSelected && "cursor-move",
-                      )}
-                      strokeWidth={isSelected ? 1.5 : 1}
-                      strokeDasharray={feature.kind === "scoop" ? "3 2" : undefined}
-                      vectorEffect="non-scaling-stroke"
-                      data-feature-of={cutout.id}
-                      data-testid={`feature-${feature.kind}-${cutout.id}`}
-                    />
+                    <g key={`${cutout.id}-${feature.kind}-${feature.id}`}>
+                      <path
+                        d={ringToCanvasPath(feature.ring, spec)}
+                        className={cn(tone, isSelected && "cursor-move")}
+                        strokeWidth={isSelected ? 1.5 : 1}
+                        strokeDasharray={feature.kind === "straight" ? undefined : "3 2"}
+                        vectorEffect="non-scaling-stroke"
+                        data-feature-of={cutout.id}
+                        data-testid={`feature-${feature.kind}-${cutout.id}`}
+                      />
+                    </g>
                   );
                 })}
               </g>

--- a/client/src/lib/gridfinity/cutouts.test.ts
+++ b/client/src/lib/gridfinity/cutouts.test.ts
@@ -559,6 +559,41 @@ describe("buildBinWithCutouts", () => {
     expect(removed).toBeLessThan(capVolume);
   });
 
+  it("a deep scoop removes a straight shaft with a hemispherical bottom", () => {
+    const shape = rectShape("s1", 12, 8);
+    const base = { depth: { mode: "mm", value: 4 } };
+    const scoop = {
+      id: "f1",
+      kind: "deep-scoop",
+      center: { x: -18, y: 20 },
+      diameterMm: 16,
+      depthMm: 30,
+    };
+    const without = buildBinWithCutouts(
+      kernel,
+      SPEC,
+      layoutFor([shape], [cutout("c1", "s1", base)]),
+      QUALITY,
+    );
+    const withScoop = buildBinWithCutouts(
+      kernel,
+      SPEC,
+      layoutFor([shape], [cutout("c1", "s1", { ...base, fingerHoles: [scoop] })]),
+      QUALITY,
+    );
+
+    expect(withScoop.solid.status()).toBe("NoError");
+    expect(withScoop.solid.genus()).toBe(0);
+    const radius = scoop.diameterMm / 2;
+    const shaftDepth = scoop.depthMm - radius;
+    const analytic =
+      Math.PI * radius * radius * shaftDepth +
+      (2 * Math.PI * radius ** 3) / 3;
+    const removed = without.solid.volume() - withScoop.solid.volume();
+    expect(removed).toBeLessThan(analytic);
+    expect(removed).toBeGreaterThan(0.94 * analytic);
+  });
+
   it("cuts every scoop-style finger hole on the same pocket", () => {
     const shape = rectShape("s1", 12, 8);
     const base = { depth: { mode: "mm", value: 4 } };

--- a/client/src/lib/gridfinity/cutouts.ts
+++ b/client/src/lib/gridfinity/cutouts.ts
@@ -2,7 +2,9 @@
 import type { Manifold } from "manifold-3d";
 
 import {
+  effectiveDeepScoopDepthMm,
   effectiveScoopDepthMm,
+  fingerHoleFootprintRing,
   resolvePocketDepth,
   transformOutlinePlacement,
   transformPointPlacement,
@@ -51,9 +53,11 @@ import {
  *  - **straight finger holes** union their circles into the cross-section
  *    *after* the offsets (they are cut at their drawn diameter, no fit
  *    clearance), so they share the pocket's depth, floor and bottom fillet;
- *  - **scoop finger holes** are their own solids — spherical caps through the
- *    top surface plus a cylinder clearing the lip above it, overlapped by a
- *    half-layer because abutting unions only weld where faces share vertices.
+ *  - **scoop finger holes** are their own solids — round scoops use spherical
+ *    caps, while deep scoops use a straight cylindrical shaft ending in a
+ *    hemisphere. Their rim is extended through the lip; the deep scoop's full
+ *    sphere overlaps inside the shaft so the exposed lower half is a robust,
+ *    watertight hemispherical bottom.
  *
  * Everything is tracked in `kernel.arena`; the caller owns disposal.
  */
@@ -129,17 +133,15 @@ export function scoopSphereRadiusMm(
   return (a * a + h * h) / (2 * h);
 }
 
-/** The scoop cutter: sphere cap below the top surface + lip-clearing mouth. */
-function buildScoopCutter(
+/** One spherical cap below the top surface, centred in bin-local XY. */
+function buildScoopCapAt(
   kernel: Kernel,
   scoop: FingerHole,
-  placement: Pick<CutoutPlacement, "position" | "rotationDeg" | "mirrored">,
+  centre: { x: number; y: number },
   pocket: ResolvedPocket,
   segments: number,
 ): Manifold {
   const { arena, Manifold: M } = kernel;
-  const centre = transformPointPlacement(scoop.center, placement);
-  const rimRadius = scoop.diameterMm / 2;
   const depth = effectiveScoopDepthMm(scoop);
   const sphereRadius = scoopSphereRadiusMm(scoop);
   const sphereCentreZ = pocket.infillTopZ + sphereRadius - depth;
@@ -167,17 +169,80 @@ function buildScoopCutter(
         pocket.infillTopZ - depth - 1,
       ]),
   );
-  const cap = arena.track(sphere.intersect(keepBelow));
+  return arena.track(sphere.intersect(keepBelow));
+}
 
-  // The mouth above the top surface is the rim circle, extended a half-layer
-  // down into the cap so the union overlaps volumetrically.
+/** Vertical mouth matching the exact plan-view rim and clearing any lip. */
+function buildScoopMouth(
+  kernel: Kernel,
+  scoop: FingerHole,
+  placement: Pick<CutoutPlacement, "position" | "rotationDeg" | "mirrored">,
+  pocket: ResolvedPocket,
+  segments: number,
+): Manifold {
+  const { arena } = kernel;
+  const ring = fingerHoleFootprintRing(scoop, placement, segments);
+  const section = toCrossSection(kernel, [{ outer: ring, holes: [] }]);
+
+  // The mouth above the top surface is the exact round rim, extended
+  // a half-layer down into the dish so the union overlaps volumetrically.
   const mouthBottomZ = pocket.infillTopZ - LAYER_HEIGHT / 2;
-  const mouth = arena.track(
-    arena
-      .track(M.cylinder(pocket.cutterTopZ - mouthBottomZ, rimRadius, rimRadius, segments))
-      .translate([centre.x, centre.y, mouthBottomZ]),
+  return arena.track(
+    arena.track(section.extrude(pocket.cutterTopZ - mouthBottomZ)).translate([
+      0,
+      0,
+      mouthBottomZ,
+    ]),
   );
+}
+
+/** Round, top-surface spherical-cap cutter. */
+function buildRoundScoopCutter(
+  kernel: Kernel,
+  scoop: FingerHole,
+  placement: Pick<CutoutPlacement, "position" | "rotationDeg" | "mirrored">,
+  pocket: ResolvedPocket,
+  segments: number,
+): Manifold {
+  const { arena } = kernel;
+  const centre = transformPointPlacement(scoop.center, placement);
+  const mouth = buildScoopMouth(kernel, scoop, placement, pocket, segments);
+  const cap = buildScoopCapAt(kernel, scoop, centre, pocket, segments);
   return arena.track(cap.add(mouth));
+}
+
+/** Straight cylindrical shaft with an exposed hemispherical bottom. */
+function buildDeepScoopCutter(
+  kernel: Kernel,
+  scoop: FingerHole,
+  placement: Pick<CutoutPlacement, "position" | "rotationDeg" | "mirrored">,
+  pocket: ResolvedPocket,
+  segments: number,
+): Manifold {
+  const { arena, Manifold: M } = kernel;
+  const centre = transformPointPlacement(scoop.center, placement);
+  const radius = scoop.diameterMm / 2;
+  const totalDepth = effectiveDeepScoopDepthMm(scoop);
+  const sphereCentreZ = pocket.infillTopZ - totalDepth + radius;
+  const sphere = arena.track(
+    arena.track(M.sphere(radius, segments)).translate([
+      centre.x,
+      centre.y,
+      sphereCentreZ,
+    ]),
+  );
+  const ring = fingerHoleFootprintRing(scoop, placement, segments);
+  const section = toCrossSection(kernel, [{ outer: ring, holes: [] }]);
+  const shaft = arena.track(
+    arena.track(section.extrude(pocket.cutterTopZ - sphereCentreZ)).translate([
+      0,
+      0,
+      sphereCentreZ,
+    ]),
+  );
+  // The sphere's upper half is contained inside the shaft, giving the union
+  // volumetric overlap while exposing exactly its lower hemisphere.
+  return arena.track(shaft.add(sphere));
 }
 
 /** Builds one cutter per cutout, skipping (and reporting) collapsed ones. */
@@ -253,7 +318,9 @@ export function buildCutoutCutters(
     const pocket = resolvePocketDepth(spec, cutout.depth);
     for (const hole of cutout.fingerHoles) {
       if (hole.kind === "scoop") {
-        cutters.push(buildScoopCutter(kernel, hole, cutout, pocket, segments));
+        cutters.push(buildRoundScoopCutter(kernel, hole, cutout, pocket, segments));
+      } else if (hole.kind === "deep-scoop") {
+        cutters.push(buildDeepScoopCutter(kernel, hole, cutout, pocket, segments));
       }
     }
     let cutter: Manifold;

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -8,7 +8,7 @@ import { WORKSPACES } from "@/components/layout/workspaces";
 import * as ShapeLibraryModule from "@/state/shape-library";
 import { ShapeLibraryProvider } from "@/state/shape-library";
 import { PROJECT_SCHEMA_VERSION, type ProjectDoc } from "@shared/gridfinity/project";
-import type { TracedShape } from "@shared/gridfinity/cutout";
+import { parseCutoutPlacement, type TracedShape } from "@shared/gridfinity/cutout";
 import { parseBinSpec } from "@shared/gridfinity/types";
 
 /**
@@ -345,6 +345,58 @@ describe("BinDesignerPage", () => {
     expect(container.querySelectorAll('[data-testid="footprint-cell"]')).toHaveLength(4);
     expect(container.querySelectorAll('[data-testid="footprint-halo-cell"]')).toHaveLength(6);
     expect(container.querySelector('[data-testid="button-reset-footprint"]')).not.toBeNull();
+    unmount();
+  });
+
+  it("restores a deep finger scoop with diameter and total-depth controls", async () => {
+    const shape = rectangularShape("shape-deep", "Deep pliers");
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT,
+      shapes: [shape],
+      cutouts: [
+        parseCutoutPlacement({
+          id: "cutout-deep",
+          shapeId: shape.id,
+          position: { x: 0, y: 0 },
+          fingerHoles: [
+            {
+              id: "finger-deep",
+              kind: "deep-scoop",
+              center: { x: 15, y: 0 },
+              diameterMm: 16,
+              depthMm: 30,
+            },
+          ],
+        }),
+      ],
+    });
+
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "tool-cutouts");
+    React.act(() => {
+      (
+        container.querySelector(
+          '[data-testid="button-select-cutout-deep"]',
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    expect(
+      container.querySelector('[data-testid="finger-hole-kind-1"]')?.textContent,
+    ).toContain("Deep scoop");
+    expect(container.querySelector('[aria-label="Diameter"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Total depth"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Reach"]')).toBeNull();
+    expect(container.textContent).toContain("Straight shaft: 22.0 mm");
+    expect(container.textContent).toContain("hemispherical bottom: 8.0 mm");
+
+    React.act(() => {
+      (container.querySelector('[data-testid="view-toggle-2d"]') as HTMLButtonElement).click();
+    });
+    expect(
+      container.querySelector('[data-testid="feature-deep-scoop-cutout-deep"]'),
+    ).not.toBeNull();
     unmount();
   });
 

--- a/docs/gridfinity-plan.md
+++ b/docs/gridfinity-plan.md
@@ -20,10 +20,13 @@ shaped-bin physical gate remains: print a full-pitch
 footprint, then print an L-tool pocket and check its fit.
 
 G4 delivered per-pocket **finger holes**, now individually selectable as
-straight cylinders sharing the pocket's floor and fillet or spherical scoops
-from the top surface (rim exactly the drawn circle, legal deeper than the
-pocket floor). Multiple holes of either kind are stored shape-local and
-draggable as circles in the Layout view; **auto-arrange**
+straight cylinders sharing the pocket's floor and fillet, spherical round
+scoops, or deep scoops from the top surface. A deep scoop keeps a round opening,
+runs straight down for the requested shaft depth, and terminates in a true
+hemisphere; total depth can therefore exceed the opening diameter without an
+inward-overhanging cavity. Round-scoop depth remains capped at half the opening
+width. Multiple holes are stored shape-local and draggable by their exact
+circular rim in the Layout view; **auto-arrange**
 (min-area OBB per cutout — features included — then shelf packing into the
 smallest grid, ids preserved); **undo/redo** over the material document
 `{spec, cutouts}` (hand-rolled history in the bin reducer, mirroring the
@@ -206,7 +209,7 @@ rewrite. Verify against the code before relying on any detail here.
 | Panel + canvas workspace shell | `client/src/components/layout/workspace-layout.tsx` | `autoSaveId` per workspace |
 | Vitest, node + jsdom projects | `vitest.config.ts` | geometry tests run headless with real WASM |
 
-The previously missing `ProjectDoc` is now implemented with `schemaVersion: 2`,
+The previously missing `ProjectDoc` is now implemented with `schemaVersion: 5`,
 IndexedDB autosave plus a named Project Library, explicit `.pocketry.json`
 backup import/export with legacy `.tooltrace.json` import compatibility, and
 reducer-owned undo/redo.
@@ -268,7 +271,7 @@ interface CutoutPlacement {
   cornerRoundMm: number;    // 1.0 — 2D vertical edge round
   topFilletMm: number;      // 0.0 — top-surface pocket-edge round-over
   bottomFilletMm: number;   // 2.8 (r_f2), clamped to depth/2
-  fingerHoles: FingerHole[]; // each kind is 'straight' or 'scoop'
+  fingerHoles: FingerHole[]; // 'straight', 'scoop', or vertical 'deep-scoop'
 }
 ```
 
@@ -288,7 +291,7 @@ export; warnings do not.
 
 `server/storage.ts` has only `MemStorage` (a `Map`, wiped on restart), there is no Drizzle
 implementation and no `migrations/`, and the client never reads anything back. Instead,
-the landed client implementation uses a `ProjectDoc` with **`schemaVersion: 2`**, a
+the landed client implementation uses a `ProjectDoc` with **`schemaVersion: 5`**, a
 hand-rolled reducer history, `idb-keyval` autosave to IndexedDB (not localStorage —
 traced shapes plus thumbnails blow past 5 MB), a browser-local named Project
 Library with active-project autosave, and explicit `.pocketry.json` backup

--- a/shared/gridfinity/cutout.test.ts
+++ b/shared/gridfinity/cutout.test.ts
@@ -7,6 +7,7 @@ import {
   binToCanvas,
   canvasToBin,
   cutoutPlacementSchema,
+  effectiveDeepScoopDepthMm,
   effectiveScoopDepthMm,
   parseCutoutPlacement,
   placementFootprint,
@@ -57,6 +58,16 @@ describe("cutout schemas", () => {
     expect(placement.cornerRoundMm).toBeCloseTo(1, 12);
     expect(placement.topFilletMm).toBe(0);
     expect(placement.bottomFilletMm).toBeCloseTo(R_F2, 12);
+    const withHole = parseCutoutPlacement({
+      id: "c2",
+      shapeId: "s1",
+      position: { x: 0, y: 0 },
+      fingerHoles: [{ id: "f1", center: { x: 0, y: 0 }, diameterMm: 18 }],
+    });
+    expect(withHole.fingerHoles[0]).toMatchObject({
+      kind: "straight",
+      depthMm: 12,
+    });
   });
 
   it("rejects unknown keys and malformed outlines", () => {
@@ -311,8 +322,38 @@ describe("typed finger holes (straight and scoop)", () => {
     expect(Math.max(...ys)).toBeCloseTo(13, 9);
   });
 
+  it("uses a round plan-view footprint for a deep scoop", () => {
+    const footprint = placementFootprint({ outlineMm: CHIRAL }, {
+      position: { x: 0, y: 0 },
+      rotationDeg: 90,
+      mirrored: false,
+      fingerHoles: [
+        {
+          id: "f1",
+          center: { x: 10, y: 0 },
+          diameterMm: 6,
+          kind: "deep-scoop",
+          depthMm: 20,
+        },
+      ],
+    });
+    const xs = footprint.features[0].map((point) => point.x);
+    const ys = footprint.features[0].map((point) => point.y);
+    // Local (10, 0) becomes bin (0, 10) after the 90° placement.
+    expect(Math.min(...xs)).toBeCloseTo(-3, 9);
+    expect(Math.max(...xs)).toBeCloseTo(3, 9);
+    expect(Math.min(...ys)).toBeCloseTo(7, 9);
+    expect(Math.max(...ys)).toBeCloseTo(13, 9);
+    expect(signedArea(footprint.features[0])).toBeGreaterThan(0);
+  });
+
   it("clamps the scoop to a hemisphere", () => {
     expect(effectiveScoopDepthMm({ diameterMm: 30, depthMm: 12 })).toBe(12);
     expect(effectiveScoopDepthMm({ diameterMm: 20, depthMm: 25 })).toBe(10);
+  });
+
+  it("keeps a deep scoop at least one radius deep", () => {
+    expect(effectiveDeepScoopDepthMm({ diameterMm: 18, depthMm: 30 })).toBe(30);
+    expect(effectiveDeepScoopDepthMm({ diameterMm: 18, depthMm: 4 })).toBe(9);
   });
 });

--- a/shared/gridfinity/cutout.ts
+++ b/shared/gridfinity/cutout.ts
@@ -41,11 +41,11 @@ import type { BinSpec } from "./types";
  * - The 2D editor's SVG view is y-down; that flip is **view-only** and lives
  *   solely in {@link binToCanvas} / {@link canvasToBin}.
  *
- * G4 adds per-pocket **finger holes** whose type is either a vertical cylinder
- * sharing the pocket's floor or a spherical scoop sunk from the top surface.
- * There may be several of either. Their centres are stored **shape-local**, so
- * they travel with the pocket through move / rotate / mirror. Schema-v1's
- * one-off scoop migrates into this per-hole model.
+ * G4 adds per-pocket **finger holes** whose type is either a vertical cylinder,
+ * a spherical scoop, or a deep scoop with a straight shaft and hemispherical
+ * bottom. There may be several of any kind. Their centres are stored
+ * **shape-local**, so they travel with the pocket through move / rotate /
+ * mirror. Schema-v1's one-off scoop migrates into this per-hole model.
  */
 
 // ---------------------------------------------------------------------------
@@ -110,8 +110,10 @@ export type DepthSpec = z.infer<typeof depthSpecSchema>;
 
 /**
  * A draggable finger-access feature. Straight holes are vertical cylinders
- * cut to the pocket floor; scoops are spherical dishes cut from the top.
- * `center` is shape-local, so either kind follows move / rotate / mirror.
+ * cut to the pocket floor; round scoops are spherical dishes cut from the top;
+ * deep scoops descend through a straight cylindrical shaft and finish in a
+ * hemispherical bottom. `center` is shape-local, so every kind follows move /
+ * rotate / mirror.
  */
 export const fingerHoleSchema = z
   .object({
@@ -119,11 +121,23 @@ export const fingerHoleSchema = z
     /** Shape-local mm, same frame as `outlineMm`. */
     center: vec2Schema,
     diameterMm: z.number().min(6).max(80).default(18),
-    kind: z.enum(["straight", "scoop"]).default("straight"),
+    // `oblong-scoop` accepts saves made by the short-lived directed-trough
+    // prototype and normalizes them to the corrected vertical deep scoop.
+    kind: z
+      .enum(["straight", "scoop", "deep-scoop", "oblong-scoop"])
+      .default("straight"),
     /** Used only for scoops; retained on straight holes so type changes are reversible. */
-    depthMm: z.number().min(1).max(30).default(12),
+    depthMm: z.number().min(1).max(120).default(12),
+    /** Compatibility only; removed with the directed-trough prototype. */
+    reachMm: z.number().min(1).max(120).optional(),
+    /** Compatibility only; removed with the directed-trough prototype. */
+    directionDeg: z.number().finite().optional(),
   })
-  .strict();
+  .strict()
+  .transform(({ reachMm: _reach, directionDeg: _direction, kind, ...hole }) => ({
+    ...hole,
+    kind: kind === "oblong-scoop" ? ("deep-scoop" as const) : kind,
+  }));
 
 export type FingerHole = z.infer<typeof fingerHoleSchema>;
 
@@ -153,6 +167,17 @@ export function effectiveScoopDepthMm(
   scoop: Pick<FingerHole, "diameterMm" | "depthMm">,
 ): number {
   return Math.min(scoop.depthMm, scoop.diameterMm / 2);
+}
+
+/**
+ * Total top-to-bottom depth of a deep scoop. The cutter always includes at
+ * least one radius so its bottom remains a true hemisphere even when an old
+ * or hand-edited project requests a shallower value.
+ */
+export function effectiveDeepScoopDepthMm(
+  scoop: Pick<FingerHole, "diameterMm" | "depthMm">,
+): number {
+  return Math.max(scoop.depthMm, scoop.diameterMm / 2);
 }
 
 const cutoutPlacementInputSchema = z
@@ -198,7 +223,11 @@ export const cutoutPlacementSchema = cutoutPlacementInputSchema.transform(
       ...placement,
       fingerHoles: [
         ...placement.fingerHoles,
-        { id, kind: "scoop" as const, ...scoop },
+        {
+          id,
+          kind: "scoop" as const,
+          ...scoop,
+        },
       ],
     };
   },
@@ -274,7 +303,7 @@ export function transformOutlinePlacement(
 }
 
 // ---------------------------------------------------------------------------
-// Placement footprint (outline + feature circles)
+// Placement footprint (outline + finger-access rims)
 // ---------------------------------------------------------------------------
 
 /** A CCW `segments`-gon approximating the circle, for validation geometry. */
@@ -288,6 +317,19 @@ export function circleRing(center: Point, radiusMm: number, segments = 24): Poin
     });
   }
   return ring;
+}
+
+/** Exact plan-view rim used by rendering, validation, and cutter geometry. */
+export function fingerHoleFootprintRing(
+  hole: FingerHole,
+  placement: PlacementTransform,
+  segments = 24,
+): Point[] {
+  const local = circleRing(hole.center, hole.diameterMm / 2, segments);
+  return ensureOrientation(
+    mapRing(local, (point) => transformPointPlacement(point, placement)),
+    OUTER_ORIENTATION,
+  );
 }
 
 export interface PlacementFootprint {
@@ -316,13 +358,7 @@ export function placementFootprint(
 ): PlacementFootprint {
   const features: Point[][] = [];
   for (const hole of placement.fingerHoles) {
-    features.push(
-      circleRing(
-        transformPointPlacement(hole.center, placement),
-        hole.diameterMm / 2,
-        segments,
-      ),
-    );
+    features.push(fingerHoleFootprintRing(hole, placement, segments));
   }
   return {
     outline: transformOutlinePlacement(shape.outlineMm, placement),

--- a/shared/gridfinity/project.test.ts
+++ b/shared/gridfinity/project.test.ts
@@ -60,7 +60,7 @@ describe("parseProjectDoc", () => {
 });
 
 describe("project file round trip", () => {
-  it("preserves straight and scoop finger holes through JSON", () => {
+  it("preserves straight, round-scoop and deep-scoop finger holes through JSON", () => {
     const withFeatures = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
     (withFeatures.cutouts as Record<string, unknown>[])[0] = {
       ...(withFeatures.cutouts as Record<string, unknown>[])[0],
@@ -79,16 +79,28 @@ describe("project file round trip", () => {
           diameterMm: 28,
           depthMm: 10,
         },
+        {
+          id: "f3",
+          kind: "deep-scoop",
+          center: { x: 12, y: 0 },
+          diameterMm: 16,
+          depthMm: 38,
+        },
       ],
     };
     // The exact path the Save file / Open file buttons take.
     const doc = parseProjectDoc(JSON.parse(JSON.stringify(withFeatures)));
     expect(doc).not.toBeNull();
-    expect(doc!.cutouts[0].fingerHoles).toHaveLength(2);
+    expect(doc!.cutouts[0].fingerHoles).toHaveLength(3);
     expect(doc!.cutouts[0].fingerHoles[1]).toMatchObject({
       id: "f2",
       kind: "scoop",
       depthMm: 10,
+    });
+    expect(doc!.cutouts[0].fingerHoles[2]).toMatchObject({
+      id: "f3",
+      kind: "deep-scoop",
+      depthMm: 38,
     });
   });
 
@@ -132,5 +144,55 @@ describe("project file round trip", () => {
     const doc = parseProjectDoc(legacy);
     expect(doc?.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
     expect(doc?.spec.footprint).toEqual({ kind: "rectangle" });
+  });
+
+  it("migrates schema v4 finger holes without changing their geometry", () => {
+    const legacy = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
+    legacy.schemaVersion = 4;
+    (legacy.cutouts as Record<string, unknown>[])[0] = {
+      ...(legacy.cutouts as Record<string, unknown>[])[0],
+      fingerHoles: [
+        {
+          id: "f1",
+          kind: "scoop",
+          center: { x: 4, y: 0 },
+          diameterMm: 18,
+          depthMm: 8,
+        },
+      ],
+    };
+    const doc = parseProjectDoc(legacy);
+    expect(doc?.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
+    expect(doc?.cutouts[0].fingerHoles[0]).toMatchObject({
+      kind: "scoop",
+      diameterMm: 18,
+      depthMm: 8,
+    });
+  });
+
+  it("normalizes the prototype oblong scoop into a vertical deep scoop", () => {
+    const prototype = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
+    (prototype.cutouts as Record<string, unknown>[])[0] = {
+      ...(prototype.cutouts as Record<string, unknown>[])[0],
+      fingerHoles: [
+        {
+          id: "prototype",
+          kind: "oblong-scoop",
+          center: { x: 4, y: 0 },
+          diameterMm: 18,
+          depthMm: 24,
+          reachMm: 30,
+          directionDeg: 180,
+        },
+      ],
+    };
+    const doc = parseProjectDoc(prototype);
+    expect(doc?.cutouts[0].fingerHoles[0]).toEqual({
+      id: "prototype",
+      kind: "deep-scoop",
+      center: { x: 4, y: 0 },
+      diameterMm: 18,
+      depthMm: 24,
+    });
   });
 });

--- a/shared/gridfinity/project.ts
+++ b/shared/gridfinity/project.ts
@@ -11,10 +11,10 @@ import { binSpecSchema } from "./types";
  * feature models change. Version 2 replaces the one-off scoop with typed,
  * per-finger-hole straight/scoop geometry; version 3 adds a per-pocket top
  * edge fillet; version 4 adds nonrectangular cell footprints and boundary-edge
- * label-tab anchors.
+ * label-tab anchors; version 5 adds straight-shaft deep finger scoops.
  */
 
-export const PROJECT_SCHEMA_VERSION = 4 as const;
+export const PROJECT_SCHEMA_VERSION = 5 as const;
 
 const projectFields = {
   shapes: z.array(tracedShapeSchema),
@@ -62,6 +62,17 @@ const projectDocV3Schema = z
     schemaVersion: PROJECT_SCHEMA_VERSION,
   }));
 
+const projectDocV4Schema = z
+  .object({
+    schemaVersion: z.literal(4),
+    ...projectFields,
+  })
+  .strict()
+  .transform(({ schemaVersion: _legacyVersion, ...doc }) => ({
+    ...doc,
+    schemaVersion: PROJECT_SCHEMA_VERSION,
+  }));
+
 export type ProjectDoc = z.infer<typeof projectDocSchema>;
 
 /**
@@ -72,6 +83,8 @@ export type ProjectDoc = z.infer<typeof projectDocSchema>;
 export function parseProjectDoc(input: unknown): ProjectDoc | null {
   const result = projectDocSchema.safeParse(input);
   if (result.success) return result.data;
+  const migratedV4 = projectDocV4Schema.safeParse(input);
+  if (migratedV4.success) return migratedV4.data;
   const migratedV3 = projectDocV3Schema.safeParse(input);
   if (migratedV3.success) return migratedV3.data;
   const migratedV2 = projectDocV2Schema.safeParse(input);

--- a/shared/gridfinity/validate-layout.test.ts
+++ b/shared/gridfinity/validate-layout.test.ts
@@ -316,6 +316,42 @@ describe("validateLayout: finger holes and scoops (G4)", () => {
     expect(result).not.toContain("out-of-bounds");
   });
 
+  it("validates a deep scoop by its round mouth, not its vertical depth", () => {
+    const shape = makeShape("s1", 20, 20);
+    const cutout = makeCutout("c1", "s1", 0, 0, {
+      fingerHoles: [
+        {
+          id: "f1",
+          kind: "deep-scoop",
+          center: { x: 0, y: 0 },
+          diameterMm: 6,
+          depthMm: 30,
+        },
+      ],
+    });
+    const result = codes(spec(), [cutout], [shape]);
+    expect(result).not.toContain("wall-breach");
+    expect(result).not.toContain("out-of-bounds");
+  });
+
+  it("uses the full deep-scoop shaft and hemisphere depth for floor validation", () => {
+    const shape = makeShape("s1", 20, 20);
+    const cutout = makeCutout("c1", "s1", 0, 0, {
+      fingerHoles: [
+        {
+          id: "f1",
+          kind: "deep-scoop",
+          center: { x: 0, y: 0 },
+          diameterMm: 10,
+          depthMm: 15,
+        },
+      ],
+    });
+    expect(codes(spec({ heightUnits: 2 }), [cutout], [shape])).toContain(
+      "scoop-too-deep",
+    );
+  });
+
   it("errors when a scoop is deeper than the bin", () => {
     const shape = makeShape("s1", 20, 20);
     const cutout = makeCutout("c1", "s1", 0, 0, {

--- a/shared/gridfinity/validate.ts
+++ b/shared/gridfinity/validate.ts
@@ -13,6 +13,7 @@ import {
   resolveBoundaryRun,
 } from "./footprint";
 import {
+  effectiveDeepScoopDepthMm,
   effectiveScoopDepthMm,
   placementFootprint,
   resolvePocketDepth,
@@ -463,8 +464,11 @@ function validateAgainstBin(spec: BinSpec, p: PlacedCutout): ValidationIssue[] {
   // Scoop-style finger holes cut from the top surface regardless of pocket
   // depth, so each gets its own floor arithmetic.
   for (const hole of cutout.fingerHoles) {
-    if (hole.kind !== "scoop") continue;
-    const scoopBottomZ = pocket.infillTopZ - effectiveScoopDepthMm(hole);
+    if (hole.kind !== "scoop" && hole.kind !== "deep-scoop") continue;
+    const cutDepth = hole.kind === "deep-scoop"
+      ? effectiveDeepScoopDepthMm(hole)
+      : effectiveScoopDepthMm(hole);
+    const scoopBottomZ = pocket.infillTopZ - cutDepth;
     if (scoopBottomZ < 0) {
       issues.push({
         code: "scoop-too-deep",


### PR DESCRIPTION
## Summary

- add a separate Deep scoop finger-hole type with a round mouth, straight cylindrical shaft, and hemispherical bottom
- expose diameter and total-depth controls while removing the discarded sideways reach/direction model
- normalize prototype oblong-scoop saves into the corrected deep-scoop model
- validate the circular footprint and full vertical depth, with real Manifold geometry coverage

## Verification

- `npm run check`
- `npm test` — 69 files, 871 tests passed
- `npm run build`
- `git diff --check origin/main...HEAD`

## Remaining physical gate

The geometry has not yet been validated with a physical print.