### PR TITLE
Add independent, resizable finger holes

### DIFF
--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  CircleDot,
   Copy,
   Download,
   Eye,
@@ -12,6 +13,8 @@ import {
   Palette,
   Pencil,
   Plus,
+  RotateCcw,
+  RotateCw,
   Ruler,
   Save,
   Scissors,
@@ -21,7 +24,13 @@ import {
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { useLocation } from "wouter";
 
-import type { FingerHole, TracedShape } from "@shared/gridfinity/cutout";
+import {
+  DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
+  MAX_OBLONG_DEEP_SCOOP_LENGTH_MM,
+  MIN_OBLONG_DEEP_SCOOP_SPAN_MM,
+  type FingerHole,
+  type TracedShape,
+} from "@shared/gridfinity/cutout";
 import {
   binFootprintMm,
   GRID_PITCH_DIVISOR,
@@ -195,6 +204,7 @@ const BIN_SETTINGS_SECTIONS = [
   { id: "bin-settings-size", label: "Size", tone: "blue" },
   { id: "bin-settings-construction", label: "Construction", tone: "rose" },
   { id: "bin-settings-pockets", label: "Tool Cutouts", tone: "violet" },
+  { id: "bin-settings-finger-holes", label: "Finger Holes", tone: "cyan" },
   { id: "bin-settings-view", label: "View", tone: "amber" },
   { id: "bin-settings-export", label: "Export", tone: "emerald" },
 ] as const;
@@ -285,7 +295,9 @@ export function BinControlsPanel({
   const {
     spec,
     cutouts,
+    fingerHoles,
     selectedCutoutId,
+    selectedFingerHoleId,
     pendingRemovalId,
     editorMode,
     hydrated,
@@ -304,9 +316,9 @@ export function BinControlsPanel({
   const issues = useMemo(
     () => [
       ...validateBinSpec(spec).issues,
-      ...validateLayout(spec, cutouts, shapesById),
+      ...validateLayout(spec, cutouts, shapesById, fingerHoles),
     ],
-    [spec, cutouts, shapesById],
+    [spec, cutouts, shapesById, fingerHoles],
   );
   const hasErrors = issues.some((issue) => issue.severity === "error");
   const enabledFeatureCount = [
@@ -317,10 +329,6 @@ export function BinControlsPanel({
     spec.screwHoles,
     spec.labelTab !== null,
   ].filter(Boolean).length;
-  const fingerHoleCount = cutouts.reduce(
-    (count, cutout) => count + cutout.fingerHoles.length,
-    0,
-  );
   const [fitCheckDepthMm, setFitCheckDepthMm] = useState(2);
   const [surfaceFitCheckThicknessMm, setSurfaceFitCheckThicknessMm] = useState(
     SURFACE_FIT_CHECK_DEFAULT_THICKNESS_MM,
@@ -369,6 +377,8 @@ export function BinControlsPanel({
   };
 
   const selectedCutout = cutouts.find((cutout) => cutout.id === selectedCutoutId) ?? null;
+  const selectedFingerHole =
+    fingerHoles.find((hole) => hole.id === selectedFingerHoleId) ?? null;
   const selectedShape = selectedCutout
     ? (shapesById.get(selectedCutout.shapeId) ?? null)
     : null;
@@ -386,6 +396,7 @@ export function BinControlsPanel({
       nextCutouts,
       shapesById,
       spec,
+      fingerHoles,
     );
     dispatch({
       type: "REPLACE_LAYOUT",
@@ -530,7 +541,7 @@ export function BinControlsPanel({
               Updating 3D preview…
             </div>
           )}
-          {cutouts.length > 0 && (
+          {(cutouts.length > 0 || fingerHoles.length > 0) && (
             <Button
               variant="outline"
               size="sm"
@@ -712,9 +723,7 @@ export function BinControlsPanel({
           title="Tool Cutout Settings"
           icon={Scissors}
           tone="violet"
-          summary={`${cutouts.length} pocket${cutouts.length === 1 ? "" : "s"} · ${
-            fingerHoleCount
-          } hole${fingerHoleCount === 1 ? "" : "s"}`}
+          summary={`${cutouts.length} pocket${cutouts.length === 1 ? "" : "s"}`}
           defaultOpen={cutouts.length > 0}
           className="scroll-mt-16"
         >
@@ -734,7 +743,7 @@ export function BinControlsPanel({
                   <span className="font-semibold">Select a tool contour to edit it.</span>{" "}
                   Click it in the Layout view or choose its pocket below. Once
                   selected, click the tool name itself to rename it; the remaining
-                  contour, depth, clearance, finger-hole, and edge options appear below.
+                  contour, depth, clearance, and edge options appear below.
                 </p>
               </div>
               <Button
@@ -856,203 +865,6 @@ export function BinControlsPanel({
                   point to remove it.
                 </p>
               )}
-
-              {/* Keep finger access beside the selected-pocket heading so it
-                  cannot disappear below the pocket-shaping controls. */}
-              <div className="space-y-2 rounded-md border border-violet-500/20 bg-violet-500/5 p-2.5">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <Label className="text-xs">Finger holes</Label>
-                    <p className="text-[11px] text-muted-foreground">
-                      Straight cut, top scoop, or deep scoop
-                    </p>
-                  </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 px-2 text-xs"
-                    data-testid="button-add-finger-hole"
-                    onClick={() =>
-                      dispatch({
-                        type: "UPDATE_CUTOUT",
-                        id: selectedCutout.id,
-                        patch: {
-                          fingerHoles: [
-                            ...selectedCutout.fingerHoles,
-                            {
-                              id: crypto.randomUUID(),
-                              // Default on the outline's right edge so the
-                              // cut straddles pocket and material.
-                              center: { x: selectedShape.bboxMm.maxX, y: 0 },
-                              diameterMm: 18,
-                              kind: "straight",
-                              depthMm: 12,
-                            },
-                          ],
-                        },
-                        historyLabel: "Add finger hole",
-                      })
-                    }
-                  >
-                    <Plus className="mr-1 h-3 w-3" />
-                    Add hole
-                  </Button>
-                </div>
-                {selectedCutout.fingerHoles.map((hole, index) => (
-                  <div key={hole.id} className="space-y-2 rounded-md border bg-background p-2">
-                    <div className="flex items-center gap-2">
-                      <Label className="flex-1 text-xs">Hole {index + 1}</Label>
-                      <Select
-                        value={hole.kind}
-                        onValueChange={(kind) =>
-                          dispatch({
-                            type: "UPDATE_CUTOUT",
-                            id: selectedCutout.id,
-                            patch: {
-                              fingerHoles: selectedCutout.fingerHoles.map((h) =>
-                                h.id === hole.id
-                                  ? {
-                                      ...h,
-                                      kind: kind as FingerHole["kind"],
-                                      depthMm:
-                                        kind === "scoop"
-                                          ? Math.min(h.depthMm, h.diameterMm / 2)
-                                          : kind === "deep-scoop"
-                                            ? Math.max(h.depthMm, h.diameterMm)
-                                            : h.depthMm,
-                                    }
-                                  : h,
-                              ),
-                            },
-                            historyLabel: "Change finger hole type",
-                          })
-                        }
-                      >
-                        <SelectTrigger
-                          className="h-7 w-36 px-2 text-xs"
-                          aria-label={`Finger hole ${index + 1} type`}
-                          data-testid={`finger-hole-kind-${index + 1}`}
-                        >
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="straight">Straight</SelectItem>
-                          <SelectItem value="scoop">Round scoop</SelectItem>
-                          <SelectItem value="deep-scoop">Deep scoop</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <button
-                        type="button"
-                        className="shrink-0 text-muted-foreground hover:text-destructive"
-                        aria-label={`Remove finger hole ${index + 1}`}
-                        onClick={() =>
-                          dispatch({
-                            type: "UPDATE_CUTOUT",
-                            id: selectedCutout.id,
-                            patch: {
-                              fingerHoles: selectedCutout.fingerHoles.filter(
-                                (h) => h.id !== hole.id,
-                              ),
-                            },
-                            historyLabel: "Remove finger hole",
-                          })
-                        }
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
-                    <MmSlider
-                      label="Diameter"
-                      value={hole.diameterMm}
-                      min={6}
-                      max={40}
-                      step={1}
-                      onChange={(diameterMm, transient) =>
-                        dispatch({
-                          type: "UPDATE_CUTOUT",
-                          id: selectedCutout.id,
-                          patch: {
-                            fingerHoles: selectedCutout.fingerHoles.map((h) =>
-                              h.id === hole.id
-                                ? {
-                                    ...h,
-                                    diameterMm,
-                                    depthMm:
-                                      h.kind === "scoop"
-                                        ? Math.min(h.depthMm, diameterMm / 2)
-                                        : h.kind === "deep-scoop"
-                                          ? Math.max(h.depthMm, diameterMm / 2)
-                                          : h.depthMm,
-                                  }
-                                : h,
-                            ),
-                          },
-                          historyLabel: "Resize finger hole",
-                          transient,
-                        })
-                      }
-                    />
-                    {hole.kind === "scoop" && (
-                      <MmSlider
-                        label="Depth"
-                        value={Math.min(hole.depthMm, hole.diameterMm / 2)}
-                        min={1}
-                        max={Math.min(30, hole.diameterMm / 2)}
-                        step={0.5}
-                        onChange={(depthMm, transient) =>
-                          dispatch({
-                            type: "UPDATE_CUTOUT",
-                            id: selectedCutout.id,
-                            patch: {
-                              fingerHoles: selectedCutout.fingerHoles.map((h) =>
-                                h.id === hole.id ? { ...h, depthMm } : h,
-                              ),
-                            },
-                            historyLabel: "Change finger scoop depth",
-                            transient,
-                          })
-                        }
-                      />
-                    )}
-                    {hole.kind === "deep-scoop" && (
-                      <div className="space-y-1">
-                        <MmSlider
-                          label="Total depth"
-                          value={Math.max(hole.depthMm, hole.diameterMm / 2)}
-                          min={hole.diameterMm / 2}
-                          max={120}
-                          step={0.5}
-                          onChange={(depthMm, transient) =>
-                            dispatch({
-                              type: "UPDATE_CUTOUT",
-                              id: selectedCutout.id,
-                              patch: {
-                                fingerHoles: selectedCutout.fingerHoles.map((h) =>
-                                  h.id === hole.id ? { ...h, depthMm } : h,
-                                ),
-                              },
-                              historyLabel: "Change deep scoop depth",
-                              transient,
-                            })
-                          }
-                        />
-                        <p className="pl-16 text-[11px] text-muted-foreground">
-                          Straight shaft: {Math.max(
-                            0,
-                            hole.depthMm - hole.diameterMm / 2,
-                          ).toFixed(1)} mm · hemispherical bottom: {(
-                            hole.diameterMm / 2
-                          ).toFixed(1)} mm
-                        </p>
-                      </div>
-                    )}
-                  </div>
-                ))}
-                <p className="text-[11px] text-muted-foreground">
-                  Drag a feature in Layout to position its round mouth. A deep
-                  scoop runs straight down, then ends in a hemisphere.
-                </p>
-              </div>
 
               <div className="flex items-center gap-2">
                 <Label className="w-16 shrink-0 text-xs">Rotation</Label>
@@ -1202,6 +1014,360 @@ export function BinControlsPanel({
 
             </div>
           )}
+        </PanelSection>
+
+        <PanelSection
+          key={fingerHoles.length > 0 ? "finger-holes" : "finger-holes-empty"}
+          id="bin-settings-finger-holes"
+          title="Finger Holes"
+          icon={CircleDot}
+          tone="cyan"
+          summary={`${fingerHoles.length} hole${fingerHoles.length === 1 ? "" : "s"}`}
+          defaultOpen={fingerHoles.length > 0}
+          className="scroll-mt-16"
+        >
+          <div className="space-y-3">
+            <div className="flex items-start justify-between gap-3 rounded-md border border-violet-500/25 bg-violet-500/10 px-2.5 py-2">
+              <p className="text-[11px] text-violet-900 dark:text-violet-100">
+                Finger holes are independent layout objects. Select, move, resize,
+                or remove one without changing a tool pocket.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 shrink-0 px-2 text-xs"
+                data-testid="button-add-finger-hole"
+                onClick={() =>
+                  dispatch({
+                    type: "ADD_FINGER_HOLE",
+                    hole: {
+                      id: crypto.randomUUID(),
+                      center: { x: 0, y: 0 },
+                      diameterMm: 18,
+                      kind: "straight",
+                      depthMm: 12,
+                    },
+                  })
+                }
+              >
+                <Plus className="mr-1 h-3 w-3" />
+                Add hole
+              </Button>
+            </div>
+
+            {fingerHoles.length > 0 && (
+              <div className="space-y-1">
+                {fingerHoles.map((hole, index) => {
+                  const isSelected = hole.id === selectedFingerHoleId;
+                  return (
+                    <div
+                      key={hole.id}
+                      className={cn(
+                        "flex items-center gap-1 rounded border px-1 py-1 text-xs",
+                        isSelected
+                          ? "border-violet-500/40 bg-violet-500/10"
+                          : "border-transparent hover:border-violet-500/20 hover:bg-accent/50",
+                      )}
+                      data-testid={`finger-hole-row-${hole.id}`}
+                    >
+                      <button
+                        type="button"
+                        className="min-w-0 flex-1 rounded px-1 py-0.5 text-left font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        onClick={() =>
+                          dispatch({ type: "SELECT_FINGER_HOLE", id: hole.id })
+                        }
+                        data-testid={`button-select-finger-hole-${hole.id}`}
+                      >
+                        Hole {index + 1} · {hole.kind === "scoop"
+                          ? "Round scoop"
+                          : hole.kind === "deep-scoop"
+                            ? "Deep scoop"
+                            : hole.kind === "oblong-deep-scoop"
+                              ? "Oblong deep scoop"
+                              : "Straight"}
+                      </button>
+                      <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                        {isSelected ? "Selected" : "Select to edit"}
+                      </span>
+                      <button
+                        type="button"
+                        className="shrink-0 text-muted-foreground hover:text-destructive"
+                        aria-label={`Remove finger hole ${index + 1}`}
+                        onClick={() =>
+                          dispatch({ type: "REMOVE_FINGER_HOLE", id: hole.id })
+                        }
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {selectedFingerHole && (
+              <div className="space-y-2 border-t pt-3">
+                <Select
+                  value={selectedFingerHole.kind}
+                  onValueChange={(kind) => {
+                    const diameterMm = selectedFingerHole.diameterMm;
+                    dispatch({
+                      type: "UPDATE_FINGER_HOLE",
+                      id: selectedFingerHole.id,
+                      patch: {
+                        kind: kind as FingerHole["kind"],
+                        depthMm:
+                          kind === "scoop"
+                            ? Math.min(selectedFingerHole.depthMm, diameterMm / 2)
+                            : kind === "deep-scoop" || kind === "oblong-deep-scoop"
+                              ? Math.max(selectedFingerHole.depthMm, diameterMm / 2)
+                              : selectedFingerHole.depthMm,
+                        lengthMm:
+                          kind === "oblong-deep-scoop"
+                            ? Math.max(
+                                selectedFingerHole.lengthMm ??
+                                  DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
+                                diameterMm + MIN_OBLONG_DEEP_SCOOP_SPAN_MM,
+                              )
+                            : selectedFingerHole.lengthMm,
+                        rotationDeg:
+                          kind === "oblong-deep-scoop"
+                            ? (selectedFingerHole.rotationDeg ?? 0)
+                            : selectedFingerHole.rotationDeg,
+                      },
+                      historyLabel: "Change finger hole type",
+                    });
+                  }}
+                >
+                  <SelectTrigger
+                    className="h-8"
+                    aria-label="Selected finger hole type"
+                    data-testid="selected-finger-hole-kind"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="straight">Straight</SelectItem>
+                    <SelectItem value="scoop">Round scoop</SelectItem>
+                    <SelectItem value="deep-scoop">Deep scoop</SelectItem>
+                    <SelectItem value="oblong-deep-scoop">
+                      Oblong deep scoop
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+
+                <MmSlider
+                  label="Diameter"
+                  value={selectedFingerHole.diameterMm}
+                  min={6}
+                  max={40}
+                  step={1}
+                  onChange={(diameterMm, transient) =>
+                    dispatch({
+                      type: "UPDATE_FINGER_HOLE",
+                      id: selectedFingerHole.id,
+                      patch: {
+                        diameterMm,
+                        depthMm:
+                          selectedFingerHole.kind === "scoop"
+                            ? Math.min(selectedFingerHole.depthMm, diameterMm / 2)
+                            : selectedFingerHole.kind === "deep-scoop" ||
+                                selectedFingerHole.kind === "oblong-deep-scoop"
+                              ? Math.max(selectedFingerHole.depthMm, diameterMm / 2)
+                              : selectedFingerHole.depthMm,
+                        lengthMm:
+                          selectedFingerHole.kind === "oblong-deep-scoop"
+                            ? Math.max(
+                                selectedFingerHole.lengthMm ??
+                                  DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
+                                diameterMm + MIN_OBLONG_DEEP_SCOOP_SPAN_MM,
+                              )
+                            : selectedFingerHole.lengthMm,
+                      },
+                      historyLabel: "Resize finger hole",
+                      transient,
+                    })
+                  }
+                  hint="You can also drag the white size handle in Layout."
+                />
+
+                {selectedFingerHole.kind === "straight" && (
+                  <MmSlider
+                    label="Depth"
+                    value={selectedFingerHole.depthMm}
+                    min={1}
+                    max={120}
+                    step={0.5}
+                    onChange={(depthMm, transient) =>
+                      dispatch({
+                        type: "UPDATE_FINGER_HOLE",
+                        id: selectedFingerHole.id,
+                        patch: { depthMm },
+                        historyLabel: "Change finger hole depth",
+                        transient,
+                      })
+                    }
+                  />
+                )}
+
+                {selectedFingerHole.kind === "scoop" && (
+                  <MmSlider
+                    label="Depth"
+                    value={Math.min(
+                      selectedFingerHole.depthMm,
+                      selectedFingerHole.diameterMm / 2,
+                    )}
+                    min={1}
+                    max={Math.min(30, selectedFingerHole.diameterMm / 2)}
+                    step={0.5}
+                    onChange={(depthMm, transient) =>
+                      dispatch({
+                        type: "UPDATE_FINGER_HOLE",
+                        id: selectedFingerHole.id,
+                        patch: { depthMm },
+                        historyLabel: "Change finger scoop depth",
+                        transient,
+                      })
+                    }
+                  />
+                )}
+
+                {(selectedFingerHole.kind === "deep-scoop" ||
+                  selectedFingerHole.kind === "oblong-deep-scoop") && (
+                  <div className="space-y-1">
+                    <MmSlider
+                      label="Total depth"
+                      value={Math.max(
+                        selectedFingerHole.depthMm,
+                        selectedFingerHole.diameterMm / 2,
+                      )}
+                      min={selectedFingerHole.diameterMm / 2}
+                      max={120}
+                      step={0.5}
+                      onChange={(depthMm, transient) =>
+                        dispatch({
+                          type: "UPDATE_FINGER_HOLE",
+                          id: selectedFingerHole.id,
+                          patch: { depthMm },
+                          historyLabel: "Change deep scoop depth",
+                          transient,
+                        })
+                      }
+                    />
+                    <p className="pl-16 text-[11px] text-muted-foreground">
+                      Vertical walls: {Math.max(
+                        0,
+                        selectedFingerHole.depthMm -
+                          selectedFingerHole.diameterMm / 2,
+                      ).toFixed(1)} mm · rounded bottom radius: {(
+                        selectedFingerHole.diameterMm / 2
+                      ).toFixed(1)} mm
+                    </p>
+                  </div>
+                )}
+
+                {selectedFingerHole.kind === "oblong-deep-scoop" && (
+                  <div className="space-y-2">
+                    <MmSlider
+                      label="Length"
+                      value={Math.max(
+                        selectedFingerHole.lengthMm ??
+                          DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
+                        selectedFingerHole.diameterMm +
+                          MIN_OBLONG_DEEP_SCOOP_SPAN_MM,
+                      )}
+                      min={
+                        selectedFingerHole.diameterMm +
+                        MIN_OBLONG_DEEP_SCOOP_SPAN_MM
+                      }
+                      max={MAX_OBLONG_DEEP_SCOOP_LENGTH_MM}
+                      step={1}
+                      onChange={(lengthMm, transient) =>
+                        dispatch({
+                          type: "UPDATE_FINGER_HOLE",
+                          id: selectedFingerHole.id,
+                          patch: { lengthMm },
+                          historyLabel: "Resize oblong finger hole",
+                          transient,
+                        })
+                      }
+                    />
+                    <div className="flex items-center gap-1.5">
+                      <Label className="w-16 shrink-0 text-xs">Rotation</Label>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-8 w-8 shrink-0"
+                        aria-label="Rotate oblong finger hole 90 degrees counterclockwise"
+                        onClick={() =>
+                          dispatch({
+                            type: "UPDATE_FINGER_HOLE",
+                            id: selectedFingerHole.id,
+                            patch: {
+                              rotationDeg:
+                                (((selectedFingerHole.rotationDeg ?? 0) + 90) %
+                                  360 +
+                                  360) %
+                                360,
+                            },
+                            historyLabel: "Rotate oblong finger hole",
+                          })
+                        }
+                      >
+                        <RotateCcw className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-8 w-8 shrink-0"
+                        aria-label="Rotate oblong finger hole 90 degrees clockwise"
+                        onClick={() =>
+                          dispatch({
+                            type: "UPDATE_FINGER_HOLE",
+                            id: selectedFingerHole.id,
+                            patch: {
+                              rotationDeg:
+                                (((selectedFingerHole.rotationDeg ?? 0) - 90) %
+                                  360 +
+                                  360) %
+                                360,
+                            },
+                            historyLabel: "Rotate oblong finger hole",
+                          })
+                        }
+                      >
+                        <RotateCw className="h-3.5 w-3.5" />
+                      </Button>
+                      <DraftNumberInput
+                        className="h-8 min-w-0"
+                        aria-label="Oblong finger hole rotation"
+                        value={
+                          Math.round((selectedFingerHole.rotationDeg ?? 0) * 10) /
+                          10
+                        }
+                        step={15}
+                        normalize={(value) => ((value % 360) + 360) % 360}
+                        onValueChange={(rotationDeg) =>
+                          dispatch({
+                            type: "UPDATE_FINGER_HOLE",
+                            id: selectedFingerHole.id,
+                            patch: { rotationDeg },
+                            historyLabel: "Rotate oblong finger hole",
+                          })
+                        }
+                      />
+                      <span className="text-xs text-muted-foreground">°</span>
+                    </div>
+                  </div>
+                )}
+                <p className="text-[11px] text-muted-foreground">
+                  Drag the shape to move it. Drag the white size handle to change
+                  diameter; oblong holes also have two end handles for length and
+                  angle.
+                </p>
+              </div>
+            )}
+          </div>
         </PanelSection>
 
         <PanelSection
@@ -1414,7 +1580,7 @@ export function BinControlsPanel({
                 ? stats
                   ? "Updating"
                   : "Building"
-                : cutouts.length === 0
+                : cutouts.length === 0 && fingerHoles.length === 0
                   ? "No cutouts"
                 : stats
                   ? "Ready"
@@ -1437,7 +1603,7 @@ export function BinControlsPanel({
               </p>
             )}
           </div>
-          {cutouts.length === 0 ? (
+          {cutouts.length === 0 && fingerHoles.length === 0 ? (
             <div
               className="rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 text-xs text-amber-900 dark:text-amber-100"
               role="status"
@@ -1471,7 +1637,7 @@ export function BinControlsPanel({
             <div>
               <Label className="text-xs">Final printable model</Label>
               <p className="text-[11px] text-muted-foreground">
-                {cutouts.length === 0
+                {cutouts.length === 0 && fingerHoles.length === 0
                   ? "Export the solid bin at print quality. Use 3MF to preserve optional material colors."
                   : "Export the complete bin at print quality. Use 3MF to preserve optional material colors."}
               </p>
@@ -1516,7 +1682,7 @@ export function BinControlsPanel({
               </p>
             </div>
 
-            {cutouts.length > 0 && (
+            {(cutouts.length > 0 || fingerHoles.length > 0) && (
               <div
                 className="space-y-2 border-t pt-2.5"
                 data-testid="surface-fit-test-export"
@@ -1562,8 +1728,8 @@ export function BinControlsPanel({
                   {exporting ? "Building…" : "Save surface fit test STL"}
                 </Button>
                 <p className="text-[11px] text-muted-foreground">
-                  Checks every pocket's opening, clearance, spacing, and finger
-                  access together. It does not test pocket depth or baseplate fit.
+                  Checks every pocket opening and independent finger hole together.
+                  It does not test cut depth or baseplate fit.
                 </p>
               </div>
             )}
@@ -1678,8 +1844,8 @@ export function BinControlsPanel({
               Resize the bin after removing “{pendingRemovalShape?.name ?? "this part"}”?
             </AlertDialogTitle>
             <AlertDialogDescription>
-              Pocketry can recenter the remaining pockets and shrink the bin to
-              the smallest Gridfinity size that contains them.
+              Pocketry can recenter the remaining layout objects and shrink the
+              bin to the smallest Gridfinity size that contains them.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/client/src/components/gridfinity/layout-canvas.tsx
+++ b/client/src/components/gridfinity/layout-canvas.tsx
@@ -13,7 +13,11 @@ import {
 import {
   binToCanvas,
   canvasToBin,
+  fingerHoleFootprintRing,
+  oblongDeepScoopEndpoints,
   placementFootprint,
+  resizeFingerHoleFromWidthHandle,
+  resizeOblongDeepScoopFromEndpoint,
   transformPointPlacement,
   untransformPointPlacement,
   type CutoutPlacement,
@@ -160,7 +164,15 @@ export function LayoutCanvas(): JSX.Element {
 }
 
 function LayoutStage(): JSX.Element {
-  const { spec, cutouts, selectedCutoutId, editorMode, dispatch } = useBin();
+  const {
+    spec,
+    cutouts,
+    fingerHoles,
+    selectedCutoutId,
+    selectedFingerHoleId,
+    editorMode,
+    dispatch,
+  } = useBin();
   const { shapes, storeShape } = useShapeLibrary();
   const shapesById = useMemo(
     () => new Map(shapes.map((shape) => [shape.id, shape])),
@@ -229,7 +241,7 @@ function LayoutStage(): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editorMode, selectedCutoutId]);
 
-  // Transformed outlines + feature handles + per-cutout worst severity,
+  // Transformed pocket outlines, recomputed per change — pure math over
   // recomputed per change — pure math over ≤150-point rings, cheap enough
   // per drag frame.
   const placed = useMemo(
@@ -243,28 +255,61 @@ function LayoutStage(): JSX.Element {
             ? { ...storedShape, outlineMm: draftContour.outline }
             : storedShape;
         const footprint = placementFootprint(shape, cutout);
-        const features = cutout.fingerHoles.map((hole, index) => ({
-          kind: hole.kind,
-          id: hole.id,
-          center: transformPointPlacement(hole.center, cutout),
-          ring: footprint.features[index],
-        }));
-        return [{ cutout, shape, outline: footprint.outline, features }];
+        return [{ cutout, shape, outline: footprint.outline }];
       }),
     [cutouts, shapesById, draftContour],
   );
 
+  const placedFingerHoles = useMemo(
+    () =>
+      fingerHoles.map((hole) => {
+        const endpoints =
+          hole.kind === "oblong-deep-scoop"
+            ? oblongDeepScoopEndpoints(hole)
+            : null;
+        const radians = ((hole.rotationDeg ?? 0) * Math.PI) / 180;
+        return {
+          hole,
+          ring: fingerHoleFootprintRing(hole, {
+            position: { x: 0, y: 0 },
+            rotationDeg: 0,
+            mirrored: false,
+          }),
+          endpoints,
+          widthHandle: {
+            x: hole.center.x - Math.sin(radians) * hole.diameterMm / 2,
+            y: hole.center.y + Math.cos(radians) * hole.diameterMm / 2,
+          },
+        };
+      }),
+    [fingerHoles],
+  );
+
   const severityByCutout = useMemo(() => {
     const map = new Map<string, IssueSeverity>();
-    for (const issue of validateLayout(spec, cutouts, shapesById)) {
+    for (const issue of validateLayout(spec, cutouts, shapesById, fingerHoles)) {
       for (const id of issue.cutoutIds ?? []) {
         if (issue.severity === "error" || !map.has(id)) map.set(id, issue.severity);
       }
     }
     return map;
-  }, [spec, cutouts, shapesById]);
+  }, [spec, cutouts, shapesById, fingerHoles]);
+
+  const severityByFingerHole = useMemo(() => {
+    const map = new Map<string, IssueSeverity>();
+    for (const issue of validateLayout(spec, cutouts, shapesById, fingerHoles)) {
+      for (const id of issue.fingerHoleIds ?? []) {
+        if (issue.severity === "error" || !map.has(id)) {
+          map.set(id, issue.severity);
+        }
+      }
+    }
+    return map;
+  }, [spec, cutouts, shapesById, fingerHoles]);
 
   const selected = placed.find((p) => p.cutout.id === selectedCutoutId) ?? null;
+  const selectedFingerHole =
+    placedFingerHoles.find((item) => item.hole.id === selectedFingerHoleId) ?? null;
 
   const commitContour = (
     cutoutId: string,
@@ -289,12 +334,13 @@ function LayoutStage(): JSX.Element {
   const dragRef = useRef<
     | { kind: "move"; id: string; grabOffset: Point }
     | { kind: "rotate"; id: string; center: Point; startPointerDeg: number; startRotationDeg: number }
+    | { kind: "finger-hole-move"; id: string; grabOffset: Point }
     | {
-        kind: "feature";
-        id: string;
-        feature: { kind: FingerHole["kind"]; id: string };
-        grabOffset: Point;
+        kind: "feature-end";
+        featureId: string;
+        endpoint: "start" | "end";
       }
+    | { kind: "feature-width"; featureId: string }
     | {
         kind: "contour";
         id: string;
@@ -310,21 +356,26 @@ function LayoutStage(): JSX.Element {
   const [rulerActive, setRulerActive] = useState(false);
   const [measurementPoints, setMeasurementPoints] = useState<Point[]>([]);
   const hasPlacedCutouts = placed.length > 0;
+  const hasPlacedObjects = hasPlacedCutouts || placedFingerHoles.length > 0;
 
   useEffect(() => {
-    if (hasPlacedCutouts) return;
+    if (hasPlacedObjects) return;
     setRulerActive(false);
     setMeasurementPoints([]);
-  }, [hasPlacedCutouts]);
+  }, [hasPlacedObjects]);
 
   const hitCutout = (point: Point): CutoutPlacement | null => {
-    // Topmost = later in the list; finger-access rims count as their pocket.
+    // Topmost = later in the list.
     for (let i = placed.length - 1; i >= 0; i--) {
       if (pointInOutline(placed[i].outline, point)) return placed[i].cutout;
-      for (const feature of placed[i].features) {
-        if (pointInRing(feature.ring, point)) {
-          return placed[i].cutout;
-        }
+    }
+    return null;
+  };
+
+  const hitFingerHole = (point: Point): FingerHole | null => {
+    for (let i = placedFingerHoles.length - 1; i >= 0; i--) {
+      if (pointInRing(placedFingerHoles[i].ring, point)) {
+        return placedFingerHoles[i].hole;
       }
     }
     return null;
@@ -335,6 +386,28 @@ function LayoutStage(): JSX.Element {
    * gesture lands in history as a single undo step.
    */
   const commitDrag = (drag: NonNullable<typeof dragRef.current>) => {
+    if (
+      drag.kind === "finger-hole-move" ||
+      drag.kind === "feature-end" ||
+      drag.kind === "feature-width"
+    ) {
+      const id = drag.kind === "finger-hole-move" ? drag.id : drag.featureId;
+      const current = fingerHoles.find((hole) => hole.id === id);
+      if (!current) return;
+      dispatch({
+        type: "UPDATE_FINGER_HOLE",
+        id,
+        patch: current,
+        historyLabel:
+          drag.kind === "finger-hole-move"
+            ? "Move finger hole"
+            : drag.kind === "feature-end"
+              ? "Resize oblong finger hole"
+              : "Resize finger hole diameter",
+      });
+      return;
+    }
+
     const current = cutouts.find((cutout) => cutout.id === drag.id);
     if (!current) return;
     if (drag.kind === "move") {
@@ -350,13 +423,6 @@ function LayoutStage(): JSX.Element {
         id: current.id,
         patch: { rotationDeg: current.rotationDeg },
         historyLabel: "Rotate tool pocket",
-      });
-    } else if (drag.kind === "feature") {
-      dispatch({
-        type: "UPDATE_CUTOUT",
-        id: current.id,
-        patch: { fingerHoles: current.fingerHoles },
-        historyLabel: "Move finger hole",
       });
     }
   };
@@ -589,28 +655,47 @@ function LayoutStage(): JSX.Element {
       return;
     }
 
-    // Finger-access features of the selected pocket grab before the body does,
-    // so a feature overlapping its own outline stays draggable.
-    if (selected) {
-      for (const feature of selected.features) {
-        const nearEdge = feature.ring.some((vertex, index) =>
-          pointSegmentDistance(
-            point,
-            vertex,
-            feature.ring[(index + 1) % feature.ring.length],
-          ) <= pickRadius / 2,
-        );
-        if (pointInRing(feature.ring, point) || nearEdge) {
-          dragRef.current = {
-            kind: "feature",
-            id: selected.cutout.id,
-            feature: { kind: feature.kind, id: feature.id },
-            grabOffset: { x: point.x - feature.center.x, y: point.y - feature.center.y },
-          };
-          event.currentTarget.setPointerCapture(event.pointerId);
-          return;
-        }
-      }
+    const featureEndpoint = target.getAttribute?.("data-feature-end");
+    const featureId = target.getAttribute?.("data-feature-id");
+    if (
+      featureId &&
+      (featureEndpoint === "start" || featureEndpoint === "end") &&
+      selectedFingerHole?.hole.id === featureId &&
+      selectedFingerHole.hole.kind === "oblong-deep-scoop"
+    ) {
+      dragRef.current = {
+        kind: "feature-end",
+        featureId,
+        endpoint: featureEndpoint,
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+      return;
+    }
+
+    if (
+      target.getAttribute?.("data-feature-width") &&
+      featureId &&
+      selectedFingerHole?.hole.id === featureId
+    ) {
+      dragRef.current = { kind: "feature-width", featureId };
+      event.currentTarget.setPointerCapture(event.pointerId);
+      return;
+    }
+
+    // Independent finger holes grab before pocket bodies when they overlap.
+    const hitHole = hitFingerHole(point);
+    if (hitHole) {
+      dispatch({ type: "SELECT_FINGER_HOLE", id: hitHole.id });
+      dragRef.current = {
+        kind: "finger-hole-move",
+        id: hitHole.id,
+        grabOffset: {
+          x: point.x - hitHole.center.x,
+          y: point.y - hitHole.center.y,
+        },
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+      return;
     }
 
     const hit = hitCutout(point);
@@ -677,23 +762,50 @@ function LayoutStage(): JSX.Element {
       return;
     }
 
-    if (drag.kind === "feature") {
-      const current = cutouts.find((cutout) => cutout.id === drag.id);
+    if (drag.kind === "finger-hole-move") {
+      const current = fingerHoles.find((hole) => hole.id === drag.id);
       if (!current) return;
-      const centreBin = {
-        x: point.x - drag.grabOffset.x,
-        y: point.y - drag.grabOffset.y,
-      };
-      // Feature centres are stored shape-local so they ride the placement.
-      const local = untransformPointPlacement(centreBin, current);
+      let x = point.x - drag.grabOffset.x;
+      let y = point.y - drag.grabOffset.y;
+      if (!event.altKey) {
+        const tolerance = SNAP_TOLERANCE_PX / Math.max(scale, 1e-6);
+        x = snapAxis(x, snapTargets(spec.gridX), tolerance);
+        y = snapAxis(y, snapTargets(spec.gridY), tolerance);
+      }
       dispatch({
-        type: "UPDATE_CUTOUT",
-        id: drag.id,
-        patch: {
-          fingerHoles: current.fingerHoles.map((hole) =>
-            hole.id === drag.feature.id ? { ...hole, center: local } : hole,
-          ),
-        },
+        type: "UPDATE_FINGER_HOLE",
+        id: current.id,
+        patch: { center: { x, y } },
+        transient: true,
+      });
+      return;
+    }
+
+    if (drag.kind === "feature-width") {
+      const current = fingerHoles.find((hole) => hole.id === drag.featureId);
+      if (!current) return;
+      const resized = resizeFingerHoleFromWidthHandle(current, point);
+      dispatch({
+        type: "UPDATE_FINGER_HOLE",
+        id: current.id,
+        patch: resized,
+        transient: true,
+      });
+      return;
+    }
+
+    if (drag.kind === "feature-end") {
+      const current = fingerHoles.find((hole) => hole.id === drag.featureId);
+      if (!current) return;
+      const resized = resizeOblongDeepScoopFromEndpoint(
+        current,
+        drag.endpoint,
+        point,
+      );
+      dispatch({
+        type: "UPDATE_FINGER_HOLE",
+        id: current.id,
+        patch: resized,
         transient: true,
       });
       return;
@@ -728,10 +840,16 @@ function LayoutStage(): JSX.Element {
       if (rulerActive && !viewport.isPanning) return;
       if (click && event.button === 0) {
         const point = toBin(event.clientX, event.clientY);
-        dispatch({
-          type: "SELECT_CUTOUT",
-          id: point ? (hitCutout(point)?.id ?? null) : null,
-        });
+        const hole = point ? hitFingerHole(point) : null;
+        const cutout = !hole && point ? hitCutout(point) : null;
+        if (hole) {
+          dispatch({ type: "SELECT_FINGER_HOLE", id: hole.id });
+        } else if (cutout) {
+          dispatch({ type: "SELECT_CUTOUT", id: cutout.id });
+        } else {
+          dispatch({ type: "SELECT_CUTOUT", id: null });
+          dispatch({ type: "SELECT_FINGER_HOLE", id: null });
+        }
       }
       viewport.handlers.onPointerUp(event);
       return;
@@ -789,9 +907,57 @@ function LayoutStage(): JSX.Element {
         }
         return;
       }
-      if (!selectedCutoutId) return;
       const target = event.target as HTMLElement | null;
       if (target && /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)) return;
+      if (selectedFingerHoleId) {
+        const hole = fingerHoles.find(
+          (candidate) => candidate.id === selectedFingerHoleId,
+        );
+        if (!hole) return;
+        const nudge = event.shiftKey ? 0.1 : 1;
+        let patch: Partial<FingerHole> | null = null;
+        if (event.key === "ArrowLeft") {
+          patch = { center: { x: hole.center.x - nudge, y: hole.center.y } };
+        } else if (event.key === "ArrowRight") {
+          patch = { center: { x: hole.center.x + nudge, y: hole.center.y } };
+        } else if (event.key === "ArrowUp") {
+          patch = { center: { x: hole.center.x, y: hole.center.y + nudge } };
+        } else if (event.key === "ArrowDown") {
+          patch = { center: { x: hole.center.x, y: hole.center.y - nudge } };
+        } else if (
+          (event.key === "r" || event.key === "R") &&
+          hole.kind === "oblong-deep-scoop"
+        ) {
+          patch = {
+            rotationDeg:
+              (((hole.rotationDeg ?? 0) + (event.shiftKey ? -15 : 15)) % 360 +
+                360) %
+              360,
+          };
+        } else if (event.key === "Delete" || event.key === "Backspace") {
+          dispatch({ type: "REMOVE_FINGER_HOLE", id: hole.id });
+          event.preventDefault();
+          return;
+        } else if (event.key === "Escape") {
+          dispatch({ type: "SELECT_FINGER_HOLE", id: null });
+          event.preventDefault();
+          return;
+        }
+        if (patch) {
+          dispatch({
+            type: "UPDATE_FINGER_HOLE",
+            id: hole.id,
+            patch,
+            historyLabel:
+              "rotationDeg" in patch
+                ? "Rotate oblong finger hole"
+                : "Move finger hole",
+          });
+          event.preventDefault();
+        }
+        return;
+      }
+      if (!selectedCutoutId) return;
       const current = cutouts.find((cutout) => cutout.id === selectedCutoutId);
       if (!current) return;
 
@@ -852,7 +1018,15 @@ function LayoutStage(): JSX.Element {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [selectedCutoutId, cutouts, editorMode, rulerActive, dispatch]);
+  }, [
+    selectedCutoutId,
+    selectedFingerHoleId,
+    cutouts,
+    fingerHoles,
+    editorMode,
+    rulerActive,
+    dispatch,
+  ]);
 
   const cursor =
     rulerActive
@@ -1012,7 +1186,7 @@ function LayoutStage(): JSX.Element {
               );
             })}
 
-          {placed.map(({ cutout, outline, features }) => {
+          {placed.map(({ cutout, outline }) => {
             const severity = severityByCutout.get(cutout.id);
             const isSelected = cutout.id === selectedCutoutId;
             const tone =
@@ -1033,21 +1207,69 @@ function LayoutStage(): JSX.Element {
                   vectorEffect="non-scaling-stroke"
                   data-cutout-id={cutout.id}
                 />
-                {features.map((feature) => {
-                  return (
-                    <g key={`${cutout.id}-${feature.kind}-${feature.id}`}>
-                      <path
-                        d={ringToCanvasPath(feature.ring, spec)}
-                        className={cn(tone, isSelected && "cursor-move")}
-                        strokeWidth={isSelected ? 1.5 : 1}
-                        strokeDasharray={feature.kind === "straight" ? undefined : "3 2"}
-                        vectorEffect="non-scaling-stroke"
-                        data-feature-of={cutout.id}
-                        data-testid={`feature-${feature.kind}-${cutout.id}`}
-                      />
-                    </g>
-                  );
-                })}
+              </g>
+            );
+          })}
+
+          {placedFingerHoles.map(({ hole, ring, endpoints, widthHandle }) => {
+            const severity = severityByFingerHole.get(hole.id);
+            const isSelected = hole.id === selectedFingerHoleId;
+            const tone =
+              severity === "error"
+                ? "fill-destructive/30 stroke-destructive"
+                : severity === "warning"
+                  ? "fill-amber-500/25 stroke-amber-600"
+                  : isSelected
+                    ? "fill-fuchsia-500/30 stroke-fuchsia-700"
+                    : "fill-fuchsia-500/15 stroke-fuchsia-600/70";
+            const widthCanvas = binToCanvas(widthHandle, spec);
+            return (
+              <g key={hole.id}>
+                <path
+                  d={ringToCanvasPath(ring, spec)}
+                  className={cn(tone, "cursor-move")}
+                  strokeWidth={isSelected ? 2 : 1.25}
+                  strokeDasharray={hole.kind === "straight" ? undefined : "3 2"}
+                  vectorEffect="non-scaling-stroke"
+                  data-feature-id={hole.id}
+                  data-testid={`finger-hole-${hole.kind}-${hole.id}`}
+                />
+                {isSelected && (
+                  <>
+                    <circle
+                      cx={widthCanvas.x}
+                      cy={widthCanvas.y}
+                      r={5 * inv}
+                      className="fill-background stroke-fuchsia-700"
+                      strokeWidth={2}
+                      vectorEffect="non-scaling-stroke"
+                      style={{ cursor: "nwse-resize" }}
+                      data-feature-width="diameter"
+                      data-feature-id={hole.id}
+                      data-testid={`finger-hole-width-${hole.id}`}
+                    />
+                    {endpoints
+                      ? (["start", "end"] as const).map((endpoint) => {
+                          const canvasPoint = binToCanvas(endpoints[endpoint], spec);
+                          return (
+                            <circle
+                              key={endpoint}
+                              cx={canvasPoint.x}
+                              cy={canvasPoint.y}
+                              r={5 * inv}
+                              className="fill-background stroke-fuchsia-700"
+                              strokeWidth={2}
+                              vectorEffect="non-scaling-stroke"
+                              style={{ cursor: "grab" }}
+                              data-feature-end={endpoint}
+                              data-feature-id={hole.id}
+                              data-testid={`finger-hole-oblong-end-${endpoint}-${hole.id}`}
+                            />
+                          );
+                        })
+                      : null}
+                  </>
+                )}
               </g>
             );
           })}
@@ -1177,15 +1399,15 @@ function LayoutStage(): JSX.Element {
         </g>
       </svg>
 
-      {!hasPlacedCutouts ? (
+      {!hasPlacedObjects ? (
         <div
           className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center p-6"
           data-testid="layout-empty-state"
         >
           <div className="max-w-sm rounded-lg border border-dashed bg-background/90 px-5 py-4 text-center shadow-sm backdrop-blur">
-            <p className="font-medium">No tool cutouts yet</p>
+            <p className="font-medium">No layout objects yet</p>
             <p className="mt-1 text-sm text-muted-foreground">
-              Trace a tool and choose Add to bin to place it here.
+              Add a tool pocket or a finger hole to place it here.
             </p>
           </div>
         </div>
@@ -1264,15 +1486,17 @@ function LayoutStage(): JSX.Element {
           ? "Footprint edit · click cells or the dashed outer halo · Esc finishes"
           : editorMode === "label-edge"
           ? "Label tab · click a highlighted boundary edge"
-          : !hasPlacedCutouts
-          ? "Add a tool from Trace to begin"
+          : !hasPlacedObjects
+          ? "Add a tool pocket or finger hole to begin"
           : editorMode === "contour"
           ? selectedCutoutId
             ? "Contour edit · drag points · click an edge to add · right-click a point to remove · Esc finishes"
             : "Contour edit · click a pocket to select it"
-          : selectedCutoutId
-          ? "Drag moves · circles drag finger holes · handle rotates · R rotates 15° · arrows nudge · Del removes"
-          : "Click a pocket to select · Shift-drag pans · Ctrl-scroll zooms"}
+          : selectedFingerHoleId
+            ? "Finger hole · drag moves · white handle resizes · arrows nudge · Del removes"
+            : selectedCutoutId
+              ? "Pocket · drag moves · handle rotates · R rotates 15° · arrows nudge · Del removes"
+              : "Click a pocket or finger hole to select · Shift-drag pans · Ctrl-scroll zooms"}
       </div>
     </>
   );

--- a/client/src/components/layout/panel-section.tsx
+++ b/client/src/components/layout/panel-section.tsx
@@ -31,6 +31,7 @@ export interface PanelSectionProps {
 export type PanelTone =
   | "slate"
   | "blue"
+  | "cyan"
   | "violet"
   | "amber"
   | "rose"
@@ -51,6 +52,13 @@ const TONE_STYLES = {
     open: "data-[state=open]:bg-blue-500/5",
     summary: "bg-blue-500/10 text-blue-700 dark:text-blue-300",
     index: "bg-blue-500/5 text-blue-700 hover:bg-blue-500/10 dark:text-blue-300",
+  },
+  cyan: {
+    marker: "bg-cyan-500",
+    icon: "text-cyan-600 dark:text-cyan-400",
+    open: "data-[state=open]:bg-cyan-500/5",
+    summary: "bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+    index: "bg-cyan-500/5 text-cyan-700 hover:bg-cyan-500/10 dark:text-cyan-300",
   },
   violet: {
     marker: "bg-violet-500",

--- a/client/src/lib/export/layout.test.ts
+++ b/client/src/lib/export/layout.test.ts
@@ -60,21 +60,25 @@ describe("layoutRingsMm", () => {
     );
   });
 
-  it("emits the footprint plus each pocket and feature ring", () => {
-    const rings = layoutRingsMm(SPEC, [
-      cutout({
-        fingerHoles: [
-          { id: "f1", center: { x: 18, y: 0 }, diameterMm: 18 },
-          {
-            id: "f2",
-            kind: "scoop",
-            center: { x: -18, y: 0 },
-            diameterMm: 30,
-            depthMm: 12,
-          },
-        ],
-      }),
-    ], BY_ID);
+  it("emits the footprint plus each pocket and independent finger-hole ring", () => {
+    const rings = layoutRingsMm(SPEC, [cutout()], BY_ID, [
+      {
+        id: "f1",
+        center: { x: 18, y: 0 },
+        diameterMm: 18,
+        kind: "straight",
+        depthMm: 12,
+      },
+      {
+        id: "f2",
+        kind: "oblong-deep-scoop",
+        center: { x: -18, y: 0 },
+        diameterMm: 10,
+        depthMm: 24,
+        lengthMm: 30,
+        rotationDeg: 90,
+      },
+    ]);
     // footprint + outline + hole circle + scoop circle
     expect(rings).toHaveLength(4);
 

--- a/client/src/lib/export/layout.ts
+++ b/client/src/lib/export/layout.ts
@@ -1,8 +1,8 @@
 import {
-  circleRing,
+  fingerHoleFootprintRing,
   transformOutlinePlacement,
-  transformPointPlacement,
   type CutoutPlacement,
+  type FingerHole,
   type TracedShape,
 } from "@shared/gridfinity/cutout";
 import { binFootprintMm, BASE_TOP_RADIUS } from "@shared/gridfinity/standard";
@@ -17,7 +17,7 @@ import { dxfFromModelRings } from "./dxf";
 
 /**
  * Top-down bin-layout export: the bin's footprint plus every placed pocket
- * outline and feature circle, in **bin-frame millimetres, y-up** — the CNC
+ * outline and independent finger-hole rim, in **bin-frame millimetres, y-up** — the CNC
  * shadow-board bridge from the design doc ("nearly free from the 2D
  * editor"). The pocket rings are the tool silhouettes at export vertex
  * budget, exactly the curves the pocket cutter starts from; fit clearance
@@ -33,6 +33,7 @@ export function layoutRingsMm(
   spec: BinSpec,
   cutouts: readonly CutoutPlacement[],
   shapesById: ReadonlyMap<string, TracedShape>,
+  fingerHoles: readonly FingerHole[] = [],
 ): Ring[] {
   const rings: Ring[] = [
     spec.footprint.kind === "custom"
@@ -51,15 +52,16 @@ export function layoutRingsMm(
     for (const placedShape of transformOutlinePlacement(budgeted, cutout)) {
       rings.push(placedShape.outer, ...placedShape.holes);
     }
-    for (const hole of cutout.fingerHoles) {
-      rings.push(
-        circleRing(
-          transformPointPlacement(hole.center, cutout),
-          hole.diameterMm / 2,
-          CIRCLE_SEGMENTS,
-        ),
-      );
-    }
+  }
+
+  for (const hole of fingerHoles) {
+    rings.push(
+      fingerHoleFootprintRing(
+        hole,
+        { position: { x: 0, y: 0 }, rotationDeg: 0, mirrored: false },
+        CIRCLE_SEGMENTS,
+      ),
+    );
   }
 
   return rings.filter((ring) => isValidRing(ring));
@@ -99,8 +101,12 @@ export function generateLayoutDXF(
   spec: BinSpec,
   cutouts: readonly CutoutPlacement[],
   shapesById: ReadonlyMap<string, TracedShape>,
+  fingerHoles: readonly FingerHole[] = [],
 ): string {
-  return dxfFromModelRings(layoutRingsMm(spec, cutouts, shapesById), LAYOUT_COMMENT);
+  return dxfFromModelRings(
+    layoutRingsMm(spec, cutouts, shapesById, fingerHoles),
+    LAYOUT_COMMENT,
+  );
 }
 
 /**
@@ -111,10 +117,11 @@ export function generateLayoutSVG(
   spec: BinSpec,
   cutouts: readonly CutoutPlacement[],
   shapesById: ReadonlyMap<string, TracedShape>,
+  fingerHoles: readonly FingerHole[] = [],
 ): string {
   const widthMm = binFootprintMm(spec.gridX, spec.gridPitch);
   const lengthMm = binFootprintMm(spec.gridY, spec.gridPitch);
-  const rings = layoutRingsMm(spec, cutouts, shapesById);
+  const rings = layoutRingsMm(spec, cutouts, shapesById, fingerHoles);
 
   const toView = (point: Point): Point => ({
     x: point.x + widthMm / 2,

--- a/client/src/lib/gridfinity/autoplace.test.ts
+++ b/client/src/lib/gridfinity/autoplace.test.ts
@@ -211,6 +211,28 @@ describe("fitLayoutToPlacements", () => {
     expect(fitted.gridY).toBe(1);
     expect(fitted.cutouts[0].position).toEqual({ x: 0, y: 0 });
   });
+
+  it("fits and recentres an independent finger hole without a tool pocket", () => {
+    const hole = {
+      id: "f1",
+      center: { x: 30, y: -12 },
+      diameterMm: 18,
+      kind: "straight" as const,
+      depthMm: 12,
+    };
+    const fitted = fitLayoutToPlacements(
+      [],
+      new Map(),
+      "standard",
+      "full",
+      [hole],
+    );
+
+    expect(fitted.cutouts).toEqual([]);
+    expect(fitted.fingerHoles[0].center).toEqual({ x: 0, y: 0 });
+    expect(fitted.gridX).toBe(1);
+    expect(fitted.gridY).toBe(1);
+  });
 });
 
 describe("fitFootprintToPlacements", () => {
@@ -363,6 +385,40 @@ describe("autoArrangeLayout", () => {
     // OBB's 180° ambiguity.
     const angle = Math.abs(arranged.cutouts[0].rotationDeg);
     expect(Math.min(angle, Math.abs(angle - 180))).toBeCloseTo(30, 6);
+  });
+
+  it("keeps a fixed independent finger hole inside the auto-arranged bin", () => {
+    const shape = rectShape("s1", 20, 10);
+    const byId = new Map([[shape.id, shape]]);
+    const placed = autoPlaceFresh([shape], "standard").cutouts;
+    const hole = {
+      id: "f1",
+      center: { x: 50, y: 0 },
+      diameterMm: 18,
+      kind: "deep-scoop" as const,
+      depthMm: 18,
+    };
+
+    const arranged = autoArrangeLayout(
+      placed,
+      byId,
+      "standard",
+      "full",
+      [hole],
+    )!;
+    const spec = parseBinSpec({
+      gridX: arranged.gridX,
+      gridY: arranged.gridY,
+      heightUnits: 6,
+      fill: "solid",
+    });
+    const boundaryErrors = validateLayout(spec, arranged.cutouts, byId, [hole])
+      .filter((issue) => issue.code === "finger-hole-out-of-bounds" ||
+        issue.code === "finger-hole-wall-breach");
+
+    expect(arranged.gridX).toBeGreaterThan(1);
+    expect(boundaryErrors).toEqual([]);
+    expect(hole.center).toEqual({ x: 50, y: 0 });
   });
 
   it("property: arranged layouts of feature-laden cutouts stay error-free", () => {

--- a/client/src/lib/gridfinity/autoplace.ts
+++ b/client/src/lib/gridfinity/autoplace.ts
@@ -1,7 +1,9 @@
 import {
   cutoutPlacementSchema,
+  fingerHoleFootprintRing,
   placementFootprint,
   type CutoutPlacement,
+  type FingerHole,
   type TracedShape,
 } from "@shared/gridfinity/cutout";
 import {
@@ -231,6 +233,7 @@ export function autoPlaceFresh(
 function existingBounds(
   cutouts: readonly CutoutPlacement[],
   shapesById: ReadonlyMap<string, TracedShape>,
+  fingerHoles: readonly FingerHole[] = [],
 ): Bounds | null {
   let bounds: Bounds | null = null;
   const includePoint = (point: Point, allowanceMm: number) => {
@@ -257,10 +260,15 @@ function existingBounds(
     for (const part of footprint.outline) {
       for (const point of part.outer) includePoint(point, outlineAllowance);
     }
-    for (const ring of footprint.features) {
-      for (const point of ring) {
-        includePoint(point, 0);
-      }
+  }
+  for (const hole of fingerHoles) {
+    const ring = fingerHoleFootprintRing(hole, {
+      position: { x: 0, y: 0 },
+      rotationDeg: 0,
+      mirrored: false,
+    });
+    for (const point of ring) {
+      includePoint(point, 0);
     }
   }
   return bounds;
@@ -367,9 +375,22 @@ export function fitLayoutToPlacements(
   shapesById: ReadonlyMap<string, TracedShape>,
   lip: BinSpec["lip"],
   gridPitch: GridPitch = "full",
-): { cutouts: CutoutPlacement[]; gridX: number; gridY: number } {
-  const bounds = existingBounds(cutouts, shapesById);
-  if (!bounds) return { cutouts: [...cutouts], gridX: 1, gridY: 1 };
+  fingerHoles: readonly FingerHole[] = [],
+): {
+  cutouts: CutoutPlacement[];
+  fingerHoles: FingerHole[];
+  gridX: number;
+  gridY: number;
+} {
+  const bounds = existingBounds(cutouts, shapesById, fingerHoles);
+  if (!bounds) {
+    return {
+      cutouts: [...cutouts],
+      fingerHoles: [...fingerHoles],
+      gridX: 1,
+      gridY: 1,
+    };
+  }
 
   // Cutter bounds already include each pocket's clearance and top round.
   const inset = placementInsetMm(lip, 0);
@@ -392,6 +413,13 @@ export function fitLayoutToPlacements(
         y: cutout.position.y - centreY,
       },
     })),
+    fingerHoles: fingerHoles.map((hole) => ({
+      ...hole,
+      center: {
+        x: hole.center.x - centreX,
+        y: hole.center.y - centreY,
+      },
+    })),
     gridX: fit(halfWNeeded),
     gridY: fit(halfHNeeded),
   };
@@ -403,7 +431,7 @@ export function fitLayoutToPlacements(
 
 interface ArrangeItem {
   cutout: CutoutPlacement;
-  /** Rotation that lays the shape (and its features) down in landscape. */
+  /** Rotation that lays the shape down in landscape. */
   rotationDeg: number;
   /** OBB centre in the pre-rotation local frame (mirror applied). */
   obbCentre: Point;
@@ -412,9 +440,8 @@ interface ArrangeItem {
 }
 
 /**
- * The measured footprint of one cutout at rotation 0 (mirror kept): outline
- * *and* feature circles, because a finger hole protruding from the outline
- * still needs floor space next to its neighbour.
+ * The measured footprint of one tool pocket at rotation 0 (mirror kept).
+ * Independent finger holes are deliberately not moved by auto-arrange.
  */
 function arrangeItem(
   cutout: CutoutPlacement,
@@ -468,9 +495,10 @@ export function trimFootprintToPlacements(
   cutouts: readonly CutoutPlacement[],
   shapesById: ReadonlyMap<string, TracedShape>,
   spec: BinSpec,
+  fingerHoles: readonly FingerHole[] = [],
 ): BinFootprint {
   let cells = rectangleCells(spec.gridX, spec.gridY);
-  const bounds = existingBounds(cutouts, shapesById);
+  const bounds = existingBounds(cutouts, shapesById, fingerHoles);
   const centre = bounds
     ? { x: (bounds.minX + bounds.maxX) / 2, y: (bounds.minY + bounds.maxY) / 2 }
     : { x: 0, y: 0 };
@@ -493,7 +521,7 @@ export function trimFootprintToPlacements(
       });
       const issues = [
         ...validateBinSpec(candidate).issues,
-        ...validateLayout(candidate, cutouts, shapesById),
+        ...validateLayout(candidate, cutouts, shapesById, fingerHoles),
       ];
       if (issues.some((issue) => FOOTPRINT_CODES.has(issue.code))) continue;
       cells = candidateCells;
@@ -510,8 +538,21 @@ export function fitFootprintToPlacements(
   cutouts: readonly CutoutPlacement[],
   shapesById: ReadonlyMap<string, TracedShape>,
   spec: BinSpec,
-): { cutouts: CutoutPlacement[]; gridX: number; gridY: number; footprint: BinFootprint } {
-  const fitted = fitLayoutToPlacements(cutouts, shapesById, spec.lip, spec.gridPitch);
+  fingerHoles: readonly FingerHole[] = [],
+): {
+  cutouts: CutoutPlacement[];
+  fingerHoles: FingerHole[];
+  gridX: number;
+  gridY: number;
+  footprint: BinFootprint;
+} {
+  const fitted = fitLayoutToPlacements(
+    cutouts,
+    shapesById,
+    spec.lip,
+    spec.gridPitch,
+    fingerHoles,
+  );
   const fittedSpec = parseBinSpec({
     ...spec,
     gridX: fitted.gridX,
@@ -520,7 +561,12 @@ export function fitFootprintToPlacements(
   });
   return {
     ...fitted,
-    footprint: trimFootprintToPlacements(fitted.cutouts, shapesById, fittedSpec),
+    footprint: trimFootprintToPlacements(
+      fitted.cutouts,
+      shapesById,
+      fittedSpec,
+      fitted.fingerHoles,
+    ),
   };
 }
 
@@ -532,8 +578,10 @@ export function fitRectangularBinToPlacements(
   cutouts: readonly CutoutPlacement[],
   shapesById: ReadonlyMap<string, TracedShape>,
   spec: BinSpec,
+  fingerHoles: readonly FingerHole[] = [],
 ): {
   cutouts: CutoutPlacement[];
+  fingerHoles: FingerHole[];
   gridX: number;
   gridY: number;
   footprint: BinFootprint;
@@ -544,23 +592,25 @@ export function fitRectangularBinToPlacements(
       shapesById,
       spec.lip,
       spec.gridPitch,
+      fingerHoles,
     ),
     footprint: { kind: "rectangle" },
   };
 }
 
 /**
- * Re-lays out *existing* cutouts: each one is rotated to its min-area OBB
- * (features included), shelf-packed, and centred in the smallest grid that
- * holds the block. Depth, clearance, features and mirroring are preserved;
- * only rotation and position change — same ids, so selection and undo
- * behave.
+ * Re-lays out existing tool pockets: each one is rotated to its min-area OBB,
+ * shelf-packed, and centred in the smallest grid that holds the block. Finger
+ * holes stay fixed in bin coordinates, but still constrain the chosen grid.
+ * Depth, clearance and mirroring are preserved; only pocket rotation and
+ * position change — same ids, so selection and undo behave.
  */
 export function autoArrangeLayout(
   cutouts: readonly CutoutPlacement[],
   shapesById: ReadonlyMap<string, TracedShape>,
   lip: BinSpec["lip"],
   gridPitch: GridPitch = "full",
+  fingerHoles: readonly FingerHole[] = [],
   baseSpec?: BinSpec,
 ): AutoArrangeResult | null {
   const items: ArrangeItem[] = [];
@@ -578,6 +628,13 @@ export function autoArrangeLayout(
     heightMm: item.heightMm,
   }));
   const inset = placementInsetMm(lip);
+  const fixedHoleBounds = existingBounds([], shapesById, fingerHoles);
+  const containsFixedHoles = (widthMm: number, heightMm: number): boolean =>
+    !fixedHoleBounds ||
+    (fixedHoleBounds.minX >= -widthMm / 2 &&
+      fixedHoleBounds.maxX <= widthMm / 2 &&
+      fixedHoleBounds.minY >= -heightMm / 2 &&
+      fixedHoleBounds.maxY <= heightMm / 2);
 
   const placeBlock = (block: PackedBlock): CutoutPlacement[] =>
     block.items.map((packed) => {
@@ -599,6 +656,7 @@ export function autoArrangeLayout(
   for (const grid of gridCandidates()) {
     const interior = interiorMm(grid, inset, gridPitch);
     if (interior.widthMm <= 0 || interior.heightMm <= 0) continue;
+    if (!containsFixedHoles(interior.widthMm, interior.heightMm)) continue;
     const block = shelfPack(targets, interior.widthMm);
     if (block.widthMm <= interior.widthMm && block.heightMm <= interior.heightMm) {
       const placed = placeBlock(block);
@@ -616,7 +674,14 @@ export function autoArrangeLayout(
         gridY: grid.gridY,
         overflow: false,
         ...(arrangedSpec
-          ? { footprint: trimFootprintToPlacements(placed, shapesById, arrangedSpec) }
+          ? {
+              footprint: trimFootprintToPlacements(
+                placed,
+                shapesById,
+                arrangedSpec,
+                fingerHoles,
+              ),
+            }
           : {}),
       };
     }

--- a/client/src/lib/gridfinity/bin-worker-handlers.test.ts
+++ b/client/src/lib/gridfinity/bin-worker-handlers.test.ts
@@ -146,6 +146,7 @@ describe("bin worker handlers", () => {
         layout: {
           shapes: [shape],
           cutouts: [placement],
+          fingerHoles: [],
         },
       },
       context(),
@@ -182,7 +183,7 @@ describe("bin worker handlers", () => {
       {
         spec,
         quality: { circularSegments: 16, cutoutVertexBudget: 150 },
-        layout: { shapes: [shape], cutouts: [placement] },
+        layout: { shapes: [shape], cutouts: [placement], fingerHoles: [] },
         pocketFloorMaterialThicknessMm: 0.8,
         stackingRimMaterialThicknessMm: 1.2,
       },
@@ -450,6 +451,7 @@ describe("complete surface fit test worker handler", () => {
           bottomFilletMm: 0,
         },
       ],
+      fingerHoles: [],
     },
     thicknessMm: 1.2,
     quality: { circularSegments: 32, cutoutVertexBudget: 600 },

--- a/client/src/lib/gridfinity/bin-worker-handlers.ts
+++ b/client/src/lib/gridfinity/bin-worker-handlers.ts
@@ -2,6 +2,7 @@ import type { ManifoldToplevel } from "manifold-3d";
 
 import {
   cutoutPlacementSchema,
+  fingerHoleSchema,
   tracedShapeSchema,
 } from "@shared/gridfinity/cutout";
 import { parseBinSpec } from "@shared/gridfinity/types";
@@ -83,7 +84,10 @@ export function createBinWorkerHandlers(
     );
     // Re-validate the layout at the boundary, exactly like the spec.
     let layout: BinLayout | null = null;
-    if (payload.layout && payload.layout.cutouts.length > 0) {
+    if (
+      payload.layout &&
+      (payload.layout.cutouts.length > 0 || payload.layout.fingerHoles.length > 0)
+    ) {
       const shapes = payload.layout.shapes.map((shape) =>
         tracedShapeSchema.parse(shape),
       );
@@ -91,6 +95,9 @@ export function createBinWorkerHandlers(
         shapesById: new Map(shapes.map((shape) => [shape.id, shape])),
         cutouts: payload.layout.cutouts.map((cutout) =>
           cutoutPlacementSchema.parse(cutout),
+        ),
+        fingerHoles: payload.layout.fingerHoles.map((hole) =>
+          fingerHoleSchema.parse(hole),
         ),
       };
     }
@@ -270,6 +277,9 @@ export function createBinWorkerHandlers(
       shapesById: new Map(shapes.map((shape) => [shape.id, shape])),
       cutouts: payload.layout.cutouts.map((cutout) =>
         cutoutPlacementSchema.parse(cutout),
+      ),
+      fingerHoles: payload.layout.fingerHoles.map((hole) =>
+        fingerHoleSchema.parse(hole),
       ),
     };
     context.progress(0.05);

--- a/client/src/lib/gridfinity/bin.ts
+++ b/client/src/lib/gridfinity/bin.ts
@@ -1,7 +1,11 @@
 // Type-only import: the kernel is injected (see `Kernel` in ../manifold/runtime).
 import type { Manifold } from "manifold-3d";
 
-import type { CutoutPlacement, TracedShape } from "@shared/gridfinity/cutout";
+import type {
+  CutoutPlacement,
+  FingerHole,
+  TracedShape,
+} from "@shared/gridfinity/cutout";
 import {
   BASE_HEIGHT,
   BASE_TOP_RADIUS,
@@ -18,7 +22,11 @@ import type { BinSpec } from "@shared/gridfinity/types";
 import type { Kernel } from "@/lib/manifold/runtime";
 
 import { buildBase } from "./base";
-import { buildCutoutCutters, type CutoutBuildReport } from "./cutouts";
+import {
+  buildCutoutCutters,
+  buildFingerHoleCutters,
+  type CutoutBuildReport,
+} from "./cutouts";
 import { holeOptionsFromSpec } from "./holes";
 import { buildLabelTab } from "./label-tab";
 import { buildLiteBase } from "./lite-base";
@@ -173,6 +181,7 @@ export function buildBinParts(
 export interface BinLayout {
   shapesById: ReadonlyMap<string, TracedShape>;
   cutouts: readonly CutoutPlacement[];
+  fingerHoles: readonly FingerHole[];
 }
 
 export interface BinMaterialParts {
@@ -214,7 +223,7 @@ export function buildBinWithCutouts(
   let solid = base.solid;
   let floorInserts: Manifold[] = [];
   let reports: CutoutBuildReport[] = [];
-  if (layout && layout.cutouts.length > 0) {
+  if (layout && (layout.cutouts.length > 0 || layout.fingerHoles.length > 0)) {
     const builtCutouts = buildCutoutCutters(
       kernel,
       layout.shapesById,
@@ -225,11 +234,15 @@ export function buildBinWithCutouts(
     );
     floorInserts = builtCutouts.floorInserts;
     reports = builtCutouts.reports;
-    if (builtCutouts.cutters.length > 0) {
+    const allCutters = [
+      ...builtCutouts.cutters,
+      ...buildFingerHoleCutters(kernel, layout.fingerHoles, spec, quality),
+    ];
+    if (allCutters.length > 0) {
       const cutter =
-        builtCutouts.cutters.length === 1
-          ? builtCutouts.cutters[0]
-          : arena.track(Manifold.union(builtCutouts.cutters));
+        allCutters.length === 1
+          ? allCutters[0]
+          : arena.track(Manifold.union(allCutters));
       solid = arena.track(base.solid.subtract(cutter));
     }
   }

--- a/client/src/lib/gridfinity/cutouts.test.ts
+++ b/client/src/lib/gridfinity/cutouts.test.ts
@@ -1,6 +1,7 @@
 import {
   parseCutoutPlacement,
   type CutoutPlacement,
+  type FingerHole,
   type TracedShape,
 } from "@shared/gridfinity/cutout";
 import { parseBinSpec } from "@shared/gridfinity/types";
@@ -66,8 +67,18 @@ function rectShape(id: string, width: number, height: number, holed = false): Tr
   };
 }
 
-function layoutFor(shapes: TracedShape[], cutouts: CutoutPlacement[]): BinLayout {
-  return { shapesById: new Map(shapes.map((s) => [s.id, s])), cutouts };
+function layoutFor(
+  shapes: TracedShape[],
+  cutouts: CutoutPlacement[],
+  fingerHoles: FingerHole[] = cutouts.flatMap(
+    (placement) => placement.fingerHoles,
+  ),
+): BinLayout {
+  return {
+    shapesById: new Map(shapes.map((s) => [s.id, s])),
+    cutouts,
+    fingerHoles,
+  };
 }
 
 function cutout(
@@ -467,7 +478,14 @@ describe("buildBinWithCutouts", () => {
         [
           cutout("c1", "s1", {
             depth: { mode: "mm", value: depth },
-            fingerHoles: [{ id: "f1", center: { x: 22, y: 0 }, diameterMm: 2 * radius }],
+            fingerHoles: [
+              {
+                id: "f1",
+                center: { x: 22, y: 0 },
+                diameterMm: 2 * radius,
+                depthMm: depth,
+              },
+            ],
           }),
         ],
       ),
@@ -480,6 +498,30 @@ describe("buildBinWithCutouts", () => {
     const expected = (30 * 10 + circleArea) * depth;
     const removed = plain.solid.volume() - pocketed.solid.volume();
     expect(Math.abs(removed - expected) / expected).toBeLessThan(1e-6);
+  });
+
+  it("builds a finger hole without any tool pocket", () => {
+    const depthMm = 5;
+    const radius = 6;
+    const plain = buildBin(kernel, SPEC, QUALITY);
+    const withHole = buildBinWithCutouts(
+      kernel,
+      SPEC,
+      layoutFor([], [], [
+        {
+          id: "independent-hole",
+          center: { x: 0, y: 0 },
+          diameterMm: radius * 2,
+          depthMm,
+          kind: "straight",
+        },
+      ]),
+      QUALITY,
+    );
+    const polygonArea =
+      0.5 * SEGMENTS * radius * radius * Math.sin((2 * Math.PI) / SEGMENTS);
+    const removed = plain.solid.volume() - withHole.solid.volume();
+    expect(Math.abs(removed - polygonArea * depthMm) / removed).toBeLessThan(1e-6);
   });
 
   it("a scoop in open surface removes its spherical cap, within facet error", () => {
@@ -594,7 +636,47 @@ describe("buildBinWithCutouts", () => {
     expect(removed).toBeGreaterThan(0.94 * analytic);
   });
 
-  it("cuts every scoop-style finger hole on the same pocket", () => {
+  it("an oblong deep scoop removes capsule walls and a rounded trough bottom", () => {
+    const shape = rectShape("s1", 12, 8);
+    const base = { depth: { mode: "mm", value: 4 } };
+    const scoop = {
+      id: "f1",
+      kind: "oblong-deep-scoop",
+      center: { x: 0, y: 20 },
+      diameterMm: 10,
+      depthMm: 25,
+      lengthMm: 40,
+      rotationDeg: 0,
+    };
+    const without = buildBinWithCutouts(
+      kernel,
+      SPEC,
+      layoutFor([shape], [cutout("c1", "s1", base)]),
+      QUALITY,
+    );
+    const withScoop = buildBinWithCutouts(
+      kernel,
+      SPEC,
+      layoutFor([shape], [cutout("c1", "s1", { ...base, fingerHoles: [scoop] })]),
+      QUALITY,
+    );
+
+    expect(withScoop.solid.status()).toBe("NoError");
+    expect(withScoop.solid.genus()).toBe(0);
+    const radius = scoop.diameterMm / 2;
+    const span = scoop.lengthMm - scoop.diameterMm;
+    const shaftArea = Math.PI * radius ** 2 + 2 * radius * span;
+    const shaftDepth = scoop.depthMm - radius;
+    const roundedBottomVolume =
+      (Math.PI * radius ** 2 * span) / 2 +
+      (2 * Math.PI * radius ** 3) / 3;
+    const analytic = shaftArea * shaftDepth + roundedBottomVolume;
+    const removed = without.solid.volume() - withScoop.solid.volume();
+    expect(removed).toBeLessThan(analytic);
+    expect(removed).toBeGreaterThan(0.92 * analytic);
+  });
+
+  it("cuts every independent scoop-style finger hole", () => {
     const shape = rectShape("s1", 12, 8);
     const base = { depth: { mode: "mm", value: 4 } };
     const left = {
@@ -628,7 +710,7 @@ describe("buildBinWithCutouts", () => {
     expect(two.solid.volume()).toBeLessThan(one.solid.volume());
   });
 
-  it("mirroring carries finger holes and scoop with the pocket", () => {
+  it("keeps independent finger holes unchanged when a pocket is mirrored", () => {
     const shape = rectShape("s1", 30, 10);
     const features = {
       depth: { mode: "mm", value: 6 },

--- a/client/src/lib/gridfinity/cutouts.ts
+++ b/client/src/lib/gridfinity/cutouts.ts
@@ -5,6 +5,7 @@ import {
   effectiveDeepScoopDepthMm,
   effectiveScoopDepthMm,
   fingerHoleFootprintRing,
+  oblongDeepScoopEndpoints,
   resolvePocketDepth,
   transformOutlinePlacement,
   transformPointPlacement,
@@ -48,16 +49,11 @@ import {
  *  7. an optional outward K-slice flare rounds the contour into the top
  *     surface without changing the vertical wall below it.
  *
- * G4 features ride the same cutter:
- *
- *  - **straight finger holes** union their circles into the cross-section
- *    *after* the offsets (they are cut at their drawn diameter, no fit
- *    clearance), so they share the pocket's depth, floor and bottom fillet;
- *  - **scoop finger holes** are their own solids — round scoops use spherical
- *    caps, while deep scoops use a straight cylindrical shaft ending in a
- *    hemisphere. Their rim is extended through the lip; the deep scoop's full
- *    sphere overlaps inside the shaft so the exposed lower half is a robust,
- *    watertight hemispherical bottom.
+ * Finger holes are built separately in the bin frame. Round scoops use
+ * spherical caps, while deep scoops use straight vertical shafts ending in
+ * rounded bottoms. The oblong version ends in a swept hemisphere
+ * (half-cylinder plus rounded ends). Full spheres and cylinders overlap inside
+ * the shafts for robust, watertight unions.
  *
  * Everything is tracked in `kernel.arena`; the caller owns disposal.
  */
@@ -119,6 +115,12 @@ export interface CutoutBuildOptions {
   /** Builds this much solid material below each flat blind-pocket floor. */
   floorInsertThicknessMm?: number;
 }
+
+const BIN_LOCAL_PLACEMENT = {
+  position: { x: 0, y: 0 },
+  rotationDeg: 0,
+  mirrored: false,
+} as const;
 
 /**
  * Radius of the sphere whose cap of height `h` has rim radius `a`:
@@ -245,6 +247,121 @@ function buildDeepScoopCutter(
   return arena.track(shaft.add(sphere));
 }
 
+/** Capsule shaft with a swept-hemisphere trough bottom. */
+function buildOblongDeepScoopCutter(
+  kernel: Kernel,
+  scoop: FingerHole,
+  placement: Pick<CutoutPlacement, "position" | "rotationDeg" | "mirrored">,
+  pocket: ResolvedPocket,
+  segments: number,
+): Manifold {
+  const { arena, Manifold: M } = kernel;
+  const localEndpoints = oblongDeepScoopEndpoints(scoop);
+  const start = transformPointPlacement(localEndpoints.start, placement);
+  const end = transformPointPlacement(localEndpoints.end, placement);
+  const radius = scoop.diameterMm / 2;
+  const totalDepth = effectiveDeepScoopDepthMm(scoop);
+  const bottomCentreZ = pocket.infillTopZ - totalDepth + radius;
+
+  const ring = fingerHoleFootprintRing(scoop, placement, segments);
+  const section = toCrossSection(kernel, [{ outer: ring, holes: [] }]);
+  const shaft = arena.track(
+    arena.track(section.extrude(pocket.cutterTopZ - bottomCentreZ)).translate([
+      0,
+      0,
+      bottomCentreZ,
+    ]),
+  );
+
+  const startSphere = arena.track(
+    arena.track(M.sphere(radius, segments)).translate([
+      start.x,
+      start.y,
+      bottomCentreZ,
+    ]),
+  );
+  const endSphere = arena.track(
+    arena.track(M.sphere(radius, segments)).translate([
+      end.x,
+      end.y,
+      bottomCentreZ,
+    ]),
+  );
+  const span = Math.hypot(end.x - start.x, end.y - start.y);
+  const angleDeg = (Math.atan2(end.y - start.y, end.x - start.x) * 180) / Math.PI;
+  let trough = arena.track(M.cylinder(span, radius, radius, segments));
+  trough = arena.track(trough.rotate([0, 90, 0]));
+  if (angleDeg !== 0) trough = arena.track(trough.rotate([0, 0, angleDeg]));
+  trough = arena.track(trough.translate([start.x, start.y, bottomCentreZ]));
+
+  const roundedBottom = arena.track(
+    arena.track(startSphere.add(trough)).add(endSphere),
+  );
+  return arena.track(shaft.add(roundedBottom));
+}
+
+/** Builds independent bin-local finger-hole cutters. */
+export function buildFingerHoleCutters(
+  kernel: Kernel,
+  fingerHoles: readonly FingerHole[],
+  spec: BinSpec,
+  quality: BuildQuality,
+): Manifold[] {
+  const { arena } = kernel;
+  const cutters: Manifold[] = [];
+  const segments = quality.circularSegments;
+
+  for (const hole of fingerHoles) {
+    const pocket = resolvePocketDepth(spec, { mode: "mm", value: hole.depthMm });
+    if (hole.kind === "straight") {
+      const floorZ = pocket.floorZ ?? -1;
+      const circle = arena.track(
+        arena
+          .track(kernel.CrossSection.circle(hole.diameterMm / 2, segments))
+          .translate([hole.center.x, hole.center.y]),
+      );
+      cutters.push(
+        arena.track(
+          arena
+            .track(circle.extrude(pocket.cutterTopZ - floorZ))
+            .translate([0, 0, floorZ]),
+        ),
+      );
+    } else if (hole.kind === "scoop") {
+      cutters.push(
+        buildRoundScoopCutter(
+          kernel,
+          hole,
+          BIN_LOCAL_PLACEMENT,
+          pocket,
+          segments,
+        ),
+      );
+    } else if (hole.kind === "deep-scoop") {
+      cutters.push(
+        buildDeepScoopCutter(
+          kernel,
+          hole,
+          BIN_LOCAL_PLACEMENT,
+          pocket,
+          segments,
+        ),
+      );
+    } else if (hole.kind === "oblong-deep-scoop") {
+      cutters.push(
+        buildOblongDeepScoopCutter(
+          kernel,
+          hole,
+          BIN_LOCAL_PLACEMENT,
+          pocket,
+          segments,
+        ),
+      );
+    }
+  }
+  return cutters;
+}
+
 /** Builds one cutter per cutout, skipping (and reporting) collapsed ones. */
 export function buildCutoutCutters(
   kernel: Kernel,
@@ -301,28 +418,7 @@ export function buildCutoutCutters(
     }
     reports.push({ id: cutout.id, emptied: false });
 
-    // Straight holes join after the offsets: cut at their drawn diameter,
-    // they inherit the pocket's depth, floor and bottom fillet through the
-    // shared cross-section. Scoop holes are independent top-surface cutters.
-    for (const hole of cutout.fingerHoles) {
-      if (hole.kind !== "straight") continue;
-      const centre = transformPointPlacement(hole.center, cutout);
-      const circle = arena.track(
-        arena
-          .track(kernel.CrossSection.circle(hole.diameterMm / 2, segments))
-          .translate([centre.x, centre.y]),
-      );
-      section = arena.track(section.add(circle));
-    }
-
     const pocket = resolvePocketDepth(spec, cutout.depth);
-    for (const hole of cutout.fingerHoles) {
-      if (hole.kind === "scoop") {
-        cutters.push(buildRoundScoopCutter(kernel, hole, cutout, pocket, segments));
-      } else if (hole.kind === "deep-scoop") {
-        cutters.push(buildDeepScoopCutter(kernel, hole, cutout, pocket, segments));
-      }
-    }
     let cutter: Manifold;
     if (pocket.floorZ === null) {
       // Through cut: from below the bin to above the lip.

--- a/client/src/lib/gridfinity/fit-check.ts
+++ b/client/src/lib/gridfinity/fit-check.ts
@@ -14,7 +14,11 @@ import type { Kernel } from "@/lib/manifold/runtime";
 
 import type { BuildQuality } from "./bin";
 import type { BinLayout } from "./bin";
-import { buildCutoutCutters, budgetOutline } from "./cutouts";
+import {
+  buildCutoutCutters,
+  buildFingerHoleCutters,
+  budgetOutline,
+} from "./cutouts";
 import { footprintOuterSection } from "./footprint-section";
 import { roundedRectPolygon } from "./profiles";
 import {
@@ -155,10 +159,14 @@ export function buildSurfaceFitCheckSolid(
     spec,
     quality,
   );
-  if (builtCutouts.cutters.length > 0) {
-    const cutter = builtCutouts.cutters.length === 1
-      ? builtCutouts.cutters[0]
-      : arena.track(Manifold.union(builtCutouts.cutters));
+  const allCutters = [
+    ...builtCutouts.cutters,
+    ...buildFingerHoleCutters(kernel, layout.fingerHoles, spec, quality),
+  ];
+  if (allCutters.length > 0) {
+    const cutter = allCutters.length === 1
+      ? allCutters[0]
+      : arena.track(Manifold.union(allCutters));
     plate = arena.track(plate.subtract(cutter));
   }
 

--- a/client/src/lib/gridfinity/use-bin-geometry.ts
+++ b/client/src/lib/gridfinity/use-bin-geometry.ts
@@ -4,6 +4,7 @@ import type { BufferGeometry } from "three";
 
 import type {
   CutoutPlacement,
+  FingerHole,
   TracedShape,
 } from "@shared/gridfinity/cutout";
 import type { BinSpec } from "@shared/gridfinity/types";
@@ -35,6 +36,7 @@ import {
 export interface BinGeometryLayout {
   shapes: TracedShape[];
   cutouts: CutoutPlacement[];
+  fingerHoles: FingerHole[];
 }
 
 /**
@@ -146,6 +148,7 @@ export function useBinGeometry(
         budget: quality.cutoutVertexBudget,
         filletStep: quality.filletProfileStepMm,
         cutouts: layout?.cutouts ?? [],
+        fingerHoles: layout?.fingerHoles ?? [],
         shapeKeys: layout?.shapes.map((shape) => `${shape.id}:${shape.pointCount}`) ?? [],
         section: section ?? null,
         pocketFloorThicknessMm:
@@ -177,8 +180,12 @@ export function useBinGeometry(
         spec,
         quality,
         layout:
-          layout && layout.cutouts.length > 0
-            ? { shapes: layout.shapes, cutouts: layout.cutouts }
+          layout && (layout.cutouts.length > 0 || layout.fingerHoles.length > 0)
+            ? {
+                shapes: layout.shapes,
+                cutouts: layout.cutouts,
+                fingerHoles: layout.fingerHoles,
+              }
             : undefined,
         section: section ?? undefined,
         pocketFloorMaterialThicknessMm:
@@ -266,8 +273,12 @@ export function useBinGeometry(
         spec,
         quality: exportQuality,
         layout:
-          layout && layout.cutouts.length > 0
-            ? { shapes: layout.shapes, cutouts: layout.cutouts }
+          layout && (layout.cutouts.length > 0 || layout.fingerHoles.length > 0)
+            ? {
+                shapes: layout.shapes,
+                cutouts: layout.cutouts,
+                fingerHoles: layout.fingerHoles,
+              }
             : undefined,
         pocketFloorMaterialThicknessMm:
           options.pocketFloorMaterialThicknessMm,
@@ -307,14 +318,21 @@ export function useBinGeometry(
       thicknessMm: number,
       exportQuality: BuildQuality,
     ): Promise<BuildSurfaceFitCheckResult> => {
-      if (!layout || layout.cutouts.length === 0) {
+      if (
+        !layout ||
+        (layout.cutouts.length === 0 && layout.fingerHoles.length === 0)
+      ) {
         return Promise.reject(
           new Error("Add at least one tool pocket before exporting a surface fit test."),
         );
       }
       const request: BuildSurfaceFitCheckRequest = {
         spec,
-        layout: { shapes: layout.shapes, cutouts: layout.cutouts },
+        layout: {
+          shapes: layout.shapes,
+          cutouts: layout.cutouts,
+          fingerHoles: layout.fingerHoles,
+        },
         thicknessMm,
         quality: exportQuality,
       };

--- a/client/src/lib/gridfinity/worker-api.ts
+++ b/client/src/lib/gridfinity/worker-api.ts
@@ -1,5 +1,6 @@
 import type {
   CutoutPlacementInput,
+  FingerHole,
   TracedShape,
 } from "@shared/gridfinity/cutout";
 import type { BinSpecInput } from "@shared/gridfinity/types";
@@ -31,6 +32,7 @@ export interface BuildBinLayoutRequest {
    */
   shapes: TracedShape[];
   cutouts: CutoutPlacementInput[];
+  fingerHoles: FingerHole[];
 }
 
 /**

--- a/client/src/lib/project/persist.test.ts
+++ b/client/src/lib/project/persist.test.ts
@@ -28,6 +28,7 @@ const DOC: ProjectDoc = {
   shapes: [],
   spec: parseBinSpec({ gridX: 2, gridY: 2, heightUnits: 6 }),
   cutouts: [],
+  fingerHoles: [],
 };
 
 const WIDE_DOC: ProjectDoc = {

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -110,6 +110,7 @@ const EMPTY_PROJECT: ProjectDoc = {
   shapes: [],
   spec: parseBinSpec({ gridX: 2, gridY: 2, heightUnits: 6 }),
   cutouts: [],
+  fingerHoles: [],
 };
 
 function rectangularShape(id: string, name: string): TracedShape {
@@ -225,7 +226,12 @@ function renderPage() {
 
 function openSettingsSection(
   container: HTMLElement,
-  section: "project" | "construction" | "tool-cutouts" | "export",
+  section:
+    | "project"
+    | "construction"
+    | "tool-cutouts"
+    | "finger-holes"
+    | "export",
 ): void {
   React.act(() => {
     (
@@ -359,45 +365,119 @@ describe("BinDesignerPage", () => {
           id: "cutout-deep",
           shapeId: shape.id,
           position: { x: 0, y: 0 },
-          fingerHoles: [
-            {
-              id: "finger-deep",
-              kind: "deep-scoop",
-              center: { x: 15, y: 0 },
-              diameterMm: 16,
-              depthMm: 30,
-            },
-          ],
         }),
+      ],
+      fingerHoles: [
+        {
+          id: "finger-deep",
+          kind: "deep-scoop",
+          center: { x: 15, y: 0 },
+          diameterMm: 16,
+          depthMm: 30,
+        },
       ],
     });
 
     const { container, unmount } = renderPage();
     await flushHydration();
-    openSettingsSection(container, "tool-cutouts");
+    openSettingsSection(container, "finger-holes");
     React.act(() => {
       (
         container.querySelector(
-          '[data-testid="button-select-cutout-deep"]',
+          '[data-testid="button-select-finger-hole-finger-deep"]',
         ) as HTMLButtonElement
       ).click();
     });
 
     expect(
-      container.querySelector('[data-testid="finger-hole-kind-1"]')?.textContent,
+      container.querySelector('[data-testid="selected-finger-hole-kind"]')?.textContent,
     ).toContain("Deep scoop");
     expect(container.querySelector('[aria-label="Diameter"]')).not.toBeNull();
     expect(container.querySelector('[aria-label="Total depth"]')).not.toBeNull();
     expect(container.querySelector('[aria-label="Reach"]')).toBeNull();
-    expect(container.textContent).toContain("Straight shaft: 22.0 mm");
-    expect(container.textContent).toContain("hemispherical bottom: 8.0 mm");
+    expect(container.textContent).toContain("Vertical walls: 22.0 mm");
+    expect(container.textContent).toContain("rounded bottom radius: 8.0 mm");
 
     React.act(() => {
       (container.querySelector('[data-testid="view-toggle-2d"]') as HTMLButtonElement).click();
     });
     expect(
-      container.querySelector('[data-testid="feature-deep-scoop-cutout-deep"]'),
+      container.querySelector('[data-testid="finger-hole-deep-scoop-finger-deep"]'),
     ).not.toBeNull();
+    unmount();
+  });
+
+  it("restores an oblong deep scoop with rotation controls and endpoint handles", async () => {
+    const shape = rectangularShape("shape-oblong-deep", "Long pliers");
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT,
+      shapes: [shape],
+      cutouts: [
+        parseCutoutPlacement({
+          id: "cutout-oblong-deep",
+          shapeId: shape.id,
+          position: { x: 0, y: 0 },
+        }),
+      ],
+      fingerHoles: [
+        {
+          id: "finger-oblong-deep",
+          kind: "oblong-deep-scoop",
+          center: { x: 0, y: 15 },
+          diameterMm: 12,
+          depthMm: 30,
+          lengthMm: 40,
+          rotationDeg: 0,
+        },
+      ],
+    });
+
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "finger-holes");
+    React.act(() => {
+      (
+        container.querySelector(
+          '[data-testid="button-select-finger-hole-finger-oblong-deep"]',
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    expect(
+      container.querySelector('[data-testid="selected-finger-hole-kind"]')?.textContent,
+    ).toContain("Oblong deep scoop");
+    expect(container.querySelector('[aria-label="Diameter"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Total depth"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Length"]')).not.toBeNull();
+    const rotateClockwise = container.querySelector(
+      '[aria-label="Rotate oblong finger hole 90 degrees clockwise"]',
+    ) as HTMLButtonElement;
+    expect(rotateClockwise).not.toBeNull();
+    expect(
+      container.querySelector(
+        '[aria-label="Rotate oblong finger hole 90 degrees counterclockwise"]',
+      ),
+    ).not.toBeNull();
+    expect(container.textContent).toContain("Vertical walls: 24.0 mm");
+    expect(container.textContent).toContain("rounded bottom radius: 6.0 mm");
+
+    React.act(() => {
+      (container.querySelector('[data-testid="view-toggle-2d"]') as HTMLButtonElement).click();
+    });
+    const handle = (endpoint: "start" | "end") =>
+      container.querySelector(
+        `[data-testid="finger-hole-oblong-end-${endpoint}-finger-oblong-deep"]`,
+      ) as SVGCircleElement;
+    expect(handle("start")).not.toBeNull();
+    expect(handle("end")).not.toBeNull();
+    expect(
+      Math.abs(Number(handle("end").getAttribute("cx")) - Number(handle("start").getAttribute("cx"))),
+    ).toBeGreaterThan(10);
+
+    React.act(() => rotateClockwise.click());
+    expect(
+      Math.abs(Number(handle("end").getAttribute("cy")) - Number(handle("start").getAttribute("cy"))),
+    ).toBeGreaterThan(10);
     unmount();
   });
 
@@ -451,6 +531,7 @@ describe("BinDesignerPage", () => {
       ["bin-settings-size", "blue", "open"],
       ["bin-settings-construction", "rose", "closed"],
       ["bin-settings-pockets", "violet", "closed"],
+      ["bin-settings-finger-holes", "cyan", "closed"],
       ["bin-settings-view", "amber", "closed"],
       ["bin-settings-export", "emerald", "closed"],
     ] as const;
@@ -642,9 +723,9 @@ describe("BinDesignerPage", () => {
     expect(ruler.title).toContain("Add a tool cutout");
     expect(
       container.querySelector('[data-testid="layout-empty-state"]')?.textContent,
-    ).toContain("Trace a tool and choose Add to bin");
+    ).toContain("Add a tool pocket or a finger hole");
     expect(container.querySelector('[data-testid="layout-ruler-status"]')).toBeNull();
-    expect(container.textContent).toContain("Add a tool from Trace to begin");
+    expect(container.textContent).toContain("Add a tool pocket or finger hole to begin");
     unmount();
   });
 
@@ -904,7 +985,7 @@ describe("BinDesignerPage", () => {
     expect(text).toContain("Outline corner round");
     expect(text).toContain("Top edge round");
     expect(text).toContain("Bottom fillet");
-    expect(text).toContain("Finger holes");
+    expect(text).toContain("Finger Holes");
     const renameButton = container.querySelector(
       '[data-testid="button-edit-shape-name"]',
     ) as HTMLButtonElement;
@@ -975,20 +1056,32 @@ describe("BinDesignerPage", () => {
       ).click();
     });
 
-    // Every finger hole gets its own straight/scoop type control.
-    openSettingsSection(container, "tool-cutouts");
+    // Finger holes live in their own object list and selection context.
+    openSettingsSection(container, "finger-holes");
     const addFingerHole = container.querySelector(
       '[data-testid="button-add-finger-hole"]',
     ) as HTMLButtonElement;
     React.act(() => addFingerHole.click());
     const kind = container.querySelector(
-      '[data-testid="finger-hole-kind-1"]',
+      '[data-testid="selected-finger-hole-kind"]',
     ) as HTMLButtonElement | null;
     expect(kind).not.toBeNull();
     expect(kind!.textContent).toContain("Straight");
     expect(container.textContent).not.toContain("Scoop depth");
 
-    // Editing a selected contour switches to Layout and exposes its vertices.
+    React.act(() => {
+      (container.querySelector('[data-testid="view-toggle-2d"]') as HTMLButtonElement).click();
+    });
+    expect(container.querySelector('[data-testid^="finger-hole-straight-"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid^="finger-hole-width-"]')).not.toBeNull();
+
+    // Selecting the pocket again is independent and exposes contour editing.
+    openSettingsSection(container, "tool-cutouts");
+    React.act(() => {
+      (
+        container.querySelector('[data-testid^="button-select-"]') as HTMLButtonElement
+      ).click();
+    });
     const editContour = container.querySelector(
       '[data-testid="button-edit-contour"]',
     ) as HTMLButtonElement;
@@ -1004,7 +1097,7 @@ describe("BinDesignerPage", () => {
     expect(
       container.querySelectorAll('[data-testid="contour-vertex-handle"]'),
     ).toHaveLength(4);
-    expect(container.querySelector('[data-testid^="feature-straight-"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid^="finger-hole-straight-"]')).not.toBeNull();
     expect(container.querySelector("[data-rotate-handle]")).toBeNull();
 
     React.act(() => {

--- a/client/src/pages/bin-designer.tsx
+++ b/client/src/pages/bin-designer.tsx
@@ -83,7 +83,7 @@ function BinDesignerWorkspace(): JSX.Element {
   const { panelOpen, setPanelOpen } = usePanelState();
   const { toast } = useToast();
   const bin = useBin();
-  const { spec, cutouts, viewMode, dispatch } = bin;
+  const { spec, cutouts, fingerHoles, viewMode, dispatch } = bin;
   const library = useShapeLibrary();
   // Sliders and canvas drags update the visible controls transiently, but the
   // history entry remains the last committed design until pointer-up. Feeding
@@ -92,6 +92,7 @@ function BinDesignerWorkspace(): JSX.Element {
   const committedDoc = getCommittedBinDoc(bin);
   const committedSpec = committedDoc.spec;
   const committedCutouts = committedDoc.cutouts;
+  const committedFingerHoles = committedDoc.fingerHoles;
 
   const [exporting, setExporting] = useState(false);
   const [section, setSection] = useState<BuildBinSection | null>(null);
@@ -123,7 +124,12 @@ function BinDesignerWorkspace(): JSX.Element {
       setProjectLibraryReady(true);
       if (doc) {
         library.mergeShapes(doc.shapes);
-        dispatch({ type: "HYDRATE", spec: doc.spec, cutouts: doc.cutouts });
+        dispatch({
+          type: "HYDRATE",
+          spec: doc.spec,
+          cutouts: doc.cutouts,
+          fingerHoles: doc.fingerHoles,
+        });
       } else {
         dispatch({ type: "MARK_HYDRATED" });
       }
@@ -144,8 +150,9 @@ function BinDesignerWorkspace(): JSX.Element {
       shapes: library.shapes,
       spec,
       cutouts,
+      fingerHoles,
     }),
-    [library.shapes, spec, cutouts],
+    [library.shapes, spec, cutouts, fingerHoles],
   );
   useEffect(() => {
     if (!bin.hydrated) return;
@@ -215,8 +222,9 @@ function BinDesignerWorkspace(): JSX.Element {
     return {
       shapes: library.shapes.filter((shape) => referenced.has(shape.id)),
       cutouts,
+      fingerHoles,
     };
-  }, [library.shapes, cutouts]);
+  }, [library.shapes, cutouts, fingerHoles]);
 
   const previewLayout = useMemo(() => {
     const referenced = new Set(
@@ -225,8 +233,9 @@ function BinDesignerWorkspace(): JSX.Element {
     return {
       shapes: library.shapes.filter((shape) => referenced.has(shape.id)),
       cutouts: committedCutouts,
+      fingerHoles: committedFingerHoles,
     };
-  }, [library.shapes, committedCutouts]);
+  }, [library.shapes, committedCutouts, committedFingerHoles]);
 
   const measurementOutlines = useMemo(() => {
     const shapesById = new Map(
@@ -302,6 +311,7 @@ function BinDesignerWorkspace(): JSX.Element {
       shapesById,
       spec.lip,
       spec.gridPitch,
+      fingerHoles,
     );
     if (!result) return;
     dispatch({
@@ -321,7 +331,7 @@ function BinDesignerWorkspace(): JSX.Element {
         variant: "destructive",
       });
     }
-  }, [cutouts, library.shapes, spec.lip, spec.gridPitch, dispatch, toast]);
+  }, [cutouts, fingerHoles, library.shapes, spec.lip, spec.gridPitch, dispatch, toast]);
 
   const handleExportLayout = useCallback(
     (format: "dxf" | "svg") => {
@@ -331,21 +341,21 @@ function BinDesignerWorkspace(): JSX.Element {
       }${spec.footprint.kind === "custom" ? `-custom-${spec.footprint.cells.length}cell` : ""}`;
       if (format === "dxf") {
         downloadBlob(
-          new Blob([generateLayoutDXF(spec, cutouts, shapesById)], {
+          new Blob([generateLayoutDXF(spec, cutouts, shapesById, fingerHoles)], {
             type: "application/dxf",
           }),
           `bin-layout-${label}.dxf`,
         );
       } else {
         downloadBlob(
-          new Blob([generateLayoutSVG(spec, cutouts, shapesById)], {
+          new Blob([generateLayoutSVG(spec, cutouts, shapesById, fingerHoles)], {
             type: "image/svg+xml",
           }),
           `bin-layout-${label}.svg`,
         );
       }
     },
-    [spec, cutouts, library.shapes],
+    [spec, cutouts, fingerHoles, library.shapes],
   );
 
   const handleExportProject = useCallback(() => {
@@ -387,7 +397,12 @@ function BinDesignerWorkspace(): JSX.Element {
       try {
         const saved = await startNewProject(doc);
         library.replaceShapes(doc.shapes);
-        dispatch({ type: "HYDRATE", spec: doc.spec, cutouts: doc.cutouts });
+        dispatch({
+          type: "HYDRATE",
+          spec: doc.spec,
+          cutouts: doc.cutouts,
+          fingerHoles: doc.fingerHoles,
+        });
         setSection(null);
         setProjectLibrary(saved);
         toast({
@@ -413,13 +428,19 @@ function BinDesignerWorkspace(): JSX.Element {
       shapes: [],
       spec: INITIAL_BIN_SPEC,
       cutouts: [],
+      fingerHoles: [],
     };
     setProjectBusy(true);
     saveProject.cancel();
     try {
       const saved = await startNewProject(doc);
       library.replaceShapes([]);
-      dispatch({ type: "HYDRATE", spec: doc.spec, cutouts: doc.cutouts });
+      dispatch({
+        type: "HYDRATE",
+        spec: doc.spec,
+        cutouts: doc.cutouts,
+        fingerHoles: doc.fingerHoles,
+      });
       setSection(null);
       setProjectLibrary(saved);
       toast({
@@ -470,7 +491,12 @@ function BinDesignerWorkspace(): JSX.Element {
     try {
       const opened = await openProjectFromLibrary(projectId);
       library.replaceShapes(opened.doc.shapes);
-      dispatch({ type: "HYDRATE", spec: opened.doc.spec, cutouts: opened.doc.cutouts });
+      dispatch({
+        type: "HYDRATE",
+        spec: opened.doc.spec,
+        cutouts: opened.doc.cutouts,
+        fingerHoles: opened.doc.fingerHoles,
+      });
       setSection(null);
       setProjectLibrary(opened.library);
       toast({

--- a/client/src/state/bin-store.test.tsx
+++ b/client/src/state/bin-store.test.tsx
@@ -125,6 +125,7 @@ describe("bin store", () => {
         type: "HYDRATE",
         spec: { ...store().spec, gridX: 4 },
         cutouts: [CUTOUT],
+        fingerHoles: [],
       }),
     );
     expect(store().hydrated).toBe(true);
@@ -297,11 +298,43 @@ describe("bin store history (G4 undo/redo)", () => {
         type: "HYDRATE",
         spec: store().spec,
         cutouts: [CUTOUT],
+        fingerHoles: [],
       }),
     );
     expect(store().canUndo).toBe(false);
     act(() => store().dispatch({ type: "UNDO" }));
     expect(store().cutouts).toHaveLength(1);
+  });
+
+  it("keeps finger holes independent when a tool pocket is moved or removed", () => {
+    const { store, act } = mountBin();
+    act(() =>
+      store().dispatch({ type: "ADD_PLACED", cutouts: [CUTOUT], gridX: 2, gridY: 2 }),
+    );
+    act(() =>
+      store().dispatch({
+        type: "ADD_FINGER_HOLE",
+        hole: {
+          id: "f1",
+          center: { x: 7, y: -3 },
+          diameterMm: 18,
+          depthMm: 12,
+          kind: "scoop",
+        },
+      }),
+    );
+    act(() =>
+      store().dispatch({
+        type: "UPDATE_CUTOUT",
+        id: "c1",
+        patch: { position: { x: 20, y: 10 } },
+      }),
+    );
+    expect(store().fingerHoles[0].center).toEqual({ x: 7, y: -3 });
+    act(() => store().dispatch({ type: "REMOVE_CUTOUT", id: "c1" }));
+    expect(store().cutouts).toEqual([]);
+    expect(store().fingerHoles).toHaveLength(1);
+    expect(store().selectedFingerHoleId).toBe("f1");
   });
 
   it("duplicate copies everything but identity and offsets the twin", () => {

--- a/client/src/state/bin-store.tsx
+++ b/client/src/state/bin-store.tsx
@@ -7,14 +7,14 @@ import {
   type ReactNode,
 } from "react";
 
-import type { CutoutPlacement } from "@shared/gridfinity/cutout";
+import type { CutoutPlacement, FingerHole } from "@shared/gridfinity/cutout";
 import { parseBinSpec, type BinSpec, type BinSpecInput } from "@shared/gridfinity/types";
 
 /**
  * The bin designer's state: spec + placed cutouts + editor selection. Same
  * reducer-provider shape as the trace store, scoped to the /bin page.
  *
- * Undo/redo (G4) covers the **material document** — `{spec, cutouts}` — and
+ * Undo/redo covers the **material document** — `{spec, cutouts, fingerHoles}` — and
  * nothing else: selection, view mode and hydration are transient UI state
  * that undoing should not yank around. The stack holds full snapshots with
  * `index` pointing at the present; drag frames dispatch with
@@ -29,6 +29,7 @@ export type BinEditorMode = "placement" | "contour" | "footprint" | "label-edge"
 export interface BinDoc {
   spec: BinSpec;
   cutouts: CutoutPlacement[];
+  fingerHoles: FingerHole[];
 }
 
 export interface BinHistoryEntry {
@@ -42,7 +43,9 @@ const HISTORY_LIMIT = 50;
 export interface BinState {
   spec: BinSpec;
   cutouts: CutoutPlacement[];
+  fingerHoles: FingerHole[];
   selectedCutoutId: string | null;
+  selectedFingerHoleId: string | null;
   /** Pocket awaiting the user's remove/resize decision. */
   pendingRemovalId: string | null;
   viewMode: BinViewMode;
@@ -65,7 +68,12 @@ export function getCommittedBinDoc(
 }
 
 export type BinAction =
-  | { type: "HYDRATE"; spec: BinSpec; cutouts: CutoutPlacement[] }
+  | {
+      type: "HYDRATE";
+      spec: BinSpec;
+      cutouts: CutoutPlacement[];
+      fingerHoles?: FingerHole[];
+    }
   | { type: "MARK_HYDRATED" }
   | {
       type: "PATCH_SPEC";
@@ -88,6 +96,15 @@ export type BinAction =
       transient?: boolean;
       historyLabel?: string;
     }
+  | { type: "ADD_FINGER_HOLE"; hole: FingerHole }
+  | {
+      type: "UPDATE_FINGER_HOLE";
+      id: string;
+      patch: Partial<FingerHole>;
+      transient?: boolean;
+      historyLabel?: string;
+    }
+  | { type: "REMOVE_FINGER_HOLE"; id: string }
   | { type: "REQUEST_REMOVE_CUTOUT"; id: string }
   | { type: "CANCEL_REMOVE_CUTOUT" }
   | { type: "REMOVE_CUTOUT"; id: string }
@@ -95,6 +112,7 @@ export type BinAction =
   | {
       type: "REPLACE_LAYOUT";
       cutouts: CutoutPlacement[];
+      fingerHoles?: FingerHole[];
       gridX: number;
       gridY: number;
       footprint?: BinSpec["footprint"];
@@ -103,6 +121,7 @@ export type BinAction =
       historyLabel?: string;
     }
   | { type: "SELECT_CUTOUT"; id: string | null }
+  | { type: "SELECT_FINGER_HOLE"; id: string | null }
   | { type: "SET_VIEW_MODE"; viewMode: BinViewMode }
   | { type: "SET_EDITOR_MODE"; editorMode: BinEditorMode }
   | { type: "SET_GRID"; gridX: number; gridY: number; historyLabel?: string }
@@ -119,7 +138,9 @@ export const INITIAL_BIN_SPEC: BinSpec = parseBinSpec({
 const INITIAL: BinState = {
   spec: INITIAL_BIN_SPEC,
   cutouts: [],
+  fingerHoles: [],
   selectedCutoutId: null,
+  selectedFingerHoleId: null,
   pendingRemovalId: null,
   viewMode: "3d",
   editorMode: "placement",
@@ -127,7 +148,7 @@ const INITIAL: BinState = {
   history: {
     stack: [
       {
-        doc: { spec: INITIAL_BIN_SPEC, cutouts: [] },
+        doc: { spec: INITIAL_BIN_SPEC, cutouts: [], fingerHoles: [] },
         label: "Start",
       },
     ],
@@ -152,6 +173,7 @@ function commit(
     ...rest,
     spec: doc.spec,
     cutouts: doc.cutouts,
+    fingerHoles: doc.fingerHoles,
     history: { stack: stack.slice(overflow), index: stack.length - 1 - overflow },
   };
 }
@@ -174,7 +196,6 @@ function cutoutPatchLabel(patch: Partial<CutoutPlacement>): string {
   if ("position" in patch) return "Move tool pocket";
   if ("rotationDeg" in patch) return "Rotate tool pocket";
   if ("mirrored" in patch) return "Mirror tool pocket";
-  if ("fingerHoles" in patch) return "Edit finger holes";
   if ("depth" in patch) return "Change pocket depth";
   if ("clearanceMm" in patch) return "Change pocket clearance";
   if ("cornerRoundMm" in patch) return "Change outline corner round";
@@ -185,7 +206,12 @@ function cutoutPatchLabel(patch: Partial<CutoutPlacement>): string {
 
 /** A transient change: present state moves, the history does not. */
 function preview(state: BinState, doc: BinDoc): BinState {
-  return { ...state, spec: doc.spec, cutouts: doc.cutouts };
+  return {
+    ...state,
+    spec: doc.spec,
+    cutouts: doc.cutouts,
+    fingerHoles: doc.fingerHoles,
+  };
 }
 
 function patchCutouts(
@@ -203,12 +229,18 @@ function reducer(state: BinState, action: BinAction): BinState {
     case "HYDRATE": {
       // A restored project is the new baseline — undo must not walk back
       // into the pre-hydration default document.
-      const doc = { spec: action.spec, cutouts: action.cutouts };
+      const doc = {
+        spec: action.spec,
+        cutouts: action.cutouts,
+        fingerHoles: action.fingerHoles ?? [],
+      };
       return {
         ...state,
         spec: doc.spec,
         cutouts: doc.cutouts,
+        fingerHoles: doc.fingerHoles,
         selectedCutoutId: null,
+        selectedFingerHoleId: null,
         pendingRemovalId: null,
         editorMode: "placement",
         hydrated: true,
@@ -231,6 +263,7 @@ function reducer(state: BinState, action: BinAction): BinState {
             : {}),
         }),
         cutouts: state.cutouts,
+        fingerHoles: state.fingerHoles,
       };
       return action.transient
         ? preview(state, doc)
@@ -247,20 +280,65 @@ function reducer(state: BinState, action: BinAction): BinState {
             ...(action.footprint ? { footprint: action.footprint } : {}),
           }),
           cutouts: [...state.cutouts, ...action.cutouts],
+          fingerHoles: state.fingerHoles,
         },
         action.historyLabel ??
           `Add ${action.cutouts.length === 1 ? "tool pocket" : `${action.cutouts.length} tool pockets`}`,
-        { selectedCutoutId: action.cutouts.at(-1)?.id ?? state.selectedCutoutId },
+        {
+          selectedCutoutId: action.cutouts.at(-1)?.id ?? state.selectedCutoutId,
+          selectedFingerHoleId: null,
+        },
       );
     case "UPDATE_CUTOUT": {
       const doc = {
         spec: state.spec,
         cutouts: patchCutouts(state.cutouts, action.id, action.patch),
+        fingerHoles: state.fingerHoles,
       };
       return action.transient
         ? preview(state, doc)
         : commit(state, doc, action.historyLabel ?? cutoutPatchLabel(action.patch));
     }
+    case "ADD_FINGER_HOLE":
+      return commit(
+        state,
+        {
+          spec: state.spec,
+          cutouts: state.cutouts,
+          fingerHoles: [...state.fingerHoles, action.hole],
+        },
+        "Add finger hole",
+        { selectedCutoutId: null, selectedFingerHoleId: action.hole.id },
+      );
+    case "UPDATE_FINGER_HOLE": {
+      const doc = {
+        spec: state.spec,
+        cutouts: state.cutouts,
+        fingerHoles: state.fingerHoles.map((hole) =>
+          hole.id === action.id ? { ...hole, ...action.patch, id: hole.id } : hole,
+        ),
+      };
+      return action.transient
+        ? preview(state, doc)
+        : commit(state, doc, action.historyLabel ?? "Edit finger hole");
+    }
+    case "REMOVE_FINGER_HOLE":
+      if (!state.fingerHoles.some((hole) => hole.id === action.id)) return state;
+      return commit(
+        state,
+        {
+          spec: state.spec,
+          cutouts: state.cutouts,
+          fingerHoles: state.fingerHoles.filter((hole) => hole.id !== action.id),
+        },
+        "Remove finger hole",
+        {
+          selectedFingerHoleId:
+            state.selectedFingerHoleId === action.id
+              ? null
+              : state.selectedFingerHoleId,
+        },
+      );
     case "REQUEST_REMOVE_CUTOUT":
       return state.cutouts.some((cutout) => cutout.id === action.id)
         ? { ...state, pendingRemovalId: action.id }
@@ -276,6 +354,7 @@ function reducer(state: BinState, action: BinAction): BinState {
         {
           spec: state.spec,
           cutouts: state.cutouts.filter((cutout) => cutout.id !== action.id),
+          fingerHoles: state.fingerHoles,
         },
         "Remove tool pocket",
         {
@@ -295,9 +374,13 @@ function reducer(state: BinState, action: BinAction): BinState {
       };
       return commit(
         state,
-        { spec: state.spec, cutouts: [...state.cutouts, copy] },
+        {
+          spec: state.spec,
+          cutouts: [...state.cutouts, copy],
+          fingerHoles: state.fingerHoles,
+        },
         "Duplicate tool pocket",
-        { selectedCutoutId: copy.id },
+        { selectedCutoutId: copy.id, selectedFingerHoleId: null },
       );
     }
     case "REPLACE_LAYOUT":
@@ -312,6 +395,7 @@ function reducer(state: BinState, action: BinAction): BinState {
             ...(action.footprint ? { footprint: action.footprint } : {}),
           }),
           cutouts: action.cutouts,
+          fingerHoles: action.fingerHoles ?? state.fingerHoles,
         },
         action.historyLabel ?? "Arrange tool pockets",
         {
@@ -320,11 +404,26 @@ function reducer(state: BinState, action: BinAction): BinState {
           )
             ? state.selectedCutoutId
             : null,
+          selectedFingerHoleId: (action.fingerHoles ?? state.fingerHoles).some(
+            (hole) => hole.id === state.selectedFingerHoleId,
+          )
+            ? state.selectedFingerHoleId
+            : null,
           pendingRemovalId: null,
         },
       );
     case "SELECT_CUTOUT":
-      return { ...state, selectedCutoutId: action.id };
+      return {
+        ...state,
+        selectedCutoutId: action.id,
+        selectedFingerHoleId: action.id === null ? state.selectedFingerHoleId : null,
+      };
+    case "SELECT_FINGER_HOLE":
+      return {
+        ...state,
+        selectedFingerHoleId: action.id,
+        selectedCutoutId: action.id === null ? state.selectedCutoutId : null,
+      };
     case "SET_VIEW_MODE":
       return {
         ...state,
@@ -344,6 +443,7 @@ function reducer(state: BinState, action: BinAction): BinState {
             footprint: { kind: "rectangle" },
           }),
           cutouts: state.cutouts,
+          fingerHoles: state.fingerHoles,
         },
         action.historyLabel ?? "Resize bin",
       );
@@ -376,11 +476,17 @@ function restore(state: BinState, entry: BinHistoryEntry, index: number): BinSta
     ...state,
     spec: doc.spec,
     cutouts: doc.cutouts,
+    fingerHoles: doc.fingerHoles,
     history: { ...state.history, index },
     // Selection survives only if the cutout still exists at this point in
     // time.
     selectedCutoutId: doc.cutouts.some((c) => c.id === state.selectedCutoutId)
       ? state.selectedCutoutId
+      : null,
+    selectedFingerHoleId: doc.fingerHoles.some(
+      (hole) => hole.id === state.selectedFingerHoleId,
+    )
+      ? state.selectedFingerHoleId
       : null,
     pendingRemovalId: null,
   };

--- a/docs/gridfinity-plan.md
+++ b/docs/gridfinity-plan.md
@@ -19,17 +19,21 @@ shaped-bin physical gate remains: print a full-pitch
 2×2/three-cell L, verify baseplate fit and the concave wall/lip, stack a matching
 footprint, then print an L-tool pocket and check its fit.
 
-G4 delivered per-pocket **finger holes**, now individually selectable as
-straight cylinders sharing the pocket's floor and fillet, spherical round
-scoops, or deep scoops from the top surface. A deep scoop keeps a round opening,
-runs straight down for the requested shaft depth, and terminates in a true
-hemisphere; total depth can therefore exceed the opening diameter without an
-inward-overhanging cavity. Round-scoop depth remains capped at half the opening
-width. Multiple holes are stored shape-local and draggable by their exact
-circular rim in the Layout view; **auto-arrange**
-(min-area OBB per cutout — features included — then shelf packing into the
-smallest grid, ids preserved); **undo/redo** over the material document
-`{spec, cutouts}` (hand-rolled history in the bin reducer, mirroring the
+G4 delivered **finger holes**, now independent bin-local layout objects rather
+than children of a tool pocket. They can be straight cylinders with their own
+depth, spherical round scoops, round deep scoops, or oblong deep scoops from the
+top surface. Deep
+scoops run straight down for the requested shaft depth and terminate in a
+rounded bottom, so total depth can exceed the opening width without an
+inward-overhanging cavity. The oblong variant has a capsule mouth and swept
+hemisphere bottom; it can be moved as a unit, rotated directly, or resized and
+rotated by dragging either endpoint. Every hole type has a mouse diameter/width
+handle; oblong holes additionally expose both end handles. Round-scoop depth
+remains capped at half the opening width. Moving, duplicating, deleting, or
+auto-arranging a pocket does not move or remove a hole. **Auto-arrange** uses a
+min-area OBB per cutout and shelf-packs pockets into the smallest grid while
+leaving independent holes fixed; **undo/redo** covers the material document
+`{spec, cutouts, fingerHoles}` (hand-rolled history in the bin reducer, mirroring the
 trace store, rather than the zustand+zundo sketched below — drags collapse
 to one step via transient dispatches). Both Trace and Bin expose the labeled
 history beside Undo/Redo and can jump directly to any retained step; contour
@@ -79,7 +83,7 @@ ruler is intentionally unavailable in the 3D preview.
 G5 completed its local software scope (2026-08-24): the 3D camera now re-fits whenever the bin's
 outer dimensions change (preserving the orbit direction), the ground grid
 scales with the bin, and the **top-down layout DXF/SVG export** landed —
-bin footprint plus pocket silhouettes and feature circles in real
+bin footprint plus pocket silhouettes and independent finger-hole rims in real
 millimetres, the CNC shadow-board bridge. The **label tab** is ported
 (upstream `TAB_POLYGON` @ the pinned SHA): full-width or 42 mm
 left/center/right on any wall, fused into the wall part, with
@@ -209,7 +213,7 @@ rewrite. Verify against the code before relying on any detail here.
 | Panel + canvas workspace shell | `client/src/components/layout/workspace-layout.tsx` | `autoSaveId` per workspace |
 | Vitest, node + jsdom projects | `vitest.config.ts` | geometry tests run headless with real WASM |
 
-The previously missing `ProjectDoc` is now implemented with `schemaVersion: 5`,
+The previously missing `ProjectDoc` is now implemented with `schemaVersion: 7`,
 IndexedDB autosave plus a named Project Library, explicit `.pocketry.json`
 backup import/export with legacy `.tooltrace.json` import compatibility, and
 reducer-owned undo/redo.
@@ -271,7 +275,11 @@ interface CutoutPlacement {
   cornerRoundMm: number;    // 1.0 — 2D vertical edge round
   topFilletMm: number;      // 0.0 — top-surface pocket-edge round-over
   bottomFilletMm: number;   // 2.8 (r_f2), clamped to depth/2
-  fingerHoles: FingerHole[]; // 'straight', 'scoop', or vertical 'deep-scoop'
+}
+
+interface ProjectDoc {
+  cutouts: CutoutPlacement[];
+  fingerHoles: FingerHole[]; // independent bin-local layout objects
 }
 ```
 
@@ -291,12 +299,14 @@ export; warnings do not.
 
 `server/storage.ts` has only `MemStorage` (a `Map`, wiped on restart), there is no Drizzle
 implementation and no `migrations/`, and the client never reads anything back. Instead,
-the landed client implementation uses a `ProjectDoc` with **`schemaVersion: 5`**, a
+the landed client implementation uses a `ProjectDoc` with **`schemaVersion: 7`**, a
 hand-rolled reducer history, `idb-keyval` autosave to IndexedDB (not localStorage —
 traced shapes plus thumbnails blow past 5 MB), a browser-local named Project
 Library with active-project autosave, and explicit `.pocketry.json` backup
-import/export (including legacy `.tooltrace.json` imports). The library is
-cross-browser code, not cross-device sync: each
+import/export (including legacy `.tooltrace.json` imports). Schemas 1–6 migrate
+pocket-local finger holes to bin-local coordinates while preserving their
+visible position and oblong orientation. The library is cross-browser code,
+not cross-device sync: each
 browser profile owns its own IndexedDB data.
 
 If server persistence is wanted later it is a `projects` table holding a **JSONB

--- a/shared/gridfinity/cutout.test.ts
+++ b/shared/gridfinity/cutout.test.ts
@@ -9,8 +9,12 @@ import {
   cutoutPlacementSchema,
   effectiveDeepScoopDepthMm,
   effectiveScoopDepthMm,
+  fingerHoleFootprintRing,
+  oblongDeepScoopEndpoints,
   parseCutoutPlacement,
   placementFootprint,
+  resizeFingerHoleFromWidthHandle,
+  resizeOblongDeepScoopFromEndpoint,
   resolvePocketDepth,
   signedDistanceToInterior,
   tracedShapeSchema,
@@ -296,7 +300,7 @@ describe("typed finger holes (straight and scoop)", () => {
     expect(back.y).toBeCloseTo(5, 12);
   });
 
-  it("footprint carries features through rotation", () => {
+  it("keeps legacy nested features out of the current pocket footprint", () => {
     const shape = { outlineMm: CHIRAL };
     const footprint = placementFootprint(shape, {
       position: { x: 0, y: 0 },
@@ -312,21 +316,14 @@ describe("typed finger holes (straight and scoop)", () => {
         },
       ],
     });
-    expect(footprint.features).toHaveLength(1);
-    // (10, 0) rotated 90° CCW lands at (0, 10); the rim is 3 mm around it.
-    const xs = footprint.features[0].map((p) => p.x);
-    const ys = footprint.features[0].map((p) => p.y);
-    expect(Math.min(...xs)).toBeCloseTo(-3, 9);
-    expect(Math.max(...xs)).toBeCloseTo(3, 9);
-    expect(Math.min(...ys)).toBeCloseTo(7, 9);
-    expect(Math.max(...ys)).toBeCloseTo(13, 9);
+    expect(footprint.features).toEqual([]);
   });
 
   it("uses a round plan-view footprint for a deep scoop", () => {
-    const footprint = placementFootprint({ outlineMm: CHIRAL }, {
+    const hole = parseCutoutPlacement({
+      id: "c1",
+      shapeId: "s1",
       position: { x: 0, y: 0 },
-      rotationDeg: 90,
-      mirrored: false,
       fingerHoles: [
         {
           id: "f1",
@@ -336,15 +333,124 @@ describe("typed finger holes (straight and scoop)", () => {
           depthMm: 20,
         },
       ],
+    }).fingerHoles[0];
+    const ring = fingerHoleFootprintRing(hole, {
+      position: { x: 0, y: 0 },
+      rotationDeg: 0,
+      mirrored: false,
     });
-    const xs = footprint.features[0].map((point) => point.x);
-    const ys = footprint.features[0].map((point) => point.y);
-    // Local (10, 0) becomes bin (0, 10) after the 90° placement.
-    expect(Math.min(...xs)).toBeCloseTo(-3, 9);
-    expect(Math.max(...xs)).toBeCloseTo(3, 9);
-    expect(Math.min(...ys)).toBeCloseTo(7, 9);
-    expect(Math.max(...ys)).toBeCloseTo(13, 9);
-    expect(signedArea(footprint.features[0])).toBeGreaterThan(0);
+    const xs = ring.map((point) => point.x);
+    const ys = ring.map((point) => point.y);
+    expect(Math.min(...xs)).toBeCloseTo(7, 9);
+    expect(Math.max(...xs)).toBeCloseTo(13, 9);
+    expect(Math.min(...ys)).toBeCloseTo(-3, 9);
+    expect(Math.max(...ys)).toBeCloseTo(3, 9);
+    expect(signedArea(ring)).toBeGreaterThan(0);
+  });
+
+  it("uses the rotated capsule mouth for an oblong deep scoop", () => {
+    const hole = parseCutoutPlacement({
+      id: "c1",
+      shapeId: "s1",
+      position: { x: 0, y: 0 },
+      fingerHoles: [
+        {
+          id: "f1",
+          center: { x: 0, y: 0 },
+          diameterMm: 10,
+          kind: "oblong-deep-scoop",
+          depthMm: 30,
+          lengthMm: 30,
+          rotationDeg: 90,
+        },
+      ],
+    }).fingerHoles[0];
+    const endpoints = oblongDeepScoopEndpoints(hole);
+    expect(endpoints.start.x).toBeCloseTo(0, 9);
+    expect(endpoints.start.y).toBeCloseTo(-10, 9);
+    expect(endpoints.end.y).toBeCloseTo(10, 9);
+
+    const ring = fingerHoleFootprintRing(hole, {
+      position: { x: 0, y: 0 },
+      rotationDeg: 0,
+      mirrored: false,
+    });
+    const xs = ring.map((point) => point.x);
+    const ys = ring.map((point) => point.y);
+    expect(Math.min(...xs)).toBeCloseTo(-5, 9);
+    expect(Math.max(...xs)).toBeCloseTo(5, 9);
+    expect(Math.min(...ys)).toBeCloseTo(-15, 9);
+    expect(Math.max(...ys)).toBeCloseTo(15, 9);
+    expect(signedArea(ring)).toBeGreaterThan(0);
+  });
+
+  it("resizes and rotates an oblong scoop by one endpoint while fixing the other", () => {
+    const hole = parseCutoutPlacement({
+      id: "c1",
+      shapeId: "s1",
+      position: { x: 0, y: 0 },
+      fingerHoles: [
+        {
+          id: "f1",
+          center: { x: 0, y: 0 },
+          diameterMm: 10,
+          kind: "oblong-deep-scoop",
+          depthMm: 30,
+          lengthMm: 30,
+          rotationDeg: 0,
+        },
+      ],
+    }).fingerHoles[0];
+    const resized = resizeOblongDeepScoopFromEndpoint(
+      hole,
+      "end",
+      { x: 10, y: 20 },
+    );
+    const endpoints = oblongDeepScoopEndpoints(resized);
+    expect(endpoints.start.x).toBeCloseTo(-10, 9);
+    expect(endpoints.start.y).toBeCloseTo(0, 9);
+    expect(endpoints.end.x).toBeCloseTo(10, 9);
+    expect(endpoints.end.y).toBeCloseTo(20, 9);
+    expect(resized.center).toEqual({ x: 0, y: 10 });
+    expect(resized.lengthMm).toBeCloseTo(10 + Math.hypot(20, 20), 9);
+    expect(resized.rotationDeg).toBeCloseTo(45, 9);
+  });
+
+  it("resizes round diameter and oblong width from a mouse handle", () => {
+    const round = parseCutoutPlacement({
+      id: "c1",
+      shapeId: "s1",
+      position: { x: 0, y: 0 },
+      fingerHoles: [{ id: "f1", center: { x: 4, y: 5 }, diameterMm: 10 }],
+    }).fingerHoles[0];
+    expect(
+      resizeFingerHoleFromWidthHandle(round, { x: 16, y: 5 }).diameterMm,
+    ).toBe(24);
+
+    const shallowDeep = {
+      ...round,
+      kind: "deep-scoop" as const,
+      depthMm: 4,
+    };
+    expect(
+      resizeFingerHoleFromWidthHandle(shallowDeep, { x: 16, y: 5 }).depthMm,
+    ).toBe(12);
+
+    const oblong = {
+      ...round,
+      kind: "oblong-deep-scoop" as const,
+      diameterMm: 10,
+      lengthMm: 30,
+      rotationDeg: 0,
+    };
+    const widened = resizeFingerHoleFromWidthHandle(oblong, { x: 4, y: 15 });
+    expect(widened.diameterMm).toBe(20);
+    expect(widened.depthMm).toBe(12);
+    expect(widened.lengthMm).toBe(40);
+    expect(oblongDeepScoopEndpoints(widened)).toMatchObject({
+      start: { x: -6, y: 5 },
+      end: { x: 14, y: 5 },
+    });
   });
 
   it("clamps the scoop to a hemisphere", () => {

--- a/shared/gridfinity/cutout.ts
+++ b/shared/gridfinity/cutout.ts
@@ -41,11 +41,9 @@ import type { BinSpec } from "./types";
  * - The 2D editor's SVG view is y-down; that flip is **view-only** and lives
  *   solely in {@link binToCanvas} / {@link canvasToBin}.
  *
- * G4 adds per-pocket **finger holes** whose type is either a vertical cylinder,
- * a spherical scoop, or a deep scoop with a straight shaft and hemispherical
- * bottom. There may be several of any kind. Their centres are stored
- * **shape-local**, so they travel with the pocket through move / rotate /
- * mirror. Schema-v1's one-off scoop migrates into this per-hole model.
+ * Finger holes are independent bin-local objects in the project document.
+ * `CutoutPlacement.fingerHoles` remains only as an import bridge for project
+ * schemas 1–6; current UI and geometry never attach holes to a tool pocket.
  */
 
 // ---------------------------------------------------------------------------
@@ -111,20 +109,27 @@ export type DepthSpec = z.infer<typeof depthSpecSchema>;
 /**
  * A draggable finger-access feature. Straight holes are vertical cylinders
  * cut to the pocket floor; round scoops are spherical dishes cut from the top;
- * deep scoops descend through a straight cylindrical shaft and finish in a
- * hemispherical bottom. `center` is shape-local, so every kind follows move /
- * rotate / mirror.
+ * deep scoops descend through straight vertical walls and finish in a rounded
+ * bottom. The oblong variant stores its midpoint, overall length and rotation
+ * so its two end handles can resize it. Every hole is positioned directly in
+ * the bin frame, independently from tool-pocket transforms.
  */
 export const fingerHoleSchema = z
   .object({
     id: z.string().min(1),
-    /** Shape-local mm, same frame as `outlineMm`. */
+    /** Bin-local mm, y-up, origin at the bin centre. */
     center: vec2Schema,
     diameterMm: z.number().min(6).max(80).default(18),
     // `oblong-scoop` accepts saves made by the short-lived directed-trough
     // prototype and normalizes them to the corrected vertical deep scoop.
     kind: z
-      .enum(["straight", "scoop", "deep-scoop", "oblong-scoop"])
+      .enum([
+        "straight",
+        "scoop",
+        "deep-scoop",
+        "oblong-deep-scoop",
+        "oblong-scoop",
+      ])
       .default("straight"),
     /** Used only for scoops; retained on straight holes so type changes are reversible. */
     depthMm: z.number().min(1).max(120).default(12),
@@ -132,6 +137,10 @@ export const fingerHoleSchema = z
     reachMm: z.number().min(1).max(120).optional(),
     /** Compatibility only; removed with the directed-trough prototype. */
     directionDeg: z.number().finite().optional(),
+    /** Overall end-to-end mouth length; used by oblong deep scoops only. */
+    lengthMm: z.number().min(6).max(160).optional(),
+    /** CCW mouth rotation in the bin-local y-up frame. */
+    rotationDeg: z.number().finite().optional(),
   })
   .strict()
   .transform(({ reachMm: _reach, directionDeg: _direction, kind, ...hole }) => ({
@@ -140,6 +149,12 @@ export const fingerHoleSchema = z
   }));
 
 export type FingerHole = z.infer<typeof fingerHoleSchema>;
+
+export const MIN_FINGER_HOLE_DIAMETER_MM = 6;
+export const MAX_FINGER_HOLE_DIAMETER_MM = 80;
+export const DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM = 36;
+export const MAX_OBLONG_DEEP_SCOOP_LENGTH_MM = 160;
+export const MIN_OBLONG_DEEP_SCOOP_SPAN_MM = 2;
 
 /**
  * A spherical dish cut down from the top surface. Placed on the pocket's
@@ -180,6 +195,129 @@ export function effectiveDeepScoopDepthMm(
   return Math.max(scoop.depthMm, scoop.diameterMm / 2);
 }
 
+export interface OblongDeepScoopEndpoints {
+  /** Centres of the two semicircular end caps in shape-local mm. */
+  start: Point;
+  end: Point;
+  /** Effective overall end-to-end mouth length. */
+  lengthMm: number;
+}
+
+/** Shape-local cap centres for an oblong deep scoop. */
+export function oblongDeepScoopEndpoints(
+  hole: Pick<
+    FingerHole,
+    "center" | "diameterMm" | "lengthMm" | "rotationDeg"
+  >,
+): OblongDeepScoopEndpoints {
+  const minimumLength = hole.diameterMm + MIN_OBLONG_DEEP_SCOOP_SPAN_MM;
+  const lengthMm = Math.min(
+    MAX_OBLONG_DEEP_SCOOP_LENGTH_MM,
+    Math.max(hole.lengthMm ?? DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM, minimumLength),
+  );
+  const halfSpan = (lengthMm - hole.diameterMm) / 2;
+  const radians = ((hole.rotationDeg ?? 0) * Math.PI) / 180;
+  const dx = halfSpan * Math.cos(radians);
+  const dy = halfSpan * Math.sin(radians);
+  return {
+    start: { x: hole.center.x - dx, y: hole.center.y - dy },
+    end: { x: hole.center.x + dx, y: hole.center.y + dy },
+    lengthMm,
+  };
+}
+
+/**
+ * Moves one oblong end while the opposite end stays fixed. This is shared by
+ * the editor and tests so endpoint dragging, resizing and rotation are one
+ * operation with one source of truth.
+ */
+export function resizeOblongDeepScoopFromEndpoint(
+  hole: FingerHole,
+  endpoint: "start" | "end",
+  dragged: Point,
+): FingerHole {
+  const current = oblongDeepScoopEndpoints(hole);
+  const fixed = endpoint === "start" ? current.end : current.start;
+  let dx = endpoint === "start" ? fixed.x - dragged.x : dragged.x - fixed.x;
+  let dy = endpoint === "start" ? fixed.y - dragged.y : dragged.y - fixed.y;
+  let span = Math.hypot(dx, dy);
+  if (span < 1e-9) {
+    const radians = ((hole.rotationDeg ?? 0) * Math.PI) / 180;
+    dx = Math.cos(radians);
+    dy = Math.sin(radians);
+    span = 1;
+  }
+  const clampedSpan = Math.min(
+    MAX_OBLONG_DEEP_SCOOP_LENGTH_MM - hole.diameterMm,
+    Math.max(MIN_OBLONG_DEEP_SCOOP_SPAN_MM, span),
+  );
+  const ux = dx / span;
+  const uy = dy / span;
+  const start = endpoint === "start"
+    ? { x: fixed.x - ux * clampedSpan, y: fixed.y - uy * clampedSpan }
+    : fixed;
+  const end = endpoint === "end"
+    ? { x: fixed.x + ux * clampedSpan, y: fixed.y + uy * clampedSpan }
+    : fixed;
+  const rotationDeg =
+    ((Math.atan2(end.y - start.y, end.x - start.x) * 180) / Math.PI + 360) % 360;
+  return {
+    ...hole,
+    center: { x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 },
+    lengthMm: clampedSpan + hole.diameterMm,
+    rotationDeg,
+  };
+}
+
+/**
+ * Resizes a mouth from its radial/width handle. Round holes keep their centre
+ * fixed. Oblong holes keep both cap centres fixed, so changing width does not
+ * unexpectedly change either end position.
+ */
+export function resizeFingerHoleFromWidthHandle(
+  hole: FingerHole,
+  dragged: Point,
+): FingerHole {
+  if (hole.kind !== "oblong-deep-scoop") {
+    const diameterMm = Math.min(
+      MAX_FINGER_HOLE_DIAMETER_MM,
+      Math.max(
+        MIN_FINGER_HOLE_DIAMETER_MM,
+        2 * Math.hypot(dragged.x - hole.center.x, dragged.y - hole.center.y),
+      ),
+    );
+    const depthMm =
+      hole.kind === "scoop"
+        ? Math.min(hole.depthMm, diameterMm / 2)
+        : hole.kind === "deep-scoop"
+          ? Math.max(hole.depthMm, diameterMm / 2)
+          : hole.depthMm;
+    return { ...hole, diameterMm, depthMm };
+  }
+
+  const endpoints = oblongDeepScoopEndpoints(hole);
+  const span = Math.hypot(
+    endpoints.end.x - endpoints.start.x,
+    endpoints.end.y - endpoints.start.y,
+  );
+  const radians = ((hole.rotationDeg ?? 0) * Math.PI) / 180;
+  const normal = { x: -Math.sin(radians), y: Math.cos(radians) };
+  const signedDistance =
+    (dragged.x - hole.center.x) * normal.x +
+    (dragged.y - hole.center.y) * normal.y;
+  const diameterMm = Math.min(
+    MAX_FINGER_HOLE_DIAMETER_MM,
+    MAX_OBLONG_DEEP_SCOOP_LENGTH_MM - span,
+    Math.max(MIN_FINGER_HOLE_DIAMETER_MM, 2 * Math.abs(signedDistance)),
+  );
+  return {
+    ...hole,
+    diameterMm,
+    depthMm: Math.max(hole.depthMm, diameterMm / 2),
+    lengthMm: span + diameterMm,
+  };
+}
+
 const cutoutPlacementInputSchema = z
   .object({
     id: z.string().min(1),
@@ -201,6 +339,7 @@ const cutoutPlacementInputSchema = z
     topFilletMm: z.number().min(0).max(5).default(0),
     /** Bottom-edge fillet radius; clamped to depth/2 at build time. */
     bottomFilletMm: z.number().min(0).max(6).default(R_F2),
+    /** Project schemas 1–6 only; current holes live at project level. */
     fingerHoles: z.array(fingerHoleSchema).default([]),
     /** Schema-v1 compatibility; normalized into a scoop finger hole below. */
     scoop: legacyScoopSpecSchema.nullable().optional(),
@@ -319,13 +458,45 @@ export function circleRing(center: Point, radiusMm: number, segments = 24): Poin
   return ring;
 }
 
+/** A CCW capsule between two cap centres, including both semicircular ends. */
+export function capsuleRing(
+  start: Point,
+  end: Point,
+  radiusMm: number,
+  segments = 24,
+): Point[] {
+  const angle = Math.atan2(end.y - start.y, end.x - start.x);
+  const halfSegments = Math.max(4, Math.ceil(segments / 2));
+  const ring: Point[] = [];
+  for (let index = 0; index <= halfSegments; index++) {
+    const theta = angle - Math.PI / 2 + (Math.PI * index) / halfSegments;
+    ring.push({
+      x: end.x + radiusMm * Math.cos(theta),
+      y: end.y + radiusMm * Math.sin(theta),
+    });
+  }
+  for (let index = 0; index <= halfSegments; index++) {
+    const theta = angle + Math.PI / 2 + (Math.PI * index) / halfSegments;
+    ring.push({
+      x: start.x + radiusMm * Math.cos(theta),
+      y: start.y + radiusMm * Math.sin(theta),
+    });
+  }
+  return ring;
+}
+
 /** Exact plan-view rim used by rendering, validation, and cutter geometry. */
 export function fingerHoleFootprintRing(
   hole: FingerHole,
   placement: PlacementTransform,
   segments = 24,
 ): Point[] {
-  const local = circleRing(hole.center, hole.diameterMm / 2, segments);
+  const local = hole.kind === "oblong-deep-scoop"
+    ? (() => {
+        const { start, end } = oblongDeepScoopEndpoints(hole);
+        return capsuleRing(start, end, hole.diameterMm / 2, segments);
+      })()
+    : circleRing(hole.center, hole.diameterMm / 2, segments);
   return ensureOrientation(
     mapRing(local, (point) => transformPointPlacement(point, placement)),
     OUTER_ORIENTATION,
@@ -344,9 +515,9 @@ export interface PlacementFootprint {
 }
 
 /**
- * Everything a placement occupies in the bin frame. This is what validation
- * measures — a finger hole poking through the bin wall is exactly as much a
- * wall breach as the outline doing it.
+ * Everything a tool-pocket placement occupies in the bin frame. The feature
+ * array is retained as a compatibility shape but remains empty; independent
+ * finger holes are measured separately.
  */
 export function placementFootprint(
   shape: Pick<TracedShape, "outlineMm">,
@@ -356,13 +527,11 @@ export function placementFootprint(
   >,
   segments = 24,
 ): PlacementFootprint {
-  const features: Point[][] = [];
-  for (const hole of placement.fingerHoles) {
-    features.push(fingerHoleFootprintRing(hole, placement, segments));
-  }
   return {
     outline: transformOutlinePlacement(shape.outlineMm, placement),
-    features,
+    // Legacy nested holes migrate to project-level objects before current
+    // layout math runs.
+    features: [],
   };
 }
 

--- a/shared/gridfinity/project.test.ts
+++ b/shared/gridfinity/project.test.ts
@@ -39,6 +39,7 @@ const VALID = {
       bottomFilletMm: 2.8,
     },
   ],
+  fingerHoles: [],
 };
 
 describe("parseProjectDoc", () => {
@@ -60,11 +61,9 @@ describe("parseProjectDoc", () => {
 });
 
 describe("project file round trip", () => {
-  it("preserves straight, round-scoop and deep-scoop finger holes through JSON", () => {
+  it("preserves round and oblong deep-scoop finger holes through JSON", () => {
     const withFeatures = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
-    (withFeatures.cutouts as Record<string, unknown>[])[0] = {
-      ...(withFeatures.cutouts as Record<string, unknown>[])[0],
-      fingerHoles: [
+    withFeatures.fingerHoles = [
         {
           id: "f1",
           kind: "straight",
@@ -86,27 +85,43 @@ describe("project file round trip", () => {
           diameterMm: 16,
           depthMm: 38,
         },
-      ],
-    };
+        {
+          id: "f4",
+          kind: "oblong-deep-scoop",
+          center: { x: 0, y: 12 },
+          diameterMm: 12,
+          depthMm: 32,
+          lengthMm: 48,
+          rotationDeg: 35,
+        },
+      ];
     // The exact path the Save file / Open file buttons take.
     const doc = parseProjectDoc(JSON.parse(JSON.stringify(withFeatures)));
     expect(doc).not.toBeNull();
-    expect(doc!.cutouts[0].fingerHoles).toHaveLength(3);
-    expect(doc!.cutouts[0].fingerHoles[1]).toMatchObject({
+    expect(doc!.cutouts[0].fingerHoles).toEqual([]);
+    expect(doc!.fingerHoles).toHaveLength(4);
+    expect(doc!.fingerHoles[1]).toMatchObject({
       id: "f2",
       kind: "scoop",
       depthMm: 10,
     });
-    expect(doc!.cutouts[0].fingerHoles[2]).toMatchObject({
+    expect(doc!.fingerHoles[2]).toMatchObject({
       id: "f3",
       kind: "deep-scoop",
       depthMm: 38,
+    });
+    expect(doc!.fingerHoles[3]).toMatchObject({
+      id: "f4",
+      kind: "oblong-deep-scoop",
+      lengthMm: 48,
+      rotationDeg: 35,
     });
   });
 
   it("migrates a schema-v1 scoop into a typed finger hole", () => {
     const legacy = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
     legacy.schemaVersion = 1;
+    delete legacy.fingerHoles;
     (legacy.cutouts as Record<string, unknown>[])[0] = {
       ...(legacy.cutouts as Record<string, unknown>[])[0],
       fingerHoles: [{ id: "f1", center: { x: 4, y: 1 }, diameterMm: 20 }],
@@ -114,16 +129,18 @@ describe("project file round trip", () => {
     };
     const doc = parseProjectDoc(legacy);
     expect(doc?.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
-    expect(doc?.cutouts[0].fingerHoles.map((hole) => hole.kind)).toEqual([
+    expect(doc?.cutouts[0].fingerHoles).toEqual([]);
+    expect(doc?.fingerHoles.map((hole) => hole.kind)).toEqual([
       "straight",
       "scoop",
     ]);
-    expect(doc?.cutouts[0].fingerHoles[1].id).toBe("legacy-scoop");
+    expect(doc?.fingerHoles[1].id).toBe("legacy-scoop");
   });
 
   it("migrates schema v2 with the safe sharp top-edge default", () => {
     const legacy = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
     legacy.schemaVersion = 2;
+    delete legacy.fingerHoles;
     delete (legacy.cutouts as Record<string, unknown>[])[0].topFilletMm;
 
     const doc = parseProjectDoc(legacy);
@@ -132,14 +149,17 @@ describe("project file round trip", () => {
   });
 
   it("still accepts a featureless schema-v1 document", () => {
-    const doc = parseProjectDoc({ ...VALID, schemaVersion: 1 });
+    const { fingerHoles: _currentHoles, ...legacy } = VALID;
+    const doc = parseProjectDoc({ ...legacy, schemaVersion: 1 });
     expect(doc!.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
     expect(doc!.cutouts[0].fingerHoles).toEqual([]);
+    expect(doc!.fingerHoles).toEqual([]);
   });
 
   it("migrates schema v3 projects to a rectangular footprint", () => {
     const legacy = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
     legacy.schemaVersion = 3;
+    delete legacy.fingerHoles;
     delete ((legacy.spec as Record<string, unknown>).footprint);
     const doc = parseProjectDoc(legacy);
     expect(doc?.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
@@ -149,6 +169,7 @@ describe("project file round trip", () => {
   it("migrates schema v4 finger holes without changing their geometry", () => {
     const legacy = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
     legacy.schemaVersion = 4;
+    delete legacy.fingerHoles;
     (legacy.cutouts as Record<string, unknown>[])[0] = {
       ...(legacy.cutouts as Record<string, unknown>[])[0],
       fingerHoles: [
@@ -163,7 +184,8 @@ describe("project file round trip", () => {
     };
     const doc = parseProjectDoc(legacy);
     expect(doc?.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
-    expect(doc?.cutouts[0].fingerHoles[0]).toMatchObject({
+    expect(doc?.cutouts[0].fingerHoles).toEqual([]);
+    expect(doc?.fingerHoles[0]).toMatchObject({
       kind: "scoop",
       diameterMm: 18,
       depthMm: 8,
@@ -172,6 +194,8 @@ describe("project file round trip", () => {
 
   it("normalizes the prototype oblong scoop into a vertical deep scoop", () => {
     const prototype = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
+    prototype.schemaVersion = 4;
+    delete prototype.fingerHoles;
     (prototype.cutouts as Record<string, unknown>[])[0] = {
       ...(prototype.cutouts as Record<string, unknown>[])[0],
       fingerHoles: [
@@ -187,12 +211,48 @@ describe("project file round trip", () => {
       ],
     };
     const doc = parseProjectDoc(prototype);
-    expect(doc?.cutouts[0].fingerHoles[0]).toEqual({
+    expect(doc?.fingerHoles[0]).toEqual({
       id: "prototype",
       kind: "deep-scoop",
       center: { x: 4, y: 0 },
       diameterMm: 18,
       depthMm: 24,
     });
+  });
+
+  it("migrates schema v5 projects before saving oblong deep scoops", () => {
+    const legacy = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
+    legacy.schemaVersion = 5;
+    delete legacy.fingerHoles;
+    const doc = parseProjectDoc(legacy);
+    expect(doc?.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
+    expect(doc?.cutouts).toHaveLength(1);
+  });
+
+  it("migrates v6 pocket-local holes into fixed bin-local positions", () => {
+    const legacy = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
+    legacy.schemaVersion = 6;
+    delete legacy.fingerHoles;
+    (legacy.cutouts as Record<string, unknown>[])[0] = {
+      ...(legacy.cutouts as Record<string, unknown>[])[0],
+      position: { x: 10, y: 20 },
+      rotationDeg: 90,
+      fingerHoles: [
+        {
+          id: "migrated",
+          kind: "oblong-deep-scoop",
+          center: { x: 4, y: 1 },
+          diameterMm: 10,
+          depthMm: 25,
+          lengthMm: 30,
+          rotationDeg: 0,
+        },
+      ],
+    };
+    const doc = parseProjectDoc(legacy);
+    expect(doc?.cutouts[0].fingerHoles).toEqual([]);
+    expect(doc?.fingerHoles[0].center.x).toBeCloseTo(9, 9);
+    expect(doc?.fingerHoles[0].center.y).toBeCloseTo(24, 9);
+    expect(doc?.fingerHoles[0].rotationDeg).toBeCloseTo(90, 9);
   });
 });

--- a/shared/gridfinity/project.ts
+++ b/shared/gridfinity/project.ts
@@ -1,6 +1,14 @@
 import { z } from "zod";
 
-import { cutoutPlacementSchema, tracedShapeSchema } from "./cutout";
+import {
+  cutoutPlacementSchema,
+  fingerHoleSchema,
+  oblongDeepScoopEndpoints,
+  resolvePocketDepth,
+  tracedShapeSchema,
+  transformPointPlacement,
+  type FingerHole,
+} from "./cutout";
 import { binSpecSchema } from "./types";
 
 /**
@@ -11,12 +19,21 @@ import { binSpecSchema } from "./types";
  * feature models change. Version 2 replaces the one-off scoop with typed,
  * per-finger-hole straight/scoop geometry; version 3 adds a per-pocket top
  * edge fillet; version 4 adds nonrectangular cell footprints and boundary-edge
- * label-tab anchors; version 5 adds straight-shaft deep finger scoops.
+ * label-tab anchors; version 5 adds straight-shaft deep finger scoops; version
+ * 6 adds resizable, rotated oblong deep scoops; version 7 promotes finger
+ * holes from pocket-relative children to independent, bin-local objects.
  */
 
-export const PROJECT_SCHEMA_VERSION = 5 as const;
+export const PROJECT_SCHEMA_VERSION = 7 as const;
 
 const projectFields = {
+  shapes: z.array(tracedShapeSchema),
+  spec: binSpecSchema,
+  cutouts: z.array(cutoutPlacementSchema),
+  fingerHoles: z.array(fingerHoleSchema),
+};
+
+const legacyProjectFields = {
   shapes: z.array(tracedShapeSchema),
   spec: binSpecSchema,
   cutouts: z.array(cutoutPlacementSchema),
@@ -29,51 +46,66 @@ export const projectDocSchema = z
   })
   .strict();
 
-const projectDocV1Schema = z
-  .object({
-    schemaVersion: z.literal(1),
-    ...projectFields,
-  })
-  .strict()
-  .transform(({ schemaVersion: _legacyVersion, ...doc }) => ({
-    ...doc,
-    schemaVersion: PROJECT_SCHEMA_VERSION,
-  }));
-
-const projectDocV2Schema = z
-  .object({
-    schemaVersion: z.literal(2),
-    ...projectFields,
-  })
-  .strict()
-  .transform(({ schemaVersion: _legacyVersion, ...doc }) => ({
-    ...doc,
-    schemaVersion: PROJECT_SCHEMA_VERSION,
-  }));
-
-const projectDocV3Schema = z
-  .object({
-    schemaVersion: z.literal(3),
-    ...projectFields,
-  })
-  .strict()
-  .transform(({ schemaVersion: _legacyVersion, ...doc }) => ({
-    ...doc,
-    schemaVersion: PROJECT_SCHEMA_VERSION,
-  }));
-
-const projectDocV4Schema = z
-  .object({
-    schemaVersion: z.literal(4),
-    ...projectFields,
-  })
-  .strict()
-  .transform(({ schemaVersion: _legacyVersion, ...doc }) => ({
-    ...doc,
-    schemaVersion: PROJECT_SCHEMA_VERSION,
-  }));
+const legacyProjectSchemas = [1, 2, 3, 4, 5, 6].map((schemaVersion) =>
+  z
+    .object({
+      schemaVersion: z.literal(schemaVersion),
+      ...legacyProjectFields,
+    })
+    .strict(),
+);
 
 export type ProjectDoc = z.infer<typeof projectDocSchema>;
+
+type LegacyProjectDoc = z.infer<(typeof legacyProjectSchemas)[number]>;
+
+/** Keeps migrated ids unique now that formerly per-pocket arrays share one list. */
+function uniqueFingerHoleId(id: string, used: Set<string>): string {
+  let candidate = id;
+  let suffix = 2;
+  while (used.has(candidate)) candidate = `${id}-${suffix++}`;
+  used.add(candidate);
+  return candidate;
+}
+
+function migrateLegacyProject(doc: LegacyProjectDoc): ProjectDoc {
+  const usedIds = new Set<string>();
+  const fingerHoles: FingerHole[] = [];
+  const cutouts = doc.cutouts.map((cutout) => {
+    const pocket = resolvePocketDepth(doc.spec, cutout.depth);
+    for (const hole of cutout.fingerHoles) {
+      const center = transformPointPlacement(hole.center, cutout);
+      let rotationDeg = hole.rotationDeg;
+      if (hole.kind === "oblong-deep-scoop") {
+        const endpoints = oblongDeepScoopEndpoints(hole);
+        const start = transformPointPlacement(endpoints.start, cutout);
+        const end = transformPointPlacement(endpoints.end, cutout);
+        rotationDeg =
+          ((Math.atan2(end.y - start.y, end.x - start.x) * 180) / Math.PI + 360) %
+          360;
+      }
+      fingerHoles.push({
+        ...hole,
+        id: uniqueFingerHoleId(hole.id, usedIds),
+        center,
+        rotationDeg,
+        // Straight holes formerly inherited the parent pocket floor.
+        depthMm:
+          hole.kind === "straight"
+            ? Math.min(120, Math.max(1, pocket.depthMm ?? pocket.infillTopZ + 1))
+            : hole.depthMm,
+      });
+    }
+    return { ...cutout, fingerHoles: [] };
+  });
+  return projectDocSchema.parse({
+    schemaVersion: PROJECT_SCHEMA_VERSION,
+    shapes: doc.shapes,
+    spec: doc.spec,
+    cutouts,
+    fingerHoles,
+  });
+}
 
 /**
  * Parses a stored document, returning null on any mismatch — a corrupt or
@@ -83,12 +115,9 @@ export type ProjectDoc = z.infer<typeof projectDocSchema>;
 export function parseProjectDoc(input: unknown): ProjectDoc | null {
   const result = projectDocSchema.safeParse(input);
   if (result.success) return result.data;
-  const migratedV4 = projectDocV4Schema.safeParse(input);
-  if (migratedV4.success) return migratedV4.data;
-  const migratedV3 = projectDocV3Schema.safeParse(input);
-  if (migratedV3.success) return migratedV3.data;
-  const migratedV2 = projectDocV2Schema.safeParse(input);
-  if (migratedV2.success) return migratedV2.data;
-  const migrated = projectDocV1Schema.safeParse(input);
-  return migrated.success ? migrated.data : null;
+  for (const schema of [...legacyProjectSchemas].reverse()) {
+    const migrated = schema.safeParse(input);
+    if (migrated.success) return migrateLegacyProject(migrated.data);
+  }
+  return null;
 }

--- a/shared/gridfinity/validate-layout.test.ts
+++ b/shared/gridfinity/validate-layout.test.ts
@@ -67,7 +67,10 @@ function codes(
   shapes: TracedShape[],
 ): string[] {
   const byId = new Map(shapes.map((shape) => [shape.id, shape]));
-  return validateLayout(binSpec, cutouts, byId).map((issue) => issue.code);
+  const fingerHoles = cutouts.flatMap((cutout) => cutout.fingerHoles);
+  return validateLayout(binSpec, cutouts, byId, fingerHoles).map(
+    (issue) => issue.code,
+  );
 }
 
 // 2×2 bin: footprint 83.5, interior half-width 40.8.
@@ -312,8 +315,8 @@ describe("validateLayout: finger holes and scoops (G4)", () => {
       fingerHoles: [{ id: "f1", center: { x: 32, y: 0 }, diameterMm: 18 }],
     });
     const result = codes(spec(), [cutout], [shape]);
-    expect(result).toContain("wall-breach");
-    expect(result).not.toContain("out-of-bounds");
+    expect(result).toContain("finger-hole-wall-breach");
+    expect(result).not.toContain("finger-hole-out-of-bounds");
   });
 
   it("validates a deep scoop by its round mouth, not its vertical depth", () => {
@@ -330,8 +333,8 @@ describe("validateLayout: finger holes and scoops (G4)", () => {
       ],
     });
     const result = codes(spec(), [cutout], [shape]);
-    expect(result).not.toContain("wall-breach");
-    expect(result).not.toContain("out-of-bounds");
+    expect(result).not.toContain("finger-hole-wall-breach");
+    expect(result).not.toContain("finger-hole-out-of-bounds");
   });
 
   it("uses the full deep-scoop shaft and hemisphere depth for floor validation", () => {
@@ -348,8 +351,28 @@ describe("validateLayout: finger holes and scoops (G4)", () => {
       ],
     });
     expect(codes(spec({ heightUnits: 2 }), [cutout], [shape])).toContain(
-      "scoop-too-deep",
+      "finger-hole-too-deep",
     );
+  });
+
+  it("validates the full rotated oblong mouth against the bin walls", () => {
+    const shape = makeShape("s1", 20, 20);
+    const cutout = makeCutout("c1", "s1", 0, 0, {
+      fingerHoles: [
+        {
+          id: "f1",
+          kind: "oblong-deep-scoop",
+          center: { x: 0, y: 0 },
+          diameterMm: 10,
+          depthMm: 25,
+          lengthMm: 100,
+          rotationDeg: 0,
+        },
+      ],
+    });
+    const result = codes(spec(), [cutout], [shape]);
+    expect(result).toContain("finger-hole-wall-breach");
+    expect(result).toContain("finger-hole-out-of-bounds");
   });
 
   it("errors when a scoop is deeper than the bin", () => {
@@ -368,7 +391,7 @@ describe("validateLayout: finger holes and scoops (G4)", () => {
     });
     // 2u bin without a lip: top surface at 14 mm, scoop bottom at −1 mm.
     const result = codes(spec({ heightUnits: 2, lip: "none" }), [cutout], [shape]);
-    expect(result).toContain("scoop-too-deep");
+    expect(result).toContain("finger-hole-too-deep");
   });
 
   it("warns when a scoop leaves a paper-thin floor", () => {
@@ -387,11 +410,11 @@ describe("validateLayout: finger holes and scoops (G4)", () => {
     });
     // Scoop bottom at 14 − 13 = 1 mm: below the 1.2 mm floor threshold.
     const result = codes(spec({ heightUnits: 2, lip: "none" }), [cutout], [shape]);
-    expect(result).toContain("floor-too-thin");
-    expect(result).not.toContain("scoop-too-deep");
+    expect(result).toContain("finger-hole-floor-too-thin");
+    expect(result).not.toContain("finger-hole-too-deep");
   });
 
-  it("errors when one pocket's finger hole reaches into another pocket", () => {
+  it("does not treat an independent finger hole as owned by either overlapping pocket", () => {
     // 20-wide pockets at x = 0 and x = 25 are silent without features (5 mm
     // apart); a hole rim reaching x = 21 crosses the second pocket's outline.
     const shapes = [makeShape("s1", 20, 20), makeShape("s2", 20, 20)];
@@ -405,7 +428,7 @@ describe("validateLayout: finger holes and scoops (G4)", () => {
       makeCutout("c2", "s2", 25, 0),
     ];
     const result = codes(spec(), withHole, shapes);
-    expect(result).toContain("cutout-overlap");
+    expect(result).not.toContain("cutout-overlap");
   });
 });
 

--- a/shared/gridfinity/validate.ts
+++ b/shared/gridfinity/validate.ts
@@ -15,10 +15,12 @@ import {
 import {
   effectiveDeepScoopDepthMm,
   effectiveScoopDepthMm,
+  fingerHoleFootprintRing,
   placementFootprint,
   resolvePocketDepth,
   signedDistanceToInterior,
   type CutoutPlacement,
+  type FingerHole,
   type TracedShape,
 } from "./cutout";
 import {
@@ -58,6 +60,8 @@ export interface ValidationIssue {
   message: string;
   /** Cutout(s) the issue is about, for per-cutout highlighting in the editor. */
   cutoutIds?: string[];
+  /** Independent finger-hole object(s) the issue is about. */
+  fingerHoleIds?: string[];
 }
 
 export interface ValidationResult {
@@ -244,15 +248,16 @@ export function validateLayout(
   spec: BinSpec,
   cutouts: readonly CutoutPlacement[],
   shapesById: ReadonlyMap<string, TracedShape>,
+  fingerHoles: readonly FingerHole[] = [],
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
-  if (cutouts.length === 0) return issues;
+  if (cutouts.length === 0 && fingerHoles.length === 0) return issues;
 
   if (spec.fill !== "solid") {
     issues.push({
       code: "cutouts-require-solid-fill",
       severity: "error",
-      message: "Pockets need material to cut into — switch the bin to solid fill.",
+      message: "Cutouts need material to cut into — switch the bin to solid fill.",
     });
   }
 
@@ -315,6 +320,10 @@ export function validateLayout(
     }
   }
 
+  for (const [index, hole] of fingerHoles.entries()) {
+    issues.push(...validateFingerHoleAgainstBin(spec, hole, index));
+  }
+
   // A pocket mouth under the label tab: legal geometry, but the tab shadows
   // the opening and the tool may not come out past it.
   const tabStrip = labelTabStripMm(spec);
@@ -361,8 +370,8 @@ function validateAgainstBin(spec: BinSpec, p: PlacedCutout): ValidationIssue[] {
   }
 
   // Exact because the interior is convex: min over vertices is the polygon
-  // min. The outline gets its fit clearance and top-surface round-over added;
-  // feature circles are cut at their drawn size, so their allowance is zero.
+  // min. The outline gets its fit clearance and top-surface round-over added.
+  // `features` is an empty compatibility collection for legacy placements.
   const interiorBoundary = spec.footprint.kind === "custom"
     ? footprintInteriorRingMm(spec)
     : null;
@@ -461,31 +470,93 @@ function validateAgainstBin(spec: BinSpec, p: PlacedCutout): ValidationIssue[] {
     }
   }
 
-  // Scoop-style finger holes cut from the top surface regardless of pocket
-  // depth, so each gets its own floor arithmetic.
-  for (const hole of cutout.fingerHoles) {
-    if (hole.kind !== "scoop" && hole.kind !== "deep-scoop") continue;
-    const cutDepth = hole.kind === "deep-scoop"
-      ? effectiveDeepScoopDepthMm(hole)
-      : effectiveScoopDepthMm(hole);
-    const scoopBottomZ = pocket.infillTopZ - cutDepth;
-    if (scoopBottomZ < 0) {
-      issues.push({
-        code: "scoop-too-deep",
-        severity: "error",
-        cutoutIds: [cutout.id],
-        message: `“${label}”'s scoop finger hole is deeper than the bin itself.`,
-      });
-    } else if (scoopBottomZ < MIN_FLOOR_MM) {
-      issues.push({
-        code: "floor-too-thin",
-        severity: "warning",
-        cutoutIds: [cutout.id],
-        message: `“${label}”'s scoop finger hole leaves a ${scoopBottomZ.toFixed(1)} mm floor — likely to flex or delaminate.`,
-      });
-    }
+  return issues;
+}
+
+function validateFingerHoleAgainstBin(
+  spec: BinSpec,
+  hole: FingerHole,
+  index: number,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const label = `Finger hole ${index + 1}`;
+  const ring = fingerHoleFootprintRing(
+    hole,
+    { position: { x: 0, y: 0 }, rotationDeg: 0, mirrored: false },
+  );
+  const bounds = ringBounds(ring);
+  if (!bounds) return issues;
+
+  const halfW = binFootprintMm(spec.gridX, spec.gridPitch) / 2;
+  const halfL = binFootprintMm(spec.gridY, spec.gridPitch) / 2;
+  const outerBoundary =
+    spec.footprint.kind === "custom" ? footprintOuterRingMm(spec) : null;
+  const outside = outerBoundary
+    ? !ringInsideBoundary(ring, outerBoundary)
+    : bounds.minX < -halfW ||
+      bounds.maxX > halfW ||
+      bounds.minY < -halfL ||
+      bounds.maxY > halfL;
+  if (outside) {
+    issues.push({
+      code: "finger-hole-out-of-bounds",
+      severity: "error",
+      fingerHoleIds: [hole.id],
+      message: `${label} extends past the bin's footprint.`,
+    });
   }
 
+  const interiorBoundary =
+    spec.footprint.kind === "custom" ? footprintInteriorRingMm(spec) : null;
+  const wallMargin = interiorBoundary
+    ? ringSignedClearance(ring, interiorBoundary)
+    : Math.min(...ring.map((point) => signedDistanceToInterior(point, spec)));
+  if (wallMargin < 0) {
+    issues.push({
+      code: "finger-hole-wall-breach",
+      severity: "error",
+      fingerHoleIds: [hole.id],
+      message: `${label} cuts into the bin wall.`,
+    });
+  } else if (spec.lip === "standard" && wallMargin < LIP_INTRUSION_MM) {
+    issues.push({
+      code: "finger-hole-lip-collision",
+      severity: "warning",
+      fingerHoleIds: [hole.id],
+      message: `${label} fouls the stacking lip's ${STACKING_LIP_DEPTH} mm overhang.`,
+    });
+  } else if (wallMargin < D_DIV) {
+    issues.push({
+      code: "finger-hole-thin-material",
+      severity: "warning",
+      fingerHoleIds: [hole.id],
+      message: `${label} leaves less than ${D_DIV} mm of material against the wall.`,
+    });
+  }
+
+  const surface = resolvePocketDepth(spec, { mode: "mm", value: hole.depthMm });
+  const cutDepth =
+    hole.kind === "scoop"
+      ? effectiveScoopDepthMm(hole)
+      : hole.kind === "deep-scoop" || hole.kind === "oblong-deep-scoop"
+        ? effectiveDeepScoopDepthMm(hole)
+        : hole.depthMm;
+  const bottomZ = surface.infillTopZ - cutDepth;
+  if (bottomZ < 0) {
+    issues.push({
+      code: "finger-hole-too-deep",
+      severity: "error",
+      fingerHoleIds: [hole.id],
+      message: `${label} is deeper than the bin itself.`,
+    });
+  } else if (bottomZ < MIN_FLOOR_MM) {
+    issues.push({
+      code: "finger-hole-floor-too-thin",
+      severity: "warning",
+      fingerHoleIds: [hole.id],
+      message: `${label} leaves a ${bottomZ.toFixed(1)} mm floor — likely to flex or delaminate.`,
+    });
+  }
   return issues;
 }
 


### PR DESCRIPTION
## Summary
- promote finger holes to independent bin-local layout objects with schema-v7 migration
- add direct mouse movement and diameter resizing for every finger-hole type
- add endpoint stretching and 90-degree rotation controls for oblong deep scoops
- carry independent holes through preview, STL/3MF, surface-fit, DXF/SVG, validation, fit, and auto-arrange workflows

## Stacked PR
This is based on PR 15 and intentionally targets its branch so this review contains only the finger-hole work. After PR 15 merges, this PR can be retargeted to main.

## Verification
- npm run check
- npm test: 69 files, 885 tests passed
- npm run build
- live UI: independent selection, resize drag, rotation, pocket-removal survival, hole-only fit, and clean browser error log