### PR TITLE
Improve Trace measurement and calibration

### DIFF
--- a/client/src/components/help/help-dialog.tsx
+++ b/client/src/components/help/help-dialog.tsx
@@ -75,6 +75,30 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
                   US Letter PDF template
                 </button>{" "}
                 at 100% scale.
+                Experimental sheets with smaller corner markers are also
+                available for {" "}
+                <button
+                  type="button"
+                  className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                  onClick={() =>
+                    downloadCalibrationTemplate("a4-experimental")
+                  }
+                  data-testid="help-print-template-a4-experimental"
+                >
+                  A4
+                </button>{" "}
+                and {" "}
+                <button
+                  type="button"
+                  className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                  onClick={() =>
+                    downloadCalibrationTemplate("letter-experimental")
+                  }
+                  data-testid="help-print-template-letter-experimental"
+                >
+                  US Letter
+                </button>
+                .
               </li>
               <li>
                 If automatic scale detection is unavailable or not sufficiently
@@ -94,7 +118,7 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
                 removes pixel noise.
               </li>
               <li>
-                Choose a physical <strong>Margin</strong> from 0.5–5.0 mm, then
+                Choose a physical <strong>Margin</strong> from 0.0–5.0 mm, then
                 edit, add, move, or remove contour points as needed.
               </li>
               <li>

--- a/client/src/components/trace/trace-canvas-history.test.tsx
+++ b/client/src/components/trace/trace-canvas-history.test.tsx
@@ -90,6 +90,29 @@ function SeedScaleDraft(): null {
   return null;
 }
 
+function SeedMeasurementScale(): null {
+  const { dispatch } = useTrace();
+  React.useEffect(() => {
+    dispatch({
+      type: "SOURCE_LOADED",
+      imageUrl: "data:image/png;base64,AA==",
+      fileName: "tool.png",
+    });
+    dispatch({ type: "SOURCE_READY", imageSize: { width: 100, height: 100 } });
+    dispatch({
+      type: "SET_CALIBRATION",
+      calibration: {
+        startX: 0,
+        startY: 0,
+        endX: 100,
+        endY: 0,
+        lengthMm: 50,
+      },
+    });
+  }, [dispatch]);
+  return null;
+}
+
 function ScaleStateProbe(): JSX.Element {
   const { mode, calibration, draftCalibration } = useTrace();
   return (
@@ -203,6 +226,43 @@ afterEach(() => {
 });
 
 describe("TraceCanvas edit history", () => {
+  it("opens canvas toolbar tips below the toolbar", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("ResizeObserver", NoopResizeObserver);
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    try {
+      await React.act(async () => {
+        root.render(
+          <TraceProvider>
+            <SeedTrace />
+            <TooltipProvider delayDuration={0}>
+              <TraceCanvas onReprocess={() => {}} />
+            </TooltipProvider>
+          </TraceProvider>,
+        );
+        await Promise.resolve();
+      });
+
+      const setScale = host.querySelector<HTMLButtonElement>(
+        '[aria-label="Set scale"]',
+      );
+      await React.act(async () => {
+        const hover = new MouseEvent("pointermove", { bubbles: true });
+        Object.defineProperty(hover, "pointerType", { value: "mouse" });
+        setScale?.dispatchEvent(hover);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(host.innerHTML).toContain('data-side="bottom"');
+      expect(host.innerHTML).toContain("Set scale");
+    } finally {
+      React.act(() => root.unmount());
+    }
+  });
+
   it("exposes named history beside the undo and redo controls", async () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     vi.stubGlobal("ResizeObserver", NoopResizeObserver);
@@ -387,6 +447,119 @@ describe("TraceCanvas edit history", () => {
       expect(line?.getAttribute("x2")).toBe("75");
       expect(line?.getAttribute("y2")).toBe("85");
       expect(line?.getAttribute("data-ruler-preview")).toBe("true");
+    } finally {
+      React.act(() => root.unmount());
+      restoreSvgCoordinates();
+    }
+  });
+
+  it("measures between two points without changing the accepted scale", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("ResizeObserver", NoopResizeObserver);
+    const restoreSvgCoordinates = installIdentitySvgCoordinates();
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    try {
+      await React.act(async () => {
+        root.render(
+          <TraceProvider>
+            <SeedMeasurementScale />
+            <ScaleStateProbe />
+            <TooltipProvider>
+              <TraceCanvas onReprocess={() => {}} />
+            </TooltipProvider>
+          </TraceProvider>,
+        );
+        await Promise.resolve();
+      });
+
+      const canvas = host.querySelector("svg");
+      const measure = host.querySelector<HTMLButtonElement>(
+        '[aria-label="Measure distance"]',
+      );
+      expect(canvas).not.toBeNull();
+      expect(measure?.disabled).toBe(false);
+
+      await React.act(async () => measure?.click());
+      expect(host.querySelector('[data-testid="scale-mode"]')?.textContent).toBe(
+        "measure",
+      );
+      expect(host.querySelector('[data-testid="ruler-overlay"]')).toBeNull();
+
+      await React.act(async () => {
+        canvas?.dispatchEvent(
+          new MouseEvent("pointerdown", {
+            bubbles: true,
+            button: 0,
+            clientX: 20,
+            clientY: 30,
+          }),
+        );
+      });
+      await React.act(async () => {
+        canvas?.dispatchEvent(
+          new MouseEvent("pointermove", {
+            bubbles: true,
+            clientX: 60,
+            clientY: 30,
+          }),
+        );
+      });
+
+      expect(
+        host.querySelectorAll('[data-testid="measurement-marker"]'),
+      ).toHaveLength(2);
+      expect(
+        host
+          .querySelector('[data-testid="measurement-line"]')
+          ?.getAttribute("data-measurement-preview"),
+      ).toBe("true");
+      expect(
+        host.querySelector('[data-testid="measurement-length-label"]')
+          ?.textContent,
+      ).toContain("20 mm");
+
+      await React.act(async () => {
+        canvas?.dispatchEvent(
+          new MouseEvent("pointerdown", {
+            bubbles: true,
+            button: 0,
+            clientX: 60,
+            clientY: 30,
+          }),
+        );
+      });
+      expect(
+        host
+          .querySelector('[data-testid="measurement-line"]')
+          ?.getAttribute("data-measurement-preview"),
+      ).toBeNull();
+      expect(
+        host.querySelector('[data-testid="scale-calibration"]')?.textContent,
+      ).toBe(
+        JSON.stringify({
+          startX: 0,
+          startY: 0,
+          endX: 100,
+          endY: 0,
+          lengthMm: 50,
+        }),
+      );
+
+      await React.act(async () => {
+        host.querySelector<HTMLButtonElement>('[aria-label="Select"]')?.click();
+      });
+      expect(
+        host.querySelector('[data-testid="measurement-overlay"]'),
+      ).toBeNull();
+      expect(
+        host.querySelector('[data-testid="ruler-overlay"]'),
+      ).not.toBeNull();
+      expect(
+        host.querySelector('[data-testid="scale-mm-per-pixel"]')?.textContent,
+      ).toBe("0.500000");
     } finally {
       React.act(() => root.unmount());
       restoreSvgCoordinates();

--- a/client/src/components/trace/trace-canvas.tsx
+++ b/client/src/components/trace/trace-canvas.tsx
@@ -3,6 +3,7 @@ import {
   Loader2,
   Maximize2,
   MousePointer2,
+  MoveDiagonal2,
   Redo2,
   Ruler,
   Spline,
@@ -22,6 +23,7 @@ import {
 import {
   calibrationFromDraft,
   hasCalibrationEndpoints,
+  mmPerPixel,
 } from "@shared/geometry/scale";
 import type { Point, Rect, RingRef } from "@shared/geometry/types";
 
@@ -119,6 +121,7 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
   const rulerEditable =
     (calibrationSource === "manual" && calibration !== null) ||
     (mode !== "calibrate" && hasCalibrationEndpoints(draftCalibration));
+  const measurementMmPerPx = mmPerPixel(calibration);
 
   const handleRulerLengthCommit = useCallback(
     (lengthMm: number) => {
@@ -150,6 +153,12 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
   // the drag starts.
   const [shiftHeld, setShiftHeld] = useState(false);
   const [rulerPointer, setRulerPointer] = useState<Point | null>(null);
+  const [measurement, setMeasurement] = useState<{
+    start: Point;
+    end: Point | null;
+  } | null>(null);
+  const [measurementPointer, setMeasurementPointer] =
+    useState<Point | null>(null);
   const [perspectivePointer, setPerspectivePointer] = useState<Point | null>(null);
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -184,6 +193,15 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
       setPerspectivePointer(null);
     }
   }, [mode, manualPerspectivePoints.length]);
+
+  useEffect(() => {
+    // Measurements are temporary inspection marks. They never become scale
+    // state and cannot leak into another tool's canvas overlay.
+    if (mode !== "measure") {
+      setMeasurement(null);
+      setMeasurementPointer(null);
+    }
+  }, [mode]);
 
   useEffect(() => {
     viewport.attachWheel(svgRef.current);
@@ -237,6 +255,8 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
     dragRef.current = null;
     clickRef.current = null;
     setRulerPointer(null);
+    setMeasurement(null);
+    setMeasurementPointer(null);
     setPerspectivePointer(null);
   }, [imageRotation]);
 
@@ -374,6 +394,21 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
       return;
     }
 
+    if (
+      mode === "measure" &&
+      event.button === 0 &&
+      measurementMmPerPx !== null
+    ) {
+      const point = clampPointToImage(image, imageSize);
+      setMeasurement((current) =>
+        !current || current.end
+          ? { start: point, end: null }
+          : { start: current.start, end: point },
+      );
+      setMeasurementPointer(null);
+      return;
+    }
+
     if (mode === "edit" && event.button === 0 && !event.shiftKey) {
       const vertex = nearestVertex(outline, image, pickRadius, selection);
       if (vertex) {
@@ -464,6 +499,13 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
           // the controls mistake ordinary pointer movement for the second click.
           setRulerPointer(image);
         }
+        return;
+      }
+      if (mode === "measure" && measurement && !measurement.end) {
+        const image = toImage(event.clientX, event.clientY);
+        setMeasurementPointer(
+          image ? clampPointToImage(image, imageSize) : null,
+        );
         return;
       }
       updateHover(event);
@@ -606,6 +648,7 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
     if (
       mode === "region" ||
       mode === "calibrate" ||
+      mode === "measure" ||
       mode === "perspective"
     ) {
       return "crosshair";
@@ -630,27 +673,34 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
           region={region}
           regionActive={mode === "region"}
           calibration={
-            mode === "perspective"
+            mode === "perspective" || mode === "measure"
               ? null
               : mode === "calibrate" && draftCalibration?.startX !== undefined
               ? null
               : displayedCalibration
           }
           draftCalibration={
-            mode === "calibrate" &&
-            draftCalibration?.startX !== undefined &&
-            draftCalibration.startY !== undefined &&
-            rulerPointer
-              ? {
-                  ...draftCalibration,
-                  endX: rulerPointer.x,
-                  endY: rulerPointer.y,
-                }
-              : draftCalibration
+            mode === "measure"
+              ? null
+              : mode === "calibrate" &&
+                  draftCalibration?.startX !== undefined &&
+                  draftCalibration.startY !== undefined &&
+                  rulerPointer
+                ? {
+                    ...draftCalibration,
+                    endX: rulerPointer.x,
+                    endY: rulerPointer.y,
+                  }
+                : draftCalibration
           }
           rulerLengthMm={rulerLengthMm}
           rulerEditable={rulerEditable}
           onRulerLengthCommit={handleRulerLengthCommit}
+          measurement={mode === "measure" ? measurement : null}
+          measurementPreview={
+            mode === "measure" ? measurementPointer : null
+          }
+          measurementMmPerPx={measurementMmPerPx}
           perspectivePoints={perspectiveOverlayPoints}
           perspectiveEditable={manualPerspectivePoints.length > 0}
           perspectivePreview={perspectivePointer}
@@ -663,6 +713,7 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
           onPointerCancel={endDrag}
           onPointerLeave={() => {
             setHoveredVertexIndex(null);
+            setMeasurementPointer(null);
             setPerspectivePointer(null);
           }}
           onContextMenu={handleContextMenu}
@@ -680,6 +731,12 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
             <ModeButton mode="region" icon={Crop} label="Region" />
             <ModeButton mode="edit" icon={Spline} label="Edit points" />
             <ModeButton mode="calibrate" icon={Ruler} label="Set scale" />
+            <ModeButton
+              mode="measure"
+              icon={MoveDiagonal2}
+              label="Measure distance"
+              disabled={measurementMmPerPx === null}
+            />
 
             {/* Always present: outline edits can happen in any pointing mode,
                 and a hidden undo reads as "there is no undo". */}
@@ -746,9 +803,15 @@ function TraceStage({ onReprocess, emptyState }: TraceCanvasProps): JSX.Element 
               )}
             </span>
             <span className="hidden border-l pl-2 pr-1.5 text-[11px] text-muted-foreground md:inline">
-              {selection
-                ? "Drag points to move · Click adds · Right-click removes · Shift-drag pans"
-                : "Shift-drag pans · Ctrl-scroll zooms"}
+              {mode === "measure"
+                ? !measurement
+                  ? "Click the first measurement point"
+                  : measurement.end
+                    ? "Click to start a new measurement"
+                    : "Click the second measurement point"
+                : selection
+                  ? "Drag points to move · Click adds · Right-click removes · Shift-drag pans"
+                  : "Shift-drag pans · Ctrl-scroll zooms"}
             </span>
           </CanvasToolbar>
 
@@ -773,10 +836,12 @@ function ModeButton({
   mode,
   icon: Icon,
   label,
+  disabled = false,
 }: {
   mode: TraceMode;
   icon: React.ComponentType<{ className?: string }>;
   label: string;
+  disabled?: boolean;
 }): JSX.Element {
   const { mode: current, dispatch } = useTrace();
   const active = current === mode;
@@ -790,12 +855,13 @@ function ModeButton({
           className={cn("h-8 w-8", active && "ring-1 ring-primary/40")}
           aria-pressed={active}
           aria-label={label}
+          disabled={disabled}
           onClick={() => dispatch({ type: "SET_MODE", mode })}
         >
           <Icon className="h-4 w-4" />
         </Button>
       </TooltipTrigger>
-      <TooltipContent>{label}</TooltipContent>
+      <TooltipContent side="bottom">{label}</TooltipContent>
     </Tooltip>
   );
 }
@@ -825,7 +891,7 @@ function IconButton({
           <Icon className="h-4 w-4" />
         </Button>
       </TooltipTrigger>
-      <TooltipContent>{label}</TooltipContent>
+      <TooltipContent side="bottom">{label}</TooltipContent>
     </Tooltip>
   );
 }

--- a/client/src/components/trace/trace-controls-panel.test.tsx
+++ b/client/src/components/trace/trace-controls-panel.test.tsx
@@ -86,6 +86,29 @@ function Harness(): JSX.Element {
         Detect auto perspective
       </button>
       <button
+        data-testid="detect-auto-experimental-perspective"
+        onClick={() =>
+          dispatch({
+            type: "AUTO_CALIBRATION_DETECTED",
+            sourceImageUrl: "data:image/png;base64,new-source",
+            calibration: CALIBRATION,
+            perspective: {
+              source: "template",
+              paper: "a4",
+              template: "a4-experimental",
+              points: [
+                { x: 10, y: 10 },
+                { x: 110, y: 12 },
+                { x: 108, y: 140 },
+                { x: 12, y: 138 },
+              ],
+            },
+          })
+        }
+      >
+        Detect experimental perspective
+      </button>
+      <button
         data-testid="complete-perspective-points"
         onClick={() => {
           for (const point of [
@@ -286,10 +309,24 @@ describe("TraceControlsPanel guided workflow", () => {
     expect(host.textContent).not.toContain("Print the current v2 sheet once");
 
     await click("button-calibration-sheet-options");
-    expect(document.body.textContent).toContain("Print the current v2 sheet once");
+    expect(document.body.textContent).toContain(
+      "Current sheets remain the stable default",
+    );
     expect(
       document.body.querySelector('[data-testid="button-template-letter"]'),
     ).not.toBeNull();
+    const experimental = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="button-template-a4-experimental"]',
+    );
+    expect(experimental).not.toBeNull();
+    await React.act(async () => {
+      experimental?.click();
+      await new Promise((resolve) => window.setTimeout(resolve, 10));
+    });
+    expect(downloadBlob).toHaveBeenLastCalledWith(
+      expect.any(Blob),
+      "pocketry-calibration-v2-a4-experimental.pdf",
+    );
   });
 
   it("offers clockwise and counterclockwise rotation for a loaded source", async () => {
@@ -377,6 +414,23 @@ describe("TraceControlsPanel guided workflow", () => {
     expect(applyPerspective).toHaveBeenLastCalledWith(
       expect.objectContaining({ source: "manual" }),
       "letter",
+    );
+  });
+
+  it("keeps an experimental sheet variant through perspective correction", async () => {
+    await click("load-source");
+    await click("detect-auto-experimental-perspective");
+
+    expect(section("scale")?.textContent).toContain(
+      "A4 experimental template detected automatically",
+    );
+    await click("button-apply-auto-perspective");
+    expect(applyPerspective).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        source: "template",
+        template: "a4-experimental",
+      }),
+      "a4-experimental",
     );
   });
 

--- a/client/src/components/trace/trace-controls-panel.tsx
+++ b/client/src/components/trace/trace-controls-panel.tsx
@@ -55,7 +55,11 @@ import {
   type PerspectiveQuad,
 } from "@/lib/calibrate/perspective";
 import { downloadCalibrationTemplate } from "@/lib/calibrate/download-template";
-import type { TemplatePaper } from "@/lib/calibrate/template";
+import {
+  templateDisplayName,
+  type TemplatePaper,
+  type TemplateVariant,
+} from "@/lib/calibrate/template";
 import { describeScale, exportScale } from "@/lib/export/scale";
 import { normalizeTracedShape } from "@/lib/gridfinity/traced-shape";
 import type { ImageRotationDirection } from "@/lib/geometry/image-rotation";
@@ -83,7 +87,7 @@ export interface TraceControlsPanelProps {
   /** Rectify the selected paper plane and replace the working image. */
   onApplyPerspective: (
     proposal: PerspectiveProposal,
-    paper: TemplatePaper,
+    template: TemplateVariant,
   ) => void;
 }
 
@@ -149,6 +153,8 @@ export function TraceControlsPanel({
   );
   const hasImage = imageSize.width > 0;
   const hasOutline = outline.length > 0;
+  const pendingTemplate =
+    pendingPerspective?.template ?? pendingPerspective?.paper;
   const hasDetectionRegion = Boolean(
     region && region.width > 5 && region.height > 5,
   );
@@ -513,18 +519,20 @@ export function TraceControlsPanel({
               {pendingPerspective ? (
                 <>
                   <p className="text-xs font-medium text-amber-800 dark:text-amber-200">
-                    {pendingPerspective.paper === "a4" ? "A4" : "US Letter"}{" "}
+                    {pendingTemplate
+                      ? templateDisplayName(pendingTemplate)
+                      : "Pocketry"}{" "}
                     template detected automatically
                   </p>
                   <Button
                     size="sm"
                     className={RESPONSIVE_PANEL_ACTION}
-                    disabled={processing || !pendingPerspective.paper}
+                    disabled={processing || !pendingTemplate}
                     onClick={() =>
-                      pendingPerspective.paper &&
+                      pendingTemplate &&
                       onApplyPerspective(
                         pendingPerspective,
-                        pendingPerspective.paper,
+                        pendingTemplate,
                       )
                     }
                     data-testid="button-apply-auto-perspective"
@@ -696,7 +704,9 @@ export function TraceControlsPanel({
                     ? "four template markers"
                     : "four manually selected page corners"}{" "}
                   using{" "}
-                  {perspectiveCorrection.paper === "a4" ? "A4" : "US Letter"}{" "}
+                  {templateDisplayName(
+                    perspectiveCorrection.template ?? perspectiveCorrection.paper,
+                  )}{" "}
                   dimensions.
                 </p>
                 <Button
@@ -836,10 +846,11 @@ export function TraceControlsPanel({
               <DialogHeader>
                 <DialogTitle>Calibration sheet</DialogTitle>
                 <DialogDescription>
-                  Print the current v2 sheet once at 100%, then include it beneath
-                  tools for automatic scale and perspective correction. Its custom
-                  marker dictionary prevents stock ArUco sheets from being mistaken
-                  for Pocketry; all four markers are required.
+                  Print at 100%, then include the sheet beneath tools for automatic
+                  scale and perspective correction. Current sheets remain the stable
+                  default. Experimental sheets use smaller markers closer to the page
+                  corners for a larger photography area and longer correction
+                  baselines. All four markers are required.
                 </DialogDescription>
               </DialogHeader>
               <Button
@@ -854,6 +865,7 @@ export function TraceControlsPanel({
                 <ScanSearch className="mr-1.5 h-4 w-4" />
                 Detect sheet in this image
               </Button>
+              <p className="text-xs font-medium">Current sheets</p>
               <div className="grid grid-cols-2 gap-2">
                 <Button
                   variant={perspectivePaper === "a4" ? "default" : "outline"}
@@ -876,6 +888,25 @@ export function TraceControlsPanel({
                   data-testid="button-template-letter"
                 >
                   Print US Letter PDF
+                </Button>
+              </div>
+              <p className="text-xs font-medium">Experimental corner-marker sheets</p>
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => downloadCalibrationTemplate("a4-experimental")}
+                  data-testid="button-template-a4-experimental"
+                >
+                  A4 experimental
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() =>
+                    downloadCalibrationTemplate("letter-experimental")
+                  }
+                  data-testid="button-template-letter-experimental"
+                >
+                  Letter experimental
                 </Button>
               </div>
             </DialogContent>

--- a/client/src/components/trace/trace-scene.test.tsx
+++ b/client/src/components/trace/trace-scene.test.tsx
@@ -25,6 +25,9 @@ function renderRuler({
   perspectiveEditable = false,
   perspectivePreview = null,
   imageRotation = 0,
+  measurement = null,
+  measurementPreview = null,
+  measurementMmPerPx = null,
 }: {
   completed?: Calibration | null;
   draft?: DraftCalibration | null;
@@ -34,6 +37,9 @@ function renderRuler({
   perspectiveEditable?: boolean;
   perspectivePreview?: Point | null;
   imageRotation?: 0 | 1 | 2 | 3;
+  measurement?: { start: Point; end: Point | null } | null;
+  measurementPreview?: Point | null;
+  measurementMmPerPx?: number | null;
 }): string {
   return renderToStaticMarkup(
     <TraceScene
@@ -51,6 +57,9 @@ function renderRuler({
       perspectivePoints={perspectivePoints}
       perspectiveEditable={perspectiveEditable}
       perspectivePreview={perspectivePreview}
+      measurement={measurement}
+      measurementPreview={measurementPreview}
+      measurementMmPerPx={measurementMmPerPx}
     />,
   );
 }
@@ -173,6 +182,38 @@ describe("TraceScene ruler overlay", () => {
     expect(count(markup, 'data-testid="ruler-marker"')).toBe(1);
     expect(markup).not.toContain('data-testid="ruler-line"');
     expect(markup).not.toContain('data-testid="ruler-length-label"');
+  });
+
+  it("renders a separate point-to-point measurement in physical units", () => {
+    const markup = renderRuler({
+      completed: calibration,
+      measurement: {
+        start: { x: 20, y: 30 },
+        end: { x: 80, y: 30 },
+      },
+      measurementMmPerPx: 0.5,
+    });
+
+    expect(markup).toContain('data-testid="ruler-overlay"');
+    expect(markup).toContain('data-testid="measurement-overlay"');
+    expect(count(markup, 'data-testid="measurement-marker"')).toBe(2);
+    expect(markup).toContain('data-testid="measurement-line"');
+    expect(markup).toContain('data-testid="measurement-length-label"');
+    expect(markup).toContain("30 mm");
+    expect(markup).toContain("stroke-cyan-500");
+  });
+
+  it("previews the measurement from its first point without scale handles", () => {
+    const markup = renderRuler({
+      measurement: { start: { x: 10, y: 10 }, end: null },
+      measurementPreview: { x: 40, y: 50 },
+      measurementMmPerPx: 0.2,
+    });
+
+    expect(markup).toContain('data-measurement-preview="true"');
+    expect(markup).toContain('stroke-dasharray="6 4"');
+    expect(markup).toContain("10 mm");
+    expect(markup).not.toContain("data-ruler-handle");
   });
 
   it("renders four numbered, editable perspective corners as a closed quad", () => {

--- a/client/src/components/trace/trace-scene.tsx
+++ b/client/src/components/trace/trace-scene.tsx
@@ -45,6 +45,12 @@ export interface TraceSceneProps {
   /** Enables the on-image reference-length editor after endpoint placement. */
   rulerEditable?: boolean;
   onRulerLengthCommit?: (lengthMm: number) => void;
+  /** Temporary point-to-point inspection ruler, independent of calibration. */
+  measurement?: { start: Point; end: Point | null } | null;
+  /** Pointer-following second point before the measurement is completed. */
+  measurementPreview?: Point | null;
+  /** Accepted physical scale used only to label the inspection ruler. */
+  measurementMmPerPx?: number | null;
   /** Template centres or manually selected page corners awaiting correction. */
   perspectivePoints?: readonly Point[];
   /** Manual points remain draggable after all four have been placed. */
@@ -121,6 +127,9 @@ export function TraceScene({
   rulerLengthMm,
   rulerEditable = false,
   onRulerLengthCommit,
+  measurement = null,
+  measurementPreview = null,
+  measurementMmPerPx = null,
   perspectivePoints = [],
   perspectiveEditable = false,
   perspectivePreview = null,
@@ -268,6 +277,12 @@ export function TraceScene({
           rulerLengthMm={rulerLengthMm}
           editable={rulerEditable}
           onLengthCommit={onRulerLengthCommit}
+          inv={inv}
+        />
+        <MeasurementOverlay
+          measurement={measurement}
+          preview={measurementPreview}
+          mmPerPx={measurementMmPerPx}
           inv={inv}
         />
         <PerspectiveOverlay
@@ -638,6 +653,136 @@ function rulerMarkerPath(point: Point, halfSize: number): string {
 
 function formatRulerLength(lengthMm: number): string {
   return Number.isFinite(lengthMm) ? String(Number(lengthMm.toPrecision(6))) : "—";
+}
+
+function MeasurementOverlay({
+  measurement,
+  preview,
+  mmPerPx,
+  inv,
+}: {
+  measurement: { start: Point; end: Point | null } | null;
+  preview: Point | null;
+  mmPerPx: number | null;
+  inv: number;
+}): JSX.Element | null {
+  if (!measurement || mmPerPx === null) return null;
+
+  const { start } = measurement;
+  const end = measurement.end ?? preview;
+  const previewing = measurement.end === null;
+  const markerRadius = 6 * inv;
+
+  return (
+    <g data-testid="measurement-overlay" pointerEvents="none">
+      {end && (
+        <>
+          <line
+            x1={start.x}
+            y1={start.y}
+            x2={end.x}
+            y2={end.y}
+            className="stroke-white/95"
+            strokeWidth={6}
+            strokeDasharray={previewing ? "6 4" : undefined}
+            vectorEffect="non-scaling-stroke"
+          />
+          <line
+            x1={start.x}
+            y1={start.y}
+            x2={end.x}
+            y2={end.y}
+            className="stroke-cyan-500"
+            strokeWidth={2.5}
+            strokeDasharray={previewing ? "6 4" : undefined}
+            vectorEffect="non-scaling-stroke"
+            data-testid="measurement-line"
+            data-measurement-preview={previewing || undefined}
+          />
+          <MeasurementLabel
+            start={start}
+            end={end}
+            lengthMm={Math.hypot(end.x - start.x, end.y - start.y) * mmPerPx}
+            inv={inv}
+          />
+        </>
+      )}
+      {[start, end].map((point, index) =>
+        point ? (
+          <g key={index} data-testid="measurement-marker">
+            <circle
+              cx={point.x}
+              cy={point.y}
+              r={markerRadius + 2 * inv}
+              className="fill-white/95"
+            />
+            <circle
+              cx={point.x}
+              cy={point.y}
+              r={markerRadius}
+              className="fill-cyan-500 stroke-cyan-950/60"
+              strokeWidth={1.5}
+              vectorEffect="non-scaling-stroke"
+            />
+          </g>
+        ) : null,
+      )}
+    </g>
+  );
+}
+
+function MeasurementLabel({
+  start,
+  end,
+  lengthMm,
+  inv,
+}: {
+  start: Point;
+  end: Point;
+  lengthMm: number;
+  inv: number;
+}): JSX.Element {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const distance = Math.hypot(dx, dy);
+  const normal =
+    distance > 0 ? { x: -dy / distance, y: dx / distance } : { x: 0, y: -1 };
+  const offset = RULER_LABEL_OFFSET * inv;
+  const x = (start.x + end.x) / 2 + normal.x * offset;
+  const y = (start.y + end.y) / 2 + normal.y * offset;
+  const label = `${formatMeasurementLength(lengthMm)} mm`;
+  const width = Math.max(46, label.length * 7 + 14) * inv;
+  const height = RULER_LABEL_HEIGHT * inv;
+
+  return (
+    <g data-testid="measurement-length-label">
+      <rect
+        x={x - width / 2}
+        y={y - height / 2}
+        width={width}
+        height={height}
+        rx={RULER_LABEL_RADIUS * inv}
+        className="fill-background/95 stroke-cyan-500"
+        strokeWidth={1.5}
+        vectorEffect="non-scaling-stroke"
+      />
+      <text
+        x={x}
+        y={y}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize={RULER_LABEL_FONT_SIZE * inv}
+        className="fill-foreground font-semibold"
+      >
+        {label}
+      </text>
+    </g>
+  );
+}
+
+function formatMeasurementLength(lengthMm: number): string {
+  if (!Number.isFinite(lengthMm)) return "—";
+  return lengthMm.toFixed(lengthMm < 10 ? 2 : 1).replace(/\.0+$/, "");
 }
 
 function PerspectiveOverlay({

--- a/client/src/lib/calibrate/aruco-4x4.ts
+++ b/client/src/lib/calibrate/aruco-4x4.ts
@@ -1,8 +1,8 @@
 /**
- * Pocketry's eight-marker custom 4x4 dictionary for calibration-sheet v2,
- * ported as data from OpenCV's deterministic `extendDictionary(8, 4)` output.
+ * Pocketry's sixteen-marker custom 4x4 dictionary for calibration-sheet v2,
+ * ported as data from OpenCV's deterministic `extendDictionary(16, 4)` output.
  *
- * Generator: OpenCV `extendDictionary(8, 4)`
+ * Generator: OpenCV `extendDictionary(16, 4)`
  * Upstream:  https://github.com/opencv/opencv at tag 4.11.0
  * Licence:  Apache-2.0 © OpenCV team — attribution in /NOTICE.
  *
@@ -18,7 +18,10 @@
  * dictionary compiled into opencv.js itself.
  */
 
-/** Canonical (rotation 0) patterns of Pocketry custom marker ids 0–7. */
+/** Existing sheets retain the first eight ids and their exact marker patterns. */
+export const STABLE_TEMPLATE_MARKER_COUNT = 8;
+
+/** Canonical (rotation 0) patterns of Pocketry custom marker ids 0–15. */
 export const POCKETRY_ARUCO_BITS: readonly number[] = [
   0x532c, // id 0
   0xaf8f, // id 1
@@ -28,6 +31,14 @@ export const POCKETRY_ARUCO_BITS: readonly number[] = [
   0x9a2f, // id 5
   0x4754, // id 6
   0xd870, // id 7
+  0xbcd7, // id 8
+  0x7de6, // id 9
+  0x5b8b, // id 10
+  0xf346, // id 11
+  0x50cc, // id 12
+  0xa729, // id 13
+  0x10a0, // id 14
+  0x0c82, // id 15
 ];
 
 /** Marker side length in modules: 4 data cells plus the black border ring. */

--- a/client/src/lib/calibrate/auto-calibrate.ts
+++ b/client/src/lib/calibrate/auto-calibrate.ts
@@ -10,7 +10,12 @@ import {
   type PerspectiveProposal,
 } from "./perspective";
 import { solveScaleFromMarkers, type ScaleSolution } from "./solve";
-import { paperFromTemplateMarkerIds, type TemplatePaper } from "./template";
+import {
+  templateFromTemplateMarkerIds,
+  templatePaper,
+  type TemplatePaper,
+  type TemplateVariant,
+} from "./template";
 
 /**
  * Detect → solve → Calibration, in one step the UI can act on.
@@ -28,6 +33,8 @@ export type AutoCalibrationResult =
       solution: ScaleSolution;
       /** Paper size encoded by this template's unique marker-id family. */
       paper: TemplatePaper;
+      /** Exact stable or experimental sheet encoded by the marker ids. */
+      template: TemplateVariant;
       /** Present only when all four unique template markers can define a homography. */
       perspectiveProposal: PerspectiveProposal;
       /** Sixteen-corner template-fit residual on the physical page plane. */
@@ -63,10 +70,8 @@ export function runAutoCalibration(cv: any, image: ImageData): AutoCalibrationRe
     };
   }
 
-  const paper = paperFromTemplateMarkerIds(
-    markerIds,
-  );
-  if (!paper) {
+  const template = templateFromTemplateMarkerIds(markerIds);
+  if (!template) {
     return {
       kind: "foreign-sheet",
       family: detection.family,
@@ -74,13 +79,14 @@ export function runAutoCalibration(cv: any, image: ImageData): AutoCalibrationRe
       markerIds,
     };
   }
+  const paper = templatePaper(template);
 
   const perspectiveProposal = proposalFromTemplateMarkers(
     detection.markers,
-    paper,
+    template,
   );
   const templateReprojectionError = perspectiveProposal
-    ? templateReprojectionErrorMm(cv, perspectiveProposal, paper)
+    ? templateReprojectionErrorMm(cv, perspectiveProposal, template)
     : null;
   if (
     templateReprojectionError === null ||
@@ -94,7 +100,7 @@ export function runAutoCalibration(cv: any, image: ImageData): AutoCalibrationRe
     };
   }
 
-  const solution = solveScaleFromMarkers(detection.markers, paper);
+  const solution = solveScaleFromMarkers(detection.markers, template);
   if (!solution || !perspectiveProposal) {
     return {
       kind: "foreign-sheet",
@@ -107,6 +113,7 @@ export function runAutoCalibration(cv: any, image: ImageData): AutoCalibrationRe
   return {
     kind: "calibrated",
     paper,
+    template,
     // The synthesised ruler joins the longest detected pair — for the full
     // sheet that is a 250 mm diagonal, the geometry least sensitive to
     // per-marker centre noise.

--- a/client/src/lib/calibrate/detect.test.ts
+++ b/client/src/lib/calibrate/detect.test.ts
@@ -14,10 +14,12 @@ import {
 } from "./detect";
 import { solveScaleFromMarkers } from "./solve";
 import {
-  TEMPLATE_MARKER_SIZE_MM,
   TEMPLATE_PAPER_MM,
   templateMarkerCentersMm,
-  type TemplatePaper,
+  templateMarkerSizeMm,
+  templateMarkerSpacingMm,
+  templatePaper,
+  type TemplateVariant,
 } from "./template";
 
 /**
@@ -42,20 +44,23 @@ const PX_PER_MM = 2;
 /** White template "photo" with its markers rendered at PX_PER_MM. */
 function composeSheet(
   createDictionary: () => any,
-  paper: TemplatePaper = "a4",
+  template: TemplateVariant = "a4",
   options: {
     markerSizeMm?: number;
     centers?: ReturnType<typeof templateMarkerCentersMm>;
   } = {},
 ): ImageData {
+  const paper = templatePaper(template);
   const width = Math.round(TEMPLATE_PAPER_MM[paper].width * PX_PER_MM);
   const height = Math.round(TEMPLATE_PAPER_MM[paper].height * PX_PER_MM);
   const data = new Uint8ClampedArray(width * height * 4).fill(255);
 
-  const sizePx = (options.markerSizeMm ?? TEMPLATE_MARKER_SIZE_MM) * PX_PER_MM;
+  const sizePx =
+    (options.markerSizeMm ?? templateMarkerSizeMm(template)) * PX_PER_MM;
   const dictionary = createDictionary();
   try {
-    for (const { id, x, y } of options.centers ?? templateMarkerCentersMm(paper)) {
+    for (const { id, x, y } of
+      options.centers ?? templateMarkerCentersMm(template)) {
       const marker = new cv.Mat();
       try {
         dictionary.generateImageMarker(id, sizePx, marker, 1);
@@ -146,7 +151,7 @@ describe("aruco detection (closed loop with the shipped bundle)", () => {
     const markers = detectPocketryTemplateMarkers(cv, scene);
 
     expect(markers.map((m) => m.id).sort()).toEqual([0, 1, 2, 3]);
-    const sizePx = TEMPLATE_MARKER_SIZE_MM * PX_PER_MM;
+    const sizePx = templateMarkerSizeMm("a4") * PX_PER_MM;
     for (const marker of markers) {
       const expected = templateMarkerCentersMm("a4").find((t) => t.id === marker.id)!;
       // The blit rounds the origin, and cv corner coordinates are
@@ -163,6 +168,17 @@ describe("aruco detection (closed loop with the shipped bundle)", () => {
   it("keeps the Pocketry namespace distinct from the stock 4x4 dictionary", () => {
     const scene = composeSheet(pocketryDictionary);
     expect(detectArucoMarkers(cv, scene, cv.DICT_4X4_50)).toEqual([]);
+  });
+
+  it.each([
+    ["a4-experimental", [8, 9, 10, 11]],
+    ["letter-experimental", [12, 13, 14, 15]],
+  ] as const)("finds all four markers on the %s sheet", (template, expectedIds) => {
+    const scene = composeSheet(pocketryDictionary, template);
+    const markers = detectPocketryTemplateMarkers(cv, scene);
+    expect(markers.map(({ id }) => id).sort((a, b) => a - b)).toEqual(
+      [...expectedIds],
+    );
   });
 
   it("keeps decoded corner identity when the sheet is rotated", () => {
@@ -239,26 +255,37 @@ describe("aruco detection (closed loop with the shipped bundle)", () => {
 });
 
 describe("runAutoCalibration", () => {
-  it.each(["a4", "letter"] as const)(
+  it.each([
+    "a4",
+    "letter",
+    "a4-experimental",
+    "letter-experimental",
+  ] as const)(
     "produces a usable Calibration and identifies a %s sheet",
-    (paper) => {
+    (template) => {
       const result = runAutoCalibration(
         cv,
-        composeSheet(pocketryDictionary, paper),
+        composeSheet(pocketryDictionary, template),
       );
       expect(result.kind).toBe("calibrated");
       if (result.kind !== "calibrated") return;
 
-      // The synthesised ruler spans the longest pair — a 250 mm diagonal — and
+      // The synthesised ruler spans the longest marker-centre pair, and
       // the app's own scale derivation must land on the composed scale.
-      expect(result.calibration.lengthMm).toBeCloseTo(250, 9);
+      const spacing = templateMarkerSpacingMm(template);
+      expect(result.calibration.lengthMm).toBeCloseTo(
+        Math.hypot(spacing.width, spacing.height),
+        9,
+      );
       const derived = mmPerPixel(result.calibration)!;
       expect(
         Math.abs(derived - 1 / PX_PER_MM) / (1 / PX_PER_MM),
       ).toBeLessThan(0.005);
       expect(result.solution.maxDeviation).toBeLessThan(0.01);
-      expect(result.paper).toBe(paper);
+      expect(result.paper).toBe(templatePaper(template));
+      expect(result.template).toBe(template);
       expect(result.perspectiveProposal?.source).toBe("template");
+      expect(result.perspectiveProposal?.template).toBe(template);
       expect(result.perspectiveProposal?.points).toHaveLength(4);
       expect(result.perspectiveProposal?.correspondences?.source).toHaveLength(16);
       expect(

--- a/client/src/lib/calibrate/detect.ts
+++ b/client/src/lib/calibrate/detect.ts
@@ -1,6 +1,9 @@
 import type { Point } from "@shared/geometry/types";
 
-import { POCKETRY_ARUCO_BITS } from "./aruco-4x4";
+import {
+  POCKETRY_ARUCO_BITS,
+  STABLE_TEMPLATE_MARKER_COUNT,
+} from "./aruco-4x4";
 import type { DetectedMarker } from "./solve";
 
 /**
@@ -61,8 +64,11 @@ export function hasArucoSupport(cv: Cv): boolean {
  * The oracle test compares every generated cell with `POCKETRY_ARUCO_BITS`, so
  * an OpenCV upgrade cannot silently change the printed/detected namespace.
  */
-export function createPocketryTemplateDictionary(cv: Cv): Cv {
-  return cv.extendDictionary(POCKETRY_ARUCO_BITS.length, 4);
+export function createPocketryTemplateDictionary(
+  cv: Cv,
+  markerCount = POCKETRY_ARUCO_BITS.length,
+): Cv {
+  return cv.extendDictionary(markerCount, 4);
 }
 
 function detectMarkersWithDictionary(
@@ -143,11 +149,20 @@ export function detectArucoMarkers(
   );
 }
 
-/** Detects only Pocketry v2 custom markers, never stock-dictionary lookalikes. */
+/**
+ * Detects only Pocketry v2 custom markers, never stock-dictionary lookalikes.
+ * Existing sheets are tried against their original eight-marker dictionary
+ * first, preserving its exact decoding/error-correction behaviour. The full
+ * dictionary is only needed for the new experimental marker signatures.
+ */
 export function detectPocketryTemplateMarkers(
   cv: Cv,
   image: ImageData,
 ): DetectedMarker[] {
+  const stable = detectMarkersWithDictionary(cv, image, () =>
+    createPocketryTemplateDictionary(cv, STABLE_TEMPLATE_MARKER_COUNT),
+  );
+  if (stable.length >= 2) return stable;
   return detectMarkersWithDictionary(cv, image, () =>
     createPocketryTemplateDictionary(cv),
   );

--- a/client/src/lib/calibrate/download-template.ts
+++ b/client/src/lib/calibrate/download-template.ts
@@ -1,13 +1,13 @@
 import { downloadBlob } from "@/lib/download";
 
 import { calibrationTemplatePdf } from "./template-pdf";
-import type { TemplatePaper } from "./template";
+import type { TemplateVariant } from "./template";
 
 /** Downloads one true-size, printable Pocketry calibration sheet. */
-export function downloadCalibrationTemplate(paper: TemplatePaper): void {
-  const pdf = calibrationTemplatePdf(paper);
+export function downloadCalibrationTemplate(template: TemplateVariant): void {
+  const pdf = calibrationTemplatePdf(template);
   downloadBlob(
     new Blob([pdf], { type: "application/pdf" }),
-    `pocketry-calibration-v2-${paper}.pdf`,
+    `pocketry-calibration-v2-${template}.pdf`,
   );
 }

--- a/client/src/lib/calibrate/perspective.test.ts
+++ b/client/src/lib/calibrate/perspective.test.ts
@@ -95,6 +95,7 @@ describe("perspective geometry", () => {
       { x: 20, y: 110 },
     ]);
     expect(proposal?.paper).toBe("a4");
+    expect(proposal?.template).toBe("a4");
     expect(proposal?.correspondences?.source).toHaveLength(16);
     expect(proposal?.correspondences?.destinationMm).toHaveLength(16);
     expect(proposalFromTemplateMarkers(markers.slice(0, 3), "a4")).toBeNull();
@@ -118,6 +119,28 @@ describe("perspective geometry", () => {
       { x: 840, y: 0 },
       { x: 840, y: 1188 },
       { x: 0, y: 1188 },
+    ]);
+  });
+
+  it("uses the experimental marker centres on the same A4 paper plane", () => {
+    const proposal: PerspectiveProposal = {
+      source: "template",
+      paper: "a4",
+      template: "a4-experimental",
+      points: [
+        { x: 10, y: 10 },
+        { x: 200, y: 10 },
+        { x: 200, y: 280 },
+        { x: 10, y: 280 },
+      ],
+    };
+    const layout = perspectiveLayout(proposal, "a4-experimental");
+    expect(layout).toMatchObject({ width: 841, height: 1189, pxPerMm: 4 });
+    expect(layout.destination).toEqual([
+      { x: 96, y: 96 },
+      { x: 744, y: 96 },
+      { x: 744, y: 1092 },
+      { x: 96, y: 1092 },
     ]);
   });
 

--- a/client/src/lib/calibrate/perspective.ts
+++ b/client/src/lib/calibrate/perspective.ts
@@ -4,12 +4,14 @@ import type { Point } from "@shared/geometry/types";
 import { loadOpenCV } from "@/lib/opencv";
 
 import {
-  TEMPLATE_SPACING_MM,
   TEMPLATE_MARKER_IDS,
   TEMPLATE_PAPER_MM,
   templateMarkerCornersMm,
   templateMarkerCentersMm,
+  templateMarkerSpacingMm,
+  templatePaper,
   type TemplatePaper,
+  type TemplateVariant,
 } from "./template";
 import type { DetectedMarker } from "./solve";
 
@@ -24,6 +26,8 @@ export interface PerspectiveProposal {
   points: PerspectiveQuad;
   /** Automatically encoded by the marker-id family for template proposals. */
   paper?: TemplatePaper;
+  /** Exact stable or experimental sheet encoded by the marker-id family. */
+  template?: TemplateVariant;
   /** Redundant marker-corner correspondences for a precision homography. */
   correspondences?: {
     source: Point[];
@@ -63,7 +67,7 @@ export const MAX_TEMPLATE_REPROJECTION_RMS_MM =
 /** Builds an ordered four-marker proposal, or null when any template id is absent. */
 export function proposalFromTemplateMarkers(
   markers: readonly DetectedMarker[],
-  paper: TemplatePaper,
+  template: TemplateVariant,
 ): PerspectiveProposal | null {
   const unique = new Map<number, DetectedMarker>();
   const duplicates = new Set<number>();
@@ -76,9 +80,9 @@ export function proposalFromTemplateMarkers(
   const source: Point[] = [];
   const destinationMm: Point[] = [];
   const physicalCorners = new Map(
-    templateMarkerCornersMm(paper).map((marker) => [marker.id, marker.corners]),
+    templateMarkerCornersMm(template).map((marker) => [marker.id, marker.corners]),
   );
-  for (const id of TEMPLATE_MARKER_IDS[paper]) {
+  for (const id of TEMPLATE_MARKER_IDS[template]) {
     if (duplicates.has(id)) return null;
     const marker = unique.get(id);
     const destinationCorners = physicalCorners.get(id);
@@ -89,7 +93,8 @@ export function proposalFromTemplateMarkers(
   }
   return {
     source: "template",
-    paper,
+    paper: templatePaper(template),
+    template,
     points: ordered as PerspectiveQuad,
     correspondences: { source, destinationMm },
   };
@@ -103,8 +108,14 @@ export function proposalFromTemplateMarkers(
 export function templateReprojectionErrorMm(
   cv: any,
   proposal: PerspectiveProposal,
-  paper: TemplatePaper,
+  template: TemplateVariant,
 ): number | null {
+  if (
+    (proposal.template && proposal.template !== template) ||
+    (proposal.paper && proposal.paper !== templatePaper(template))
+  ) {
+    return null;
+  }
   const fit = proposal.source === "template" ? proposal.correspondences : null;
   if (
     !fit ||
@@ -184,9 +195,10 @@ export function scalePerspectiveProposal(
  */
 export function perspectiveLayout(
   proposal: PerspectiveProposal,
-  paper: TemplatePaper,
+  template: TemplateVariant,
   max: { width: number; height: number } = RECTIFIED_IMAGE_MAX,
 ): PerspectiveLayout {
+  const paper = templatePaper(template);
   const page = TEMPLATE_PAPER_MM[paper];
   const availableX = Math.max(1, max.width - 1) / page.width;
   const availableY = Math.max(1, max.height - 1) / page.height;
@@ -196,7 +208,7 @@ export function perspectiveLayout(
 
   const destination =
     proposal.source === "template"
-      ? (templateMarkerCentersMm(paper).map(({ x, y }) => ({
+      ? (templateMarkerCentersMm(template).map(({ x, y }) => ({
           x: x * pxPerMm,
           y: y * pxPerMm,
         })) as PerspectiveQuad)
@@ -239,7 +251,7 @@ export function runPerspectiveCorrection(
   cv: any,
   image: ImageData,
   proposal: PerspectiveProposal,
-  paper: TemplatePaper,
+  template: TemplateVariant,
   max: { width: number; height: number } = RECTIFIED_IMAGE_MAX,
 ): PerspectiveCorrectionResult {
   if (!validPerspectiveQuad(proposal.points)) {
@@ -247,11 +259,15 @@ export function runPerspectiveCorrection(
       "The four correction points must form one non-overlapping rectangle in clockwise order.",
     );
   }
+  const paper = templatePaper(template);
   if (proposal.paper && proposal.paper !== paper) {
     throw new Error("The detected template paper does not match the requested correction.");
   }
+  if (proposal.template && proposal.template !== template) {
+    throw new Error("The detected template does not match the requested correction.");
+  }
 
-  const layout = perspectiveLayout(proposal, paper, max);
+  const layout = perspectiveLayout(proposal, template, max);
   const source = cv.matFromImageData(image);
   const corrected = new cv.Mat();
   const precisionFit =
@@ -337,9 +353,10 @@ export function runPerspectiveCorrection(
 
     const start = layout.destination[0];
     const end = layout.destination[2];
+    const markerSpacing = templateMarkerSpacingMm(template);
     const lengthMm =
       proposal.source === "template"
-        ? Math.hypot(TEMPLATE_SPACING_MM.width, TEMPLATE_SPACING_MM.height)
+        ? Math.hypot(markerSpacing.width, markerSpacing.height)
         : Math.hypot(TEMPLATE_PAPER_MM[paper].width, TEMPLATE_PAPER_MM[paper].height);
 
     return {
@@ -368,7 +385,7 @@ export function runPerspectiveCorrection(
 export async function correctPerspective(
   image: ImageData,
   proposal: PerspectiveProposal,
-  paper: TemplatePaper,
+  template: TemplateVariant,
   max: { width: number; height: number } = RECTIFIED_IMAGE_MAX,
 ): Promise<PerspectiveCorrectionResult> {
   const cv = await loadOpenCV();
@@ -378,5 +395,5 @@ export async function correctPerspective(
   ) {
     throw new Error("Perspective correction is unavailable in this browser session.");
   }
-  return runPerspectiveCorrection(cv, image, proposal, paper, max);
+  return runPerspectiveCorrection(cv, image, proposal, template, max);
 }

--- a/client/src/lib/calibrate/solve.test.ts
+++ b/client/src/lib/calibrate/solve.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vitest";
 
 import { solveScaleFromMarkers, SKEW_WARN_FRACTION } from "./solve";
-import { templateMarkerCentersMm } from "./template";
+import {
+  templateMarkerCentersMm,
+  templateMarkerSpacingMm,
+  type TemplateVariant,
+} from "./template";
 
 /** Detected markers synthesised from the template at `pxPerMm`. */
 function syntheticMarkers(
   pxPerMm: number,
   ids?: number[],
-  paper: "a4" | "letter" = "a4",
+  paper: TemplateVariant = "a4",
 ) {
   return templateMarkerCentersMm(paper)
     .filter((entry) => !ids || ids.includes(entry.id))
@@ -37,6 +41,21 @@ describe("solveScaleFromMarkers", () => {
     expect(solution.mmPerPx).toBeCloseTo(0.5, 9);
     expect(solution.markerIds).toEqual([4, 5, 6, 7]);
     expect(solution.pairCount).toBe(6);
+  });
+
+  it("uses the wider experimental marker geometry", () => {
+    const template = "a4-experimental";
+    const solution = solveScaleFromMarkers(
+      syntheticMarkers(2, undefined, template),
+      template,
+    )!;
+    const spacing = templateMarkerSpacingMm(template);
+    expect(solution.mmPerPx).toBeCloseTo(0.5, 9);
+    expect(solution.markerIds).toEqual([8, 9, 10, 11]);
+    expect(solution.ruler.lengthMm).toBeCloseTo(
+      Math.hypot(spacing.width, spacing.height),
+      9,
+    );
   });
 
   it("works from any two markers", () => {

--- a/client/src/lib/calibrate/solve.ts
+++ b/client/src/lib/calibrate/solve.ts
@@ -3,7 +3,7 @@ import type { Point } from "@shared/geometry/types";
 import {
   TEMPLATE_MARKER_IDS,
   templateMarkerCentersMm,
-  type TemplatePaper,
+  type TemplateVariant,
 } from "./template";
 
 /**
@@ -45,15 +45,15 @@ export const SKEW_WARN_FRACTION = 0.02;
 
 export function solveScaleFromMarkers(
   markers: readonly DetectedMarker[],
-  paper: TemplatePaper,
+  templateVariant: TemplateVariant,
 ): ScaleSolution | null {
   const template = new Map(
-    templateMarkerCentersMm(paper).map((entry) => [entry.id, entry]),
+    templateMarkerCentersMm(templateVariant).map((entry) => [entry.id, entry]),
   );
   const usable = markers.filter(
     (marker) =>
       template.has(marker.id) &&
-      TEMPLATE_MARKER_IDS[paper].includes(marker.id),
+      TEMPLATE_MARKER_IDS[templateVariant].includes(marker.id),
   );
   // Dedupe ids: a reflection or reprint can yield the same id twice; trust
   // neither copy.

--- a/client/src/lib/calibrate/template-pdf.test.ts
+++ b/client/src/lib/calibrate/template-pdf.test.ts
@@ -1,15 +1,25 @@
 import { describe, expect, it } from "vitest";
 
 import { calibrationTemplatePdf } from "./template-pdf";
+import type { TemplateVariant } from "./template";
 
-function pdfText(paper: "a4" | "letter"): string {
+function pdfText(paper: TemplateVariant): string {
   return new TextDecoder().decode(calibrationTemplatePdf(paper));
 }
 
-function markerRectangles(pdf: string): { x: number; y: number }[] {
-  return [...pdf.matchAll(/0 g\n([\d.]+) ([\d.]+) 85\.0394 85\.0394 re f/g)].map(
-    (match) => ({ x: Number(match[1]), y: Number(match[2]) }),
-  );
+function markerRectangles(
+  pdf: string,
+): { x: number; y: number; width: number; height: number }[] {
+  return [
+    ...pdf.matchAll(
+      /0 g\n([\d.]+) ([\d.]+) ([\d.]+) ([\d.]+) re f/g,
+    ),
+  ].map((match) => ({
+    x: Number(match[1]),
+    y: Number(match[2]),
+    width: Number(match[3]),
+    height: Number(match[4]),
+  }));
 }
 
 describe("printable calibration PDF", () => {
@@ -24,6 +34,13 @@ describe("printable calibration PDF", () => {
     expect(letter).toContain("/MediaBox [0 0 612 792]");
     expect(letter).toContain("/CropBox [0 0 612 792]");
     expect(letter).toContain("/PrintScaling /None");
+
+    expect(pdfText("a4-experimental")).toContain(
+      "/MediaBox [0 0 595.2756 841.8898]",
+    );
+    expect(pdfText("letter-experimental")).toContain(
+      "/MediaBox [0 0 612 792]",
+    );
   });
 
   it("draws four 30 mm markers at 150 x 200 mm centre spacing", () => {
@@ -34,7 +51,38 @@ describe("printable calibration PDF", () => {
       const ys = [...new Set(rectangles.map(({ y }) => y))].sort((a, b) => a - b);
       expect((xs[1] - xs[0]) / (72 / 25.4)).toBeCloseTo(150, 4);
       expect((ys[1] - ys[0]) / (72 / 25.4)).toBeCloseTo(200, 4);
-      expect(85.0394 / (72 / 25.4)).toBeCloseTo(30, 4);
+      expect(rectangles[0].width / (72 / 25.4)).toBeCloseTo(30, 4);
+    }
+  });
+
+  it("draws 24 mm experimental markers with 12 mm outer margins", () => {
+    for (const template of [
+      "a4-experimental",
+      "letter-experimental",
+    ] as const) {
+      const pdf = pdfText(template);
+      const rectangles = markerRectangles(pdf);
+      const mediaBox = pdf.match(/\/MediaBox \[0 0 ([\d.]+) ([\d.]+)\]/)!;
+      const pageWidth = Number(mediaBox[1]);
+      const pageHeight = Number(mediaBox[2]);
+      const pointsPerMm = 72 / 25.4;
+      expect(rectangles).toHaveLength(4);
+      for (const rectangle of rectangles) {
+        expect(rectangle.width / pointsPerMm).toBeCloseTo(24, 4);
+        expect(rectangle.height / pointsPerMm).toBeCloseTo(24, 4);
+      }
+      const xs = [...new Set(rectangles.map(({ x }) => x))].sort((a, b) => a - b);
+      const ys = [...new Set(rectangles.map(({ y }) => y))].sort((a, b) => a - b);
+      expect(xs[0] / pointsPerMm).toBeCloseTo(12, 4);
+      expect(ys[0] / pointsPerMm).toBeCloseTo(12, 4);
+      expect((pageWidth - xs[1] - rectangles[0].width) / pointsPerMm).toBeCloseTo(
+        12,
+        4,
+      );
+      expect((pageHeight - ys[1] - rectangles[0].height) / pointsPerMm).toBeCloseTo(
+        12,
+        4,
+      );
     }
   });
 
@@ -47,6 +95,15 @@ describe("printable calibration PDF", () => {
     for (const id of [4, 5, 6, 7]) expect(letter).toContain(`(id ${id})`);
     expect(letter).not.toContain("(id 0)");
 
+    const a4Experimental = pdfText("a4-experimental");
+    for (const id of [8, 9, 10, 11]) {
+      expect(a4Experimental).toContain(`(id ${id})`);
+    }
+    const letterExperimental = pdfText("letter-experimental");
+    for (const id of [12, 13, 14, 15]) {
+      expect(letterExperimental).toContain(`(id ${id})`);
+    }
+
     const lines = [...a4.matchAll(/([\d.]+) ([\d.]+) m ([\d.]+) \2 l S/g)];
     expect(
       lines.some(
@@ -55,6 +112,34 @@ describe("printable calibration PDF", () => {
           0.0001,
       ),
     ).toBe(true);
+  });
+
+  it("puts the experimental 100 mm bar between the lower markers near their bottoms", () => {
+    for (const template of [
+      "a4-experimental",
+      "letter-experimental",
+    ] as const) {
+      const pdf = pdfText(template);
+      const pointsPerMm = 72 / 25.4;
+      const line = [
+        ...pdf.matchAll(/([\d.]+) ([\d.]+) m ([\d.]+) \2 l S/g),
+      ].find(
+        (match) =>
+          Math.abs(
+            (Number(match[3]) - Number(match[1])) / pointsPerMm - 100,
+          ) < 0.0001,
+      );
+      expect(line).toBeDefined();
+      expect(Number(line![2]) / pointsPerMm).toBeCloseTo(16, 4);
+
+      const lowerMarkers = markerRectangles(pdf).filter(
+        ({ y }) => Math.abs(y / pointsPerMm - 12) < 0.001,
+      );
+      expect(lowerMarkers).toHaveLength(2);
+      const [left, right] = lowerMarkers.sort((a, b) => a.x - b.x);
+      expect(Number(line![1])).toBeGreaterThan(left.x + left.width);
+      expect(Number(line![3])).toBeLessThan(right.x);
+    }
   });
 
   it("keeps every drawn element inside an 8 mm print-safe margin", () => {
@@ -112,7 +197,12 @@ describe("printable calibration PDF", () => {
   });
 
   it("emits a complete single-page PDF with a cross-reference table", () => {
-    for (const paper of ["a4", "letter"] as const) {
+    for (const paper of [
+      "a4",
+      "letter",
+      "a4-experimental",
+      "letter-experimental",
+    ] as const) {
       const pdf = pdfText(paper);
       expect(pdf.startsWith("%PDF-1.4\n")).toBe(true);
       expect(pdf).toContain("/Type /Page");

--- a/client/src/lib/calibrate/template-pdf.ts
+++ b/client/src/lib/calibrate/template-pdf.ts
@@ -1,12 +1,16 @@
 import { ARUCO_4X4_MODULES, markerBits } from "./aruco-4x4";
 import {
-  TEMPLATE_MARKER_SIZE_MM,
   TEMPLATE_PAPER_MM,
-  TEMPLATE_PRINT_SAFE_MARGIN_MM,
   TEMPLATE_SIGNATURE_VERSION,
+  formatTemplateMm,
+  isExperimentalTemplate,
   templateHeaderBaselinesMm,
   templateMarkerCentersMm,
-  type TemplatePaper,
+  templateMarkerSizeMm,
+  templateMarkerSpacingMm,
+  templatePaper,
+  templateVerificationBarMm,
+  type TemplateVariant,
 } from "./template";
 
 export const PDF_POINTS_PER_MM = 72 / 25.4;
@@ -46,13 +50,15 @@ function concatBytes(parts: readonly Uint8Array[]): Uint8Array {
  * Builds a one-page vector PDF whose drawing coordinates are derived directly
  * from the same millimetre template geometry used by the detector.
  */
-export function calibrationTemplatePdf(paper: TemplatePaper): Uint8Array {
+export function calibrationTemplatePdf(template: TemplateVariant): Uint8Array {
+  const paper = templatePaper(template);
   const page = TEMPLATE_PAPER_MM[paper];
   const pageWidth = page.width * PDF_POINTS_PER_MM;
   const pageHeight = page.height * PDF_POINTS_PER_MM;
-  const centers = templateMarkerCentersMm(paper);
-  const header = templateHeaderBaselinesMm(paper);
-  const markerSize = TEMPLATE_MARKER_SIZE_MM * PDF_POINTS_PER_MM;
+  const centers = templateMarkerCentersMm(template);
+  const header = templateHeaderBaselinesMm(template);
+  const markerSizeMm = templateMarkerSizeMm(template);
+  const markerSize = markerSizeMm * PDF_POINTS_PER_MM;
   const moduleSize = markerSize / ARUCO_4X4_MODULES;
   const commands: string[] = ["1 g", `0 0 ${number(pageWidth)} ${number(pageHeight)} re f`];
 
@@ -90,14 +96,14 @@ export function calibrationTemplatePdf(paper: TemplatePaper): Uint8Array {
     );
   };
 
-  for (const { id, x, y } of centers) {
-    const originX = x - TEMPLATE_MARKER_SIZE_MM / 2;
-    const originY = y - TEMPLATE_MARKER_SIZE_MM / 2;
+  for (const [index, { id, x, y }] of centers.entries()) {
+    const originX = x - markerSizeMm / 2;
+    const originY = y - markerSizeMm / 2;
     drawTopOriginRect(
       originX,
       originY,
-      TEMPLATE_MARKER_SIZE_MM,
-      TEMPLATE_MARKER_SIZE_MM,
+      markerSizeMm,
+      markerSizeMm,
       0,
     );
     const bits = markerBits(id);
@@ -112,48 +118,59 @@ export function calibrationTemplatePdf(paper: TemplatePaper): Uint8Array {
         );
       }
     }
-    drawCenteredText(`id ${id}`, x, originY + TEMPLATE_MARKER_SIZE_MM + 5, 3.5, 0.2);
+    const labelY =
+      isExperimentalTemplate(template) && index >= 2
+        ? originY - 3
+        : originY + markerSizeMm + 5;
+    drawCenteredText(`id ${id}`, x, labelY, 3.5, 0.2);
   }
 
   const centerX = page.width / 2;
+  const experimental = isExperimentalTemplate(template);
   drawCenteredText(
-    `Pocketry v${TEMPLATE_SIGNATURE_VERSION} ${paper === "a4" ? "A4" : "US Letter"} calibration sheet - print at 100% scale (no fit to page)`,
+    experimental
+      ? `Pocketry v${TEMPLATE_SIGNATURE_VERSION} experimental - ${paper === "a4" ? "A4" : "US Letter"} - print at 100% scale`
+      : `Pocketry v${TEMPLATE_SIGNATURE_VERSION} ${paper === "a4" ? "A4" : "US Letter"} calibration sheet - print at 100% scale (no fit to page)`,
     centerX,
     header.title,
-    5,
+    experimental ? 4 : 5,
     0,
   );
   drawCenteredText(
-    "Place the tool between the markers, keep all four visible, shoot from directly above.",
+    experimental
+      ? "Keep all four markers visible - camera 1x - shoot straight down."
+      : "Place the tool between the markers, keep all four visible, shoot from directly above.",
     centerX,
     header.instructions,
-    3.5,
+    experimental ? 3 : 3.5,
     0.2,
   );
 
-  const rulerY = page.height - TEMPLATE_PRINT_SAFE_MARGIN_MM;
-  const rulerX = centerX - 50;
+  const ruler = templateVerificationBarMm(template);
   commands.push(
     "0 G",
     `${number(pdfX(0.5))} w`,
-    `${number(pdfX(rulerX))} ${number(pdfY(rulerY))} m ${number(
-      pdfX(rulerX + 100),
-    )} ${number(pdfY(rulerY))} l S`,
+    `${number(pdfX(ruler.startX))} ${number(pdfY(ruler.y))} m ${number(
+      pdfX(ruler.endX),
+    )} ${number(pdfY(ruler.y))} l S`,
   );
   for (let index = 0; index <= 10; index++) {
-    const x = rulerX + index * 10;
+    const x = ruler.startX + index * 10;
     const tick = index % 5 === 0 ? 4 : 2.5;
     commands.push(
       `${number(pdfX(0.3))} w`,
-      `${number(pdfX(x))} ${number(pdfY(rulerY))} m ${number(
+      `${number(pdfX(x))} ${number(pdfY(ruler.y))} m ${number(
         pdfX(x),
-      )} ${number(pdfY(rulerY - tick))} l S`,
+      )} ${number(pdfY(ruler.y - tick))} l S`,
     );
   }
+  const spacing = templateMarkerSpacingMm(template);
   drawCenteredText(
-    "check: this bar is exactly 100 mm - marker centres 150 x 200 mm, diagonals 250 mm",
+    experimental
+      ? `check: this bar is exactly 100 mm - marker centres ${formatTemplateMm(spacing.width)} x ${formatTemplateMm(spacing.height)} mm`
+      : "check: this bar is exactly 100 mm - marker centres 150 x 200 mm, diagonals 250 mm",
     centerX,
-    rulerY - 6,
+    ruler.labelY,
     3.5,
     0.2,
   );

--- a/client/src/lib/calibrate/template.test.ts
+++ b/client/src/lib/calibrate/template.test.ts
@@ -3,21 +3,29 @@ import { describe, expect, it } from "vitest";
 import { POCKETRY_ARUCO_BITS, markerBits } from "./aruco-4x4";
 import {
   calibrationTemplateSvg,
+  EXPERIMENTAL_TEMPLATE_MARKER_SIZE_MM,
+  EXPERIMENTAL_TEMPLATE_OUTER_MARGIN_MM,
   paperFromTemplateMarkerIds,
   TEMPLATE_MARKER_IDS,
   TEMPLATE_MARKER_SIZE_MM,
   TEMPLATE_PAPER_MM,
   TEMPLATE_SPACING_MM,
+  templateFromTemplateMarkerIds,
   templateMarkerCornersMm,
   templateMarkerCentersMm,
+  templateMarkerSizeMm,
+  templateVerificationBarMm,
 } from "./template";
 
 describe("ArUco 4x4 dictionary port", () => {
-  it("carries the canonical DICT_4X4 patterns for ids 0-7", () => {
+  it("preserves ids 0-7 and adds the deterministic ids 8-15", () => {
     // Decoded from OpenCV 4.11.0 predefined_dictionaries.hpp (rotation 0 of
     // each marker's byte record) — see the module header for provenance.
-    expect(POCKETRY_ARUCO_BITS).toEqual([
+    expect(POCKETRY_ARUCO_BITS.slice(0, 8)).toEqual([
       0x532c, 0xaf8f, 0x203f, 0x1296, 0x03f9, 0x9a2f, 0x4754, 0xd870,
+    ]);
+    expect(POCKETRY_ARUCO_BITS.slice(8)).toEqual([
+      0xbcd7, 0x7de6, 0x5b8b, 0xf346, 0x50cc, 0xa729, 0x10a0, 0x0c82,
     ]);
   });
 
@@ -31,7 +39,7 @@ describe("ArUco 4x4 dictionary port", () => {
   });
 
   it("rejects unported ids", () => {
-    expect(() => markerBits(8)).toThrow(/no ported pattern/);
+    expect(() => markerBits(16)).toThrow(/no ported pattern/);
   });
 });
 
@@ -61,6 +69,14 @@ describe("calibration template", () => {
   it("requires the complete paper-specific marker signature", () => {
     expect(paperFromTemplateMarkerIds([0, 1, 2, 3])).toBe("a4");
     expect(paperFromTemplateMarkerIds([4, 5, 6, 7])).toBe("letter");
+    expect(paperFromTemplateMarkerIds([8, 9, 10, 11])).toBe("a4");
+    expect(paperFromTemplateMarkerIds([12, 13, 14, 15])).toBe("letter");
+    expect(templateFromTemplateMarkerIds([8, 9, 10, 11])).toBe(
+      "a4-experimental",
+    );
+    expect(templateFromTemplateMarkerIds([12, 13, 14, 15])).toBe(
+      "letter-experimental",
+    );
     expect(paperFromTemplateMarkerIds([0, 2])).toBeNull();
     expect(paperFromTemplateMarkerIds([4, 7])).toBeNull();
     expect(paperFromTemplateMarkerIds([0, 1, 2, 3, 4])).toBeNull();
@@ -69,14 +85,49 @@ describe("calibration template", () => {
     expect(paperFromTemplateMarkerIds([12, 13])).toBeNull();
   });
 
+  it("places 24 mm experimental markers 12 mm from each paper edge", () => {
+    for (const template of [
+      "a4-experimental",
+      "letter-experimental",
+    ] as const) {
+      const paper = template.startsWith("a4") ? "a4" : "letter";
+      const page = TEMPLATE_PAPER_MM[paper];
+      const centers = templateMarkerCentersMm(template);
+      const half = EXPERIMENTAL_TEMPLATE_MARKER_SIZE_MM / 2;
+
+      expect(centers.map(({ id }) => id)).toEqual(TEMPLATE_MARKER_IDS[template]);
+      expect(centers[0].x - half).toBe(
+        EXPERIMENTAL_TEMPLATE_OUTER_MARGIN_MM,
+      );
+      expect(centers[0].y - half).toBe(
+        EXPERIMENTAL_TEMPLATE_OUTER_MARGIN_MM,
+      );
+      expect(page.width - (centers[1].x + half)).toBeCloseTo(
+        EXPERIMENTAL_TEMPLATE_OUTER_MARGIN_MM,
+        9,
+      );
+      expect(page.height - (centers[2].y + half)).toBeCloseTo(
+        EXPERIMENTAL_TEMPLATE_OUTER_MARGIN_MM,
+        9,
+      );
+      expect(centers[1].x - centers[0].x).toBeCloseTo(page.width - 48, 9);
+      expect(centers[3].y - centers[0].y).toBeCloseTo(page.height - 48, 9);
+    }
+  });
+
   it("provides all sixteen physical marker corners for precision fitting", () => {
-    for (const paper of ["a4", "letter"] as const) {
-      const markers = templateMarkerCornersMm(paper);
+    for (const template of [
+      "a4",
+      "letter",
+      "a4-experimental",
+      "letter-experimental",
+    ] as const) {
+      const markers = templateMarkerCornersMm(template);
       expect(markers).toHaveLength(4);
       expect(markers.flatMap(({ corners }) => corners)).toHaveLength(16);
       for (const marker of markers) {
         expect(marker.corners[1].x - marker.corners[0].x).toBeCloseTo(
-          TEMPLATE_MARKER_SIZE_MM,
+          templateMarkerSizeMm(template),
           9,
         );
       }
@@ -92,6 +143,10 @@ describe("calibration template", () => {
     const letter = calibrationTemplateSvg("letter");
     expect(letter).toContain('width="215.9mm"');
     expect(letter).toContain('viewBox="0 0 215.9 279.4"');
+
+    const experimental = calibrationTemplateSvg("a4-experimental");
+    expect(experimental).toContain("experimental");
+    expect(experimental).toContain('width="24" height="24"');
   });
 
   it("renders one white cell per set bit, per marker", () => {
@@ -122,6 +177,30 @@ describe("calibration template", () => {
     expect(letter).toContain("id 4");
     expect(letter).toContain("id 7");
     expect(letter).not.toContain("id 0");
+
+    const experimental = calibrationTemplateSvg("a4-experimental");
+    expect(experimental).toContain("id 8");
+    expect(experimental).toContain("id 11");
+    expect(experimental).not.toContain("id 0");
+  });
+
+  it("places the experimental 100 mm line between the lower markers", () => {
+    for (const template of [
+      "a4-experimental",
+      "letter-experimental",
+    ] as const) {
+      const centers = templateMarkerCentersMm(template);
+      const ruler = templateVerificationBarMm(template);
+      const half = EXPERIMENTAL_TEMPLATE_MARKER_SIZE_MM / 2;
+      const leftInnerEdge = centers[3].x + half;
+      const rightInnerEdge = centers[2].x - half;
+      const lowerEdge = centers[2].y + half;
+
+      expect(ruler.endX - ruler.startX).toBeCloseTo(100, 9);
+      expect(ruler.startX).toBeGreaterThan(leftInnerEdge);
+      expect(ruler.endX).toBeLessThan(rightInnerEdge);
+      expect(lowerEdge - ruler.y).toBe(4);
+    }
   });
 
   it("is deterministic", () => {

--- a/client/src/lib/calibrate/template.ts
+++ b/client/src/lib/calibrate/template.ts
@@ -1,87 +1,123 @@
 import { ARUCO_4X4_MODULES, markerBits } from "./aruco-4x4";
 
-/**
- * The printable auto-calibration sheet: four ArUco markers at precisely known
- * centre-to-centre distances. Photograph a tool lying on the printed sheet and
- * the detector (opencv.js `ArucoDetector`) can recover millimetres-per-pixel
- * without the manual ruler flow.
- *
- * Geometry: marker centres sit on a 150 × 200 mm rectangle around the page
- * centre — a 3-4-5 triangle, so the diagonals are exactly 250 mm and the
- * numbers double as a self-check. IDs are fixed per corner, which lets the
- * solver identify orientation however the sheet is rotated in the photo:
- *
- *     A4:     id 0 ── top left        id 1 ── top right
- *             id 3 ── bottom left     id 2 ── bottom right
- *
- *     Letter: id 4 ── top left        id 5 ── top right
- *             id 7 ── bottom left     id 6 ── bottom right
- *
- * Distinct marker families let the detector infer the paper size rather than
- * asking the user which sheet was printed.
- *
- * The SVG's user unit is the millimetre (`width="210mm"` + matching viewBox),
- * so any browser or slicer printing at 100% produces true-size markers; the
- * 100 mm verification bar makes a wrong printer scale obvious before it can
- * poison every measurement taken from the sheet.
- */
-
+/** Physical paper sizes supported by printed calibration sheets. */
 export type TemplatePaper = "a4" | "letter";
+
+/**
+ * Stable sheets remain the default. Experimental sheets move smaller markers
+ * toward the paper corners to enlarge the useful photography area and improve
+ * the perspective baseline.
+ */
+export type TemplateVariant =
+  | TemplatePaper
+  | "a4-experimental"
+  | "letter-experimental";
+
+export const TEMPLATE_VARIANTS: readonly TemplateVariant[] = [
+  "a4",
+  "letter",
+  "a4-experimental",
+  "letter-experimental",
+];
 
 /** Printed and machine-readable template generation. */
 export const TEMPLATE_SIGNATURE_VERSION = 2;
 
-/** Centre-to-centre marker spacing. 150-200-250: a 3-4-5 triangle. */
+/** Existing sheets use a 150-200-250 centre rectangle. */
 export const TEMPLATE_SPACING_MM = { width: 150, height: 200 } as const;
 
-/** Printed side length of one marker, border modules included. */
+/** Printed side length of one marker on the existing sheets. */
 export const TEMPLATE_MARKER_SIZE_MM = 30;
 
-/** Minimum clearance between printed calibration content and the paper edge. */
+/** Printed side length of one marker on the experimental sheets. */
+export const EXPERIMENTAL_TEMPLATE_MARKER_SIZE_MM = 24;
+
+/** Outer marker edges on experimental sheets are this far from the paper. */
+export const EXPERIMENTAL_TEMPLATE_OUTER_MARGIN_MM = 12;
+
+/** Minimum clearance used by the existing printable calibration content. */
 export const TEMPLATE_PRINT_SAFE_MARGIN_MM = 8;
 
-/** Header baselines; A4 uses its extra height to leave more marker clearance. */
+/** Corner assignment, clockwise from top-left, unique to every sheet. */
+export const TEMPLATE_MARKER_IDS: Record<
+  TemplateVariant,
+  readonly [number, number, number, number]
+> = {
+  a4: [0, 1, 2, 3],
+  letter: [4, 5, 6, 7],
+  "a4-experimental": [8, 9, 10, 11],
+  "letter-experimental": [12, 13, 14, 15],
+};
+
+export const ALL_TEMPLATE_MARKER_IDS = Object.values(TEMPLATE_MARKER_IDS).flat();
+
+export const TEMPLATE_PAPER_MM: Record<
+  TemplatePaper,
+  { width: number; height: number }
+> = {
+  a4: { width: 210, height: 297 },
+  letter: { width: 215.9, height: 279.4 },
+};
+
+export function isExperimentalTemplate(template: TemplateVariant): boolean {
+  return template.endsWith("-experimental");
+}
+
+export function templatePaper(template: TemplateVariant): TemplatePaper {
+  return template.startsWith("a4") ? "a4" : "letter";
+}
+
+export function templateDisplayName(template: TemplateVariant): string {
+  const paper = templatePaper(template) === "a4" ? "A4" : "US Letter";
+  return isExperimentalTemplate(template) ? `${paper} experimental` : paper;
+}
+
+export function templateMarkerSizeMm(template: TemplateVariant): number {
+  return isExperimentalTemplate(template)
+    ? EXPERIMENTAL_TEMPLATE_MARKER_SIZE_MM
+    : TEMPLATE_MARKER_SIZE_MM;
+}
+
+/** Header baselines in millimetres from the top of the page. */
 export function templateHeaderBaselinesMm(
-  paper: TemplatePaper,
+  template: TemplateVariant,
 ): { title: number; instructions: number } {
-  if (paper === "a4") {
+  if (isExperimentalTemplate(template)) {
+    return { title: 16, instructions: 23 };
+  }
+  if (template === "a4") {
     return {
       title: TEMPLATE_PRINT_SAFE_MARGIN_MM + 7,
       instructions: TEMPLATE_PRINT_SAFE_MARGIN_MM + 14,
     };
   }
   const markerTop =
-    templateMarkerCentersMm(paper)[0].y - TEMPLATE_MARKER_SIZE_MM / 2;
+    templateMarkerCentersMm(template)[0].y - TEMPLATE_MARKER_SIZE_MM / 2;
   return { title: markerTop - 8, instructions: markerTop - 2 };
 }
 
-/** Corner assignment, clockwise from top-left, unique to each paper size. */
-export const TEMPLATE_MARKER_IDS: Record<
-  TemplatePaper,
-  readonly [number, number, number, number]
-> = {
-  a4: [0, 1, 2, 3],
-  letter: [4, 5, 6, 7],
-};
-
-export const ALL_TEMPLATE_MARKER_IDS = Object.values(TEMPLATE_MARKER_IDS).flat();
-
-export const TEMPLATE_PAPER_MM: Record<TemplatePaper, { width: number; height: number }> =
-  {
-    a4: { width: 210, height: 297 },
-    letter: { width: 215.9, height: 279.4 },
-  };
-
-/** Marker centre positions in page millimetres, in `TEMPLATE_MARKER_IDS` order. */
+/** Marker centre positions in page millimetres, in marker-id order. */
 export function templateMarkerCentersMm(
-  paper: TemplatePaper,
+  template: TemplateVariant,
 ): { id: number; x: number; y: number }[] {
-  const page = TEMPLATE_PAPER_MM[paper];
+  const page = TEMPLATE_PAPER_MM[templatePaper(template)];
+  const ids = TEMPLATE_MARKER_IDS[template];
+  if (isExperimentalTemplate(template)) {
+    const inset =
+      EXPERIMENTAL_TEMPLATE_OUTER_MARGIN_MM +
+      EXPERIMENTAL_TEMPLATE_MARKER_SIZE_MM / 2;
+    return [
+      { id: ids[0], x: inset, y: inset },
+      { id: ids[1], x: page.width - inset, y: inset },
+      { id: ids[2], x: page.width - inset, y: page.height - inset },
+      { id: ids[3], x: inset, y: page.height - inset },
+    ];
+  }
+
   const cx = page.width / 2;
   const cy = page.height / 2;
   const dx = TEMPLATE_SPACING_MM.width / 2;
   const dy = TEMPLATE_SPACING_MM.height / 2;
-  const ids = TEMPLATE_MARKER_IDS[paper];
   return [
     { id: ids[0], x: cx - dx, y: cy - dy },
     { id: ids[1], x: cx + dx, y: cy - dy },
@@ -90,12 +126,27 @@ export function templateMarkerCentersMm(
   ];
 }
 
+export function templateMarkerSpacingMm(
+  template: TemplateVariant,
+): { width: number; height: number } {
+  const [topLeft, topRight, , bottomLeft] = templateMarkerCentersMm(template);
+  return {
+    width: topRight.x - topLeft.x,
+    height: bottomLeft.y - topLeft.y,
+  };
+}
+
+/** Compact human-readable millimetres without binary floating-point noise. */
+export function formatTemplateMm(value: number): string {
+  return Number(value.toFixed(4)).toString();
+}
+
 /** Known physical corners for every printed marker, in detector order. */
 export function templateMarkerCornersMm(
-  paper: TemplatePaper,
+  template: TemplateVariant,
 ): { id: number; corners: readonly { x: number; y: number }[] }[] {
-  const half = TEMPLATE_MARKER_SIZE_MM / 2;
-  return templateMarkerCentersMm(paper).map(({ id, x, y }) => ({
+  const half = templateMarkerSizeMm(template) / 2;
+  return templateMarkerCentersMm(template).map(({ id, x, y }) => ({
     id,
     corners: [
       { x: x - half, y: y - half },
@@ -106,21 +157,55 @@ export function templateMarkerCornersMm(
   }));
 }
 
-/** Identifies one Pocketry v2 template only from its complete four-marker signature. */
-export function paperFromTemplateMarkerIds(
+/** Identifies one Pocketry v2 sheet only from its complete marker signature. */
+export function templateFromTemplateMarkerIds(
   ids: readonly number[],
-): TemplatePaper | null {
-  const known = [...new Set(ids.filter((id) => ALL_TEMPLATE_MARKER_IDS.includes(id)))];
+): TemplateVariant | null {
+  const known = [
+    ...new Set(ids.filter((id) => ALL_TEMPLATE_MARKER_IDS.includes(id))),
+  ];
   if (known.length !== 4) return null;
-  const matches = (Object.keys(TEMPLATE_MARKER_IDS) as TemplatePaper[]).filter(
-    (paper) => TEMPLATE_MARKER_IDS[paper].every((id) => known.includes(id)),
+  const matches = TEMPLATE_VARIANTS.filter((template) =>
+    TEMPLATE_MARKER_IDS[template].every((id) => known.includes(id)),
   );
   return matches.length === 1 ? matches[0] : null;
 }
 
+/** Backwards-compatible physical-paper lookup for a complete signature. */
+export function paperFromTemplateMarkerIds(
+  ids: readonly number[],
+): TemplatePaper | null {
+  const template = templateFromTemplateMarkerIds(ids);
+  return template ? templatePaper(template) : null;
+}
+
+export interface TemplateVerificationBar {
+  startX: number;
+  endX: number;
+  y: number;
+  labelY: number;
+}
+
+/** Exact 100 mm verification line geometry for SVG and PDF output. */
+export function templateVerificationBarMm(
+  template: TemplateVariant,
+): TemplateVerificationBar {
+  const page = TEMPLATE_PAPER_MM[templatePaper(template)];
+  const centerX = page.width / 2;
+  const y = isExperimentalTemplate(template)
+    ? page.height - EXPERIMENTAL_TEMPLATE_OUTER_MARGIN_MM - 4
+    : page.height - TEMPLATE_PRINT_SAFE_MARGIN_MM;
+  return { startX: centerX - 50, endX: centerX + 50, y, labelY: y - 6 };
+}
+
 /** One marker as SVG: black square with the pattern's white cells punched in. */
-function markerSvg(id: number, centerX: number, centerY: number): string {
-  const size = TEMPLATE_MARKER_SIZE_MM;
+function markerSvg(
+  id: number,
+  centerX: number,
+  centerY: number,
+  size: number,
+  labelY: number,
+): string {
   const module = size / ARUCO_4X4_MODULES;
   const originX = centerX - size / 2;
   const originY = centerY - size / 2;
@@ -133,45 +218,66 @@ function markerSvg(id: number, centerX: number, centerY: number): string {
   for (let row = 0; row < 4; row++) {
     for (let col = 0; col < 4; col++) {
       if (!bits[row][col]) continue;
-      // +1: the outer ring of modules is the black border.
       const x = originX + (col + 1) * module;
       const y = originY + (row + 1) * module;
-      parts.push(`<rect x="${x}" y="${y}" width="${module}" height="${module}" fill="#fff"/>`);
+      parts.push(
+        `<rect x="${x}" y="${y}" width="${module}" height="${module}" fill="#fff"/>`,
+      );
     }
   }
   parts.push(
-    `<text x="${centerX}" y="${originY + size + 5}" text-anchor="middle" font-size="3.5" fill="#333" font-family="sans-serif">id ${id}</text>`,
+    `<text x="${centerX}" y="${labelY}" text-anchor="middle" font-size="3.5" fill="#333" font-family="sans-serif">id ${id}</text>`,
     `</g>`,
   );
   return parts.join("");
 }
 
 /** The complete printable sheet. */
-export function calibrationTemplateSvg(paper: TemplatePaper): string {
+export function calibrationTemplateSvg(template: TemplateVariant): string {
+  const paper = templatePaper(template);
   const page = TEMPLATE_PAPER_MM[paper];
-  const centers = templateMarkerCentersMm(paper);
-  const header = templateHeaderBaselinesMm(paper);
+  const centers = templateMarkerCentersMm(template);
+  const header = templateHeaderBaselinesMm(template);
+  const markerSize = templateMarkerSizeMm(template);
+  const experimental = isExperimentalTemplate(template);
   const cx = page.width / 2;
 
-  const markers = centers.map(({ id, x, y }) => markerSvg(id, x, y)).join("\n  ");
+  const markers = centers
+    .map(({ id, x, y }, index) => {
+      const originY = y - markerSize / 2;
+      const labelY =
+        experimental && index >= 2
+          ? originY - 3
+          : originY + markerSize + 5;
+      return markerSvg(id, x, y, markerSize, labelY);
+    })
+    .join("\n  ");
 
-  // 100 mm verification bar, centred and kept inside common printer margins.
-  const rulerY = page.height - TEMPLATE_PRINT_SAFE_MARGIN_MM;
-  const rulerX = cx - 50;
+  const ruler = templateVerificationBarMm(template);
   const ticks = Array.from({ length: 11 }, (_, i) => {
-    const x = rulerX + i * 10;
-    return `<line x1="${x}" y1="${rulerY}" x2="${x}" y2="${rulerY - (i % 5 === 0 ? 4 : 2.5)}" stroke="#000" stroke-width="0.3"/>`;
+    const x = ruler.startX + i * 10;
+    return `<line x1="${x}" y1="${ruler.y}" x2="${x}" y2="${ruler.y - (i % 5 === 0 ? 4 : 2.5)}" stroke="#000" stroke-width="0.3"/>`;
   }).join("");
+  const title = experimental
+    ? `Pocketry v${TEMPLATE_SIGNATURE_VERSION} experimental — ${paper === "a4" ? "A4" : "US Letter"} — print at 100% scale`
+    : `Pocketry v${TEMPLATE_SIGNATURE_VERSION} calibration sheet — print at 100% scale (no “fit to page”)`;
+  const instructions = experimental
+    ? "Keep all four markers visible · camera 1× · shoot straight down"
+    : "Place the tool between the markers, keep all four visible, shoot from directly above.";
+  const spacing = templateMarkerSpacingMm(template);
+  const check = experimental
+    ? `check: this bar is exactly 100 mm — marker centres ${formatTemplateMm(spacing.width)} × ${formatTemplateMm(spacing.height)} mm`
+    : "check: this bar is exactly 100 mm — marker centres 150 × 200 mm, diagonals 250 mm";
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${page.width}mm" height="${page.height}mm" viewBox="0 0 ${page.width} ${page.height}">
   <rect width="${page.width}" height="${page.height}" fill="#fff"/>
-  <text x="${cx}" y="${header.title}" text-anchor="middle" font-size="5" font-family="sans-serif" fill="#000">Pocketry v${TEMPLATE_SIGNATURE_VERSION} calibration sheet — print at 100% scale (no “fit to page”)</text>
-  <text x="${cx}" y="${header.instructions}" text-anchor="middle" font-size="3.5" font-family="sans-serif" fill="#333">Place the tool between the markers, keep all four visible, shoot from directly above.</text>
+  <text x="${cx}" y="${header.title}" text-anchor="middle" font-size="${experimental ? 4 : 5}" font-family="sans-serif" fill="#000">${title}</text>
+  <text x="${cx}" y="${header.instructions}" text-anchor="middle" font-size="${experimental ? 3 : 3.5}" font-family="sans-serif" fill="#333">${instructions}</text>
   ${markers}
   <g>
-    <line x1="${rulerX}" y1="${rulerY}" x2="${rulerX + 100}" y2="${rulerY}" stroke="#000" stroke-width="0.5"/>
+    <line x1="${ruler.startX}" y1="${ruler.y}" x2="${ruler.endX}" y2="${ruler.y}" stroke="#000" stroke-width="0.5"/>
     ${ticks}
-    <text x="${cx}" y="${rulerY - 6}" text-anchor="middle" font-size="3.5" font-family="sans-serif" fill="#333">check: this bar is exactly 100 mm — marker centres 150 × 200 mm, diagonals 250 mm</text>
+    <text x="${cx}" y="${ruler.labelY}" text-anchor="middle" font-size="3.5" font-family="sans-serif" fill="#333">${check}</text>
   </g>
 </svg>
 `;

--- a/client/src/lib/image-processor.test.ts
+++ b/client/src/lib/image-processor.test.ts
@@ -200,12 +200,46 @@ describe("processImage: margins", () => {
     expect(adjusted[0].holes).toEqual([]);
     expect(after.maxX - after.minX).toBeGreaterThan(before.maxX - before.minX);
   });
+
+  it("can remove the full applied margin by selecting zero", async () => {
+    const plain = await processImage(photo(200, 180, pliers), { detect: JS });
+    const margined = await processImage(photo(200, 180, pliers), {
+      detect: JS,
+      margin: 1.5,
+      calibration: {
+        startX: 0,
+        startY: 0,
+        endX: 100,
+        endY: 0,
+        lengthMm: 50,
+      },
+    });
+    const restored = await adjustOutlineMargin(
+      margined.outline,
+      1.5,
+      0,
+      {
+        startX: 0,
+        startY: 0,
+        endX: 100,
+        endY: 0,
+        lengthMm: 50,
+      },
+    );
+
+    const plainBounds = outlineBounds(plain.outline)!;
+    const restoredBounds = outlineBounds(restored)!;
+    expect(restoredBounds.minX).toBeCloseTo(plainBounds.minX, 1);
+    expect(restoredBounds.maxX).toBeCloseTo(plainBounds.maxX, 1);
+    expect(restoredBounds.minY).toBeCloseTo(plainBounds.minY, 1);
+    expect(restoredBounds.maxY).toBeCloseTo(plainBounds.maxY, 1);
+  });
 });
 
 describe("marginToPixels", () => {
-  it("offers 0.5-5.0 mm in 0.5 mm steps", () => {
+  it("offers 0.0-5.0 mm in 0.5 mm steps", () => {
     expect(MARGIN_MM_OPTIONS).toEqual([
-      0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5,
+      0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5,
     ]);
   });
 
@@ -245,7 +279,7 @@ describe("marginToPixels", () => {
       endY: 0,
       lengthMm: 100,
     };
-    expect(marginToPixels(0.5, calibration)).toBeCloseTo(1, 6);
+    expect(marginToPixels(0, calibration)).toBe(0);
     expect(marginToPixels(5, calibration)).toBeCloseTo(10, 6);
   });
 });

--- a/client/src/lib/image-processor.ts
+++ b/client/src/lib/image-processor.ts
@@ -27,7 +27,7 @@ export type { Point, Outline };
 
 /** The physical clearance choices exposed by the Trace workspace, in mm. */
 export const MARGIN_MM_OPTIONS = [
-  0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5,
+  0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5,
 ] as const;
 
 /** The clearance selected when a Trace image first receives a valid scale. */

--- a/client/src/pages/trace.test.tsx
+++ b/client/src/pages/trace.test.tsx
@@ -198,10 +198,28 @@ describe("Trace detection workflow", () => {
           '[data-testid="empty-state-template-letter"]',
         )
         ?.click();
+      host
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="empty-state-template-a4-experimental"]',
+        )
+        ?.click();
+      host
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="empty-state-template-letter-experimental"]',
+        )
+        ?.click();
     });
 
     expect(downloadCalibrationTemplateMock).toHaveBeenNthCalledWith(1, "a4");
     expect(downloadCalibrationTemplateMock).toHaveBeenNthCalledWith(2, "letter");
+    expect(downloadCalibrationTemplateMock).toHaveBeenNthCalledWith(
+      3,
+      "a4-experimental",
+    );
+    expect(downloadCalibrationTemplateMock).toHaveBeenNthCalledWith(
+      4,
+      "letter-experimental",
+    );
   });
 
   it("keeps the current photo visible until its replacement is decoded", async () => {

--- a/client/src/pages/trace.tsx
+++ b/client/src/pages/trace.tsx
@@ -34,7 +34,11 @@ import {
   type PerspectiveProposal,
 } from "@/lib/calibrate/perspective";
 import { SKEW_WARN_FRACTION } from "@/lib/calibrate/solve";
-import type { TemplatePaper } from "@/lib/calibrate/template";
+import {
+  templateDisplayName,
+  templatePaper,
+  type TemplateVariant,
+} from "@/lib/calibrate/template";
 import { downloadBlob } from "@/lib/download";
 import { generateDXF } from "@/lib/export/dxf";
 import { exportScale } from "@/lib/export/scale";
@@ -225,8 +229,8 @@ function TraceWorkspace(): JSX.Element {
             });
             const { solution } = result;
             const mmPerPx = mmPerPixel(calibration);
-            const paperName = result.paper === "a4" ? "A4" : "US Letter";
-            const summary = `${paperName} · ${solution.markerIds.length} markers · ${(mmPerPx ?? solution.mmPerPx).toFixed(3)} mm/px`;
+            const sheetName = templateDisplayName(result.template);
+            const summary = `${sheetName} · ${solution.markerIds.length} markers · ${(mmPerPx ?? solution.mmPerPx).toFixed(3)} mm/px`;
             if (solution.maxDeviation > SKEW_WARN_FRACTION) {
               toast({
                 title: "Scale detected — review carefully",
@@ -288,7 +292,7 @@ function TraceWorkspace(): JSX.Element {
   );
 
   const applyPerspective = useCallback(
-    async (proposal: PerspectiveProposal, paper: TemplatePaper) => {
+    async (proposal: PerspectiveProposal, template: TemplateVariant) => {
       const frame = getDetectionFrame();
       if (
         !frame ||
@@ -315,7 +319,7 @@ function TraceWorkspace(): JSX.Element {
         const corrected = await correctPerspective(
           frame.imageData,
           detectionProposal,
-          paper,
+          template,
         );
         if (activeImageUrlRef.current !== frame.sourceImageUrl) return;
         const imageUrl = imageDataToPngUrl(corrected.imageData);
@@ -326,11 +330,12 @@ function TraceWorkspace(): JSX.Element {
           imageSize: { width: corrected.width, height: corrected.height },
           calibration: corrected.calibration,
           source: proposal.source,
-          paper,
+          paper: templatePaper(template),
+          template,
         });
         toast({
           title: "Perspective corrected",
-          description: `${paper === "a4" ? "A4" : "US Letter"} plane rectified at ${(1 / corrected.pxPerMm).toFixed(3)} mm/px${corrected.reprojectionErrorPx === null ? "" : ` · ${corrected.reprojectionErrorPx.toFixed(2)} px fit residual`}.`,
+          description: `${templateDisplayName(template)} plane rectified at ${(1 / corrected.pxPerMm).toFixed(3)} mm/px${corrected.reprojectionErrorPx === null ? "" : ` · ${corrected.reprojectionErrorPx.toFixed(2)} px fit residual`}.`,
         });
       } catch (error) {
         if (activeImageUrlRef.current !== frame.sourceImageUrl) return;
@@ -544,6 +549,32 @@ function TraceWorkspace(): JSX.Element {
                   <strong className="font-semibold italic">or</strong>{" "}
                   plain background that contrasts with it, and keep the whole
                   tool in frame.
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Experimental sheets place smaller markers nearer the page
+                  corners: {" "}
+                  <button
+                    type="button"
+                    className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                    onClick={() =>
+                      downloadCalibrationTemplate("a4-experimental")
+                    }
+                    data-testid="empty-state-template-a4-experimental"
+                  >
+                    A4 experimental
+                  </button>{" "}
+                  or {" "}
+                  <button
+                    type="button"
+                    className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                    onClick={() =>
+                      downloadCalibrationTemplate("letter-experimental")
+                    }
+                    data-testid="empty-state-template-letter-experimental"
+                  >
+                    US Letter experimental
+                  </button>
+                  .
                 </p>
                 {dropzone}
               </div>

--- a/client/src/state/trace-store.test.ts
+++ b/client/src/state/trace-store.test.ts
@@ -747,6 +747,23 @@ describe("modes and calibration", () => {
     expect(state.margin).toBe(2.5);
   });
 
+  it("preserves an explicit zero margin when the scale is replaced", () => {
+    const calibration = {
+      startX: 0,
+      startY: 0,
+      endX: 100,
+      endY: 0,
+      lengthMm: 50,
+    };
+    const state = run(
+      initialTraceState,
+      { type: "SET_CALIBRATION", calibration },
+      { type: "SET_MARGIN", margin: 0 },
+      { type: "SET_CALIBRATION", calibration: { ...calibration, lengthMm: 75 } },
+    );
+    expect(state.margin).toBe(0);
+  });
+
   it("updates mm/px when a completed manual ruler length changes", () => {
     const calibration = {
       startX: 0,

--- a/client/src/state/trace-store.tsx
+++ b/client/src/state/trace-store.tsx
@@ -20,7 +20,10 @@ import type {
   PerspectiveQuad,
   PerspectiveSource,
 } from "@/lib/calibrate/perspective";
-import type { TemplatePaper } from "@/lib/calibrate/template";
+import type {
+  TemplatePaper,
+  TemplateVariant,
+} from "@/lib/calibrate/template";
 import {
   combineImageRotations,
   fitImageWithin,
@@ -54,7 +57,13 @@ import { DEFAULT_MARGIN_MM, type Margin } from "@/lib/image-processor";
  */
 
 /** Exactly one interaction mode is active at a time. */
-export type TraceMode = "pan" | "region" | "edit" | "calibrate" | "perspective";
+export type TraceMode =
+  | "pan"
+  | "region"
+  | "edit"
+  | "calibrate"
+  | "measure"
+  | "perspective";
 
 export type ExportFormat = "svg" | "dxf" | "dwg" | "stl";
 export type CalibrationSource = "manual" | "sheet";
@@ -121,6 +130,7 @@ export interface TraceState {
   perspectiveCorrection: {
     source: PerspectiveSource;
     paper: TemplatePaper;
+    template?: TemplateVariant;
   } | null;
 
   region: Rect | null;
@@ -238,6 +248,7 @@ export type TraceAction =
       calibration: Calibration;
       source: PerspectiveSource;
       paper: TemplatePaper;
+      template?: TemplateVariant;
     }
   | { type: "RESTORE_PERSPECTIVE_SOURCE" }
   | { type: "SET_EXPORT_FORMAT"; exportFormat: ExportFormat }
@@ -761,7 +772,11 @@ export function traceReducer(state: TraceState, action: TraceAction): TraceState
           state.perspectiveOriginalImageUrl ?? state.imageUrl,
         perspectiveOriginalImageRotation:
           state.perspectiveOriginalImageRotation ?? state.imageRotation,
-        perspectiveCorrection: { source: action.source, paper: action.paper },
+        perspectiveCorrection: {
+          source: action.source,
+          paper: action.paper,
+          ...(action.template ? { template: action.template } : {}),
+        },
         mode: "region",
         exportFormat: state.exportFormat,
         extrusionHeight: state.extrusionHeight,

--- a/scripts/generate-calibration-templates.ts
+++ b/scripts/generate-calibration-templates.ts
@@ -2,11 +2,12 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
 import { calibrationTemplatePdf } from "../client/src/lib/calibrate/template-pdf";
+import { TEMPLATE_VARIANTS } from "../client/src/lib/calibrate/template";
 
 const outputDirectory = resolve("output/pdf");
 await mkdir(outputDirectory, { recursive: true });
 
-for (const paper of ["a4", "letter"] as const) {
+for (const paper of TEMPLATE_VARIANTS) {
   await writeFile(
     resolve(outputDirectory, `pocketry-calibration-${paper}.pdf`),
     calibrationTemplatePdf(paper),


### PR DESCRIPTION
## Summary
- separate scale-setting from reusable distance measurement on Trace, with persistent editable ruler points and corrected tooltip placement
- add an explicit 0.0 mm Trace margin that removes prior contour offset and survives scale changes
- add experimental A4 and US Letter calibration sheets with 24 mm corner markers, distinct signed IDs, and a 100 mm check line between the lower markers
- carry stable versus experimental geometry through auto-detection, scale solving, and perspective correction while preserving the existing sheets

## Verification
- npm test (69 files, 916 tests)
- npm run check
- npm run build
- rendered and visually inspected all four generated calibration PDFs
- verified current and experimental download controls in the live Trace UI on port 5001