### PR TITLE
Remove AdSense and Replit remnants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@ exports/
 output/pdf/
 
 # Legacy scaffold and pasted-session artifacts
-.replit
-replit.md
 attached_assets/
 generated-icon.png
 vite.config.ts.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ No linter is configured yet (prefer ESLint when one lands).
 - Shared validation lives in `shared/schema.ts` as Zod schemas derived from Drizzle tables (`drizzle-zod`); never duplicate validation logic client- or server-side.
 - Storage access goes through the `IStorage` interface in `server/storage.ts` — do not reach around it to Drizzle directly from routes.
 - UI: compose shadcn/ui components from `client/src/components/ui`; TailwindCSS for styling, with the shadcn design tokens defined as CSS variables at the top of `client/src/index.css`; `lucide-react` for icons.
-- No Replit-specific tooling. The app builds and runs anywhere with plain Node — do not reintroduce `@replit/*` plugins or a `theme.json`.
+- Keep build tooling platform-independent. The app builds and runs anywhere with plain Node; do not add hosted-IDE-specific build plugins or theme configuration.
 - Server state via TanStack Query; local state via React hooks; routing via wouter.
 - Image processing runs client-side (canvas + OpenCV.js); keep heavy processing off the server.
 - Detection has **one** pipeline (`lib/detect/pipeline.ts`) with two interchangeable

--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <title>Pocketry - Tool Cutout and Gridfinity Bin Designer</title>
-    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5836736537976040" crossorigin="anonymous"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/client/public/ads.txt
+++ b/client/public/ads.txt
@@ -1,2 +1,0 @@
-
-google.com, pub-5836736537976040, DIRECT, f08c47fec0942fa0

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,12 +5,8 @@
 /*
  * Design tokens for the shadcn/ui theme.
  *
- * These were previously generated at build time from `theme.json` by
- * `@replit/vite-plugin-shadcn-theme-json`, which injected them as an inline
- * <style> tag. That plugin has been removed so the app builds without any
- * Replit-specific tooling; the values below are the exact output it produced
- * for the "professional" variant (primary hsl(222.2 47.4% 11.2%), radius 0.5).
- * Edit them here directly.
+ * These values are maintained directly so the application's theme remains
+ * explicit and portable across build environments.
  */
 :root {
   --background: 0 0% 100%;

--- a/docs/open-source-review.md
+++ b/docs/open-source-review.md
@@ -61,8 +61,8 @@ smoothing, marching squares, Otsu thresholding, DXF, STL, SVG, and 3MF—do not
 carry evidence of copied implementations. The implementations in this tree
 appear project-authored and contain no external source or licence markers.
 
-A repository-hygiene follow-up removed the unreferenced Replit configuration
-and notes, pasted-session `attached_assets/`, root `generated-icon.png`, and an
+A repository-hygiene follow-up removed obsolete scaffold configuration and
+notes, pasted-session `attached_assets/`, root `generated-icon.png`, and an
 unused deprecated point-simplifier compatibility shim. The pasted images and
 prototype material were not shipped by the application and had no confirmed
 provenance, so removing them also eliminated an unnecessary public-release


### PR DESCRIPTION
## Summary

- remove the AdSense loader and publisher authorization file
- remove remaining Replit-specific documentation and historical comments
- keep the platform-independence guidance in generic terms

## Verification

- npm run check
- npm test (69 files, 916 tests passed)
- npm run build
- git diff --check
- full working-tree residue scan for AdSense and Replit identifiers