### PR TITLE
Fix non-manifold edges in 3MF exports

### DIFF
--- a/client/src/lib/mesh/threemf.test.ts
+++ b/client/src/lib/mesh/threemf.test.ts
@@ -1,6 +1,9 @@
 import { strFromU8, unzipSync } from "fflate";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { parseBinSpec } from "@shared/gridfinity/types";
+
+import { buildBinWithCutouts } from "@/lib/gridfinity/bin";
 import { Arena } from "@/lib/manifold/arena";
 import { createKernel, loadManifold, type Kernel } from "@/lib/manifold/runtime";
 
@@ -35,6 +38,30 @@ function unzipModel(file: Uint8Array): {
   };
 }
 
+function objectEdgeCounts(model: string, name: string): number[] {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const object = model.match(
+    new RegExp(`<object[^>]*name="${escapedName}"[^>]*>([\\s\\S]*?)<\\/object>`),
+  )?.[1];
+  if (!object) throw new Error(`Missing 3MF object ${name}`);
+
+  const edgeCounts = new Map<string, number>();
+  for (const match of object.matchAll(
+    /<triangle v1="(\d+)" v2="(\d+)" v3="(\d+)"\/>/g,
+  )) {
+    const triangle = match.slice(1).map(Number);
+    for (const [a, b] of [
+      [triangle[0], triangle[1]],
+      [triangle[1], triangle[2]],
+      [triangle[2], triangle[0]],
+    ]) {
+      const key = a < b ? `${a}:${b}` : `${b}:${a}`;
+      edgeCounts.set(key, (edgeCounts.get(key) ?? 0) + 1);
+    }
+  }
+  return [...edgeCounts.values()];
+}
+
 const TRIANGLE: ThreeMfObject = {
   name: "tri",
   mesh: {
@@ -65,36 +92,78 @@ describe("writeThreeMf", () => {
     expect(model.match(/<item objectid="1"\/>/g)).toHaveLength(1);
   });
 
-  it("welds vertices duplicated for sharp preview normals", () => {
-    const cube = arena.track(kernel.Manifold.cube([2, 3, 4], false));
-    const mesh = extractMeshData(kernel, cube, { normals: true });
-    expect(mesh.positions.length / 3).toBeGreaterThan(8);
+  it("preserves vertex identities when closed components touch along an edge", () => {
+    const mesh = {
+      // Two closed tetrahedra intentionally use distinct indices for the same
+      // first edge. Welding vertices 4→0 and 5→1 would give that edge four
+      // incident faces, matching the defect Bambu reported on a 4×4 bin.
+      positions: [
+        0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1,
+        0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0, -1,
+      ],
+      indices: [
+        0, 2, 1, 0, 1, 3, 1, 2, 3, 2, 0, 3,
+        4, 6, 5, 4, 5, 7, 5, 6, 7, 6, 4, 7,
+      ],
+    };
 
-    const { model } = unzipModel(writeThreeMf([{ name: "creased cube", mesh }]));
+    const { model } = unzipModel(writeThreeMf([{ name: "touching tetrahedra", mesh }]));
     expect(model.match(/<vertex /g)).toHaveLength(8);
-    expect(model.match(/<triangle /g)).toHaveLength(12);
+    expect(model.match(/<triangle /g)).toHaveLength(8);
 
-    const edgeCounts = new Map<string, number>();
-    for (const match of model.matchAll(
-      /<triangle v1="(\d+)" v2="(\d+)" v3="(\d+)"\/>/g,
-    )) {
-      const triangle = match.slice(1).map(Number);
-      for (const [a, b] of [
-        [triangle[0], triangle[1]],
-        [triangle[1], triangle[2]],
-        [triangle[2], triangle[0]],
-      ]) {
-        const key = a < b ? `${a}:${b}` : `${b}:${a}`;
-        edgeCounts.set(key, (edgeCounts.get(key) ?? 0) + 1);
-      }
-    }
-    expect([...edgeCounts.values()].every((count) => count === 2)).toBe(true);
+    expect(
+      objectEdgeCounts(model, "touching tetrahedra").every((count) => count === 2),
+    ).toBe(true);
   });
 
-  it("writes compact 1e-4 mm coordinates", () => {
+  it("keeps a 4x4 multicolor bin body manifold after serialization", () => {
+    const spec = parseBinSpec({ gridX: 4, gridY: 4, heightUnits: 6.5 });
+    const { materialParts } = buildBinWithCutouts(
+      kernel,
+      spec,
+      null,
+      { circularSegments: 32 },
+      { rimInsertThicknessMm: 0.6 },
+    );
+    expect(materialParts?.stackingRim).not.toBeNull();
+
+    const body = extractMeshData(kernel, materialParts!.body);
+    const rim = extractMeshData(kernel, materialParts!.stackingRim!);
+    const bytes = writeThreeMf(
+      [
+        { name: "4x4 body", mesh: body },
+        { name: "4x4 rim", mesh: rim },
+      ],
+      { assemble: true },
+    );
+    const { model } = unzipModel(bytes);
+
+    expect(objectEdgeCounts(model, "4x4 body").every((count) => count === 2)).toBe(
+      true,
+    );
+  });
+
+  it("writes compact round-trippable coordinates", () => {
     const { model } = unzipModel(writeThreeMf([TRIANGLE]));
     expect(model).toContain('<vertex x="0" y="0" z="41.75"/>');
-    expect(model).toContain('<vertex x="0.5" y="1.2346" z="2"/>');
+    expect(model).toContain('<vertex x="0.5" y="1.23456" z="2"/>');
+  });
+
+  it("does not collapse small but distinct coordinates", () => {
+    const { model } = unzipModel(
+      writeThreeMf([
+        {
+          name: "small triangle",
+          mesh: {
+            positions: [0, 0, 0, 0.00001, 0, 0, 0, 0.00001, 0],
+            indices: [0, 1, 2],
+          },
+        },
+      ]),
+    );
+
+    expect(model).toContain('<vertex x="0.00001" y="0" z="0"/>');
+    expect(model).toContain('<vertex x="0" y="0.00001" z="0"/>');
   });
 
   it("emits one object and one build item per part (the multicolor hook)", () => {
@@ -226,14 +295,14 @@ describe("writeThreeMf", () => {
     expect(() =>
       writeThreeMf([
         {
-          name: "too small",
+          name: "degenerate",
           mesh: {
-            positions: [0, 0, 0, 0.00001, 0, 0, 0, 0.00001, 0],
-            indices: [0, 1, 2],
+            positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+            indices: [0, 0, 2],
           },
         },
       ]),
-    ).toThrow(/no triangles at 1e-4 mm precision/);
+    ).toThrow(/repeated vertex indices/);
     expect(() =>
       writeThreeMf([
         {

--- a/client/src/lib/mesh/threemf.ts
+++ b/client/src/lib/mesh/threemf.ts
@@ -12,9 +12,9 @@ import { strToU8, zipSync } from "fflate";
  * bin's tagged parts (base / wall / lip / infill) are exported separately, a
  * multi-material workflow needs no restructuring here.
  *
- * Coordinates are emitted in millimetres (`unit="millimeter"`), rounded to
- * 1e-4 mm — an order below any FDM printer's resolution, and it keeps files
- * compact. 3MF stores no normals; topology carries the shape.
+ * Coordinates are emitted in millimetres (`unit="millimeter"`) with enough
+ * significant digits to round-trip the Float32 geometry. 3MF stores no
+ * normals; topology carries the shape.
  */
 
 export interface ThreeMfMesh {
@@ -100,54 +100,27 @@ export function writeThreeMf(
 }
 
 /**
- * 3MF has no normals, so vertices duplicated solely to preserve preview
- * creases must share one exported index. Keying by the emitted coordinates
- * also prevents two equal serialized vertices from becoming an artificial
- * open seam in slicers such as Bambu Studio.
+ * Preserve the kernel's vertex identities exactly. Distinct closed components
+ * can legitimately touch along an edge or at a point. Welding equal positions
+ * across those components turns the shared edge into a four-face,
+ * non-manifold edge in slicers. Export callers therefore provide the kernel's
+ * topology mesh (without preview-only normal splits), and this boundary only
+ * converts coordinates to XML-safe strings.
  */
-function serializeMesh({ name, mesh }: ThreeMfObject): SerializedMesh {
+function serializeMesh({ mesh }: ThreeMfObject): SerializedMesh {
   const vertexCount = mesh.positions.length / 3;
-  const oldToNew = new Uint32Array(vertexCount);
   const vertices: [string, string, string][] = [];
-  const indexByPosition = new Map<string, number>();
 
-  for (let oldIndex = 0; oldIndex < vertexCount; oldIndex++) {
-    const offset = oldIndex * 3;
-    const vertex: [string, string, string] = [
+  for (let index = 0; index < vertexCount; index++) {
+    const offset = index * 3;
+    vertices.push([
       coord(mesh.positions[offset]),
       coord(mesh.positions[offset + 1]),
       coord(mesh.positions[offset + 2]),
-    ];
-    const key = vertex.join("\0");
-    let newIndex = indexByPosition.get(key);
-    if (newIndex === undefined) {
-      newIndex = vertices.length;
-      vertices.push(vertex);
-      indexByPosition.set(key, newIndex);
-    }
-    oldToNew[oldIndex] = newIndex;
+    ]);
   }
 
-  const indices: number[] = [];
-  for (let offset = 0; offset < mesh.indices.length; offset += 3) {
-    const v1 = oldToNew[mesh.indices[offset]];
-    const v2 = oldToNew[mesh.indices[offset + 1]];
-    const v3 = oldToNew[mesh.indices[offset + 2]];
-    if (v1 === v2 || v2 === v3 || v1 === v3) {
-      // The face has no printable area after coordinate quantization. Writing
-      // it would leave an invalid triangle in the archive, so omit it.
-      continue;
-    }
-    indices.push(v1, v2, v3);
-  }
-
-  if (indices.length === 0) {
-    throw new Error(
-      `writeThreeMf: "${name}" has no triangles at 1e-4 mm precision`,
-    );
-  }
-
-  return { vertices, indices };
+  return { vertices, indices: Array.from(mesh.indices) };
 }
 
 function validateMesh({ name, mesh }: ThreeMfObject): void {
@@ -158,10 +131,25 @@ function validateMesh({ name, mesh }: ThreeMfObject): void {
   if (mesh.indices.length === 0 || mesh.indices.length % 3 !== 0) {
     throw new Error(`writeThreeMf: "${name}" indices length ${mesh.indices.length} is not triangles`);
   }
+  for (const coordinate of mesh.positions) {
+    if (!Number.isFinite(coordinate)) {
+      throw new Error(`writeThreeMf: "${name}" has non-finite coordinate ${coordinate}`);
+    }
+  }
   const vertexCount = positionCount / 3;
-  for (const index of mesh.indices) {
+  for (let offset = 0; offset < mesh.indices.length; offset++) {
+    const index = mesh.indices[offset];
     if (!Number.isInteger(index) || index < 0 || index >= vertexCount) {
       throw new Error(`writeThreeMf: "${name}" triangle index ${index} out of range`);
+    }
+    if (offset % 3 === 2) {
+      const v1 = mesh.indices[offset - 2];
+      const v2 = mesh.indices[offset - 1];
+      if (v1 === v2 || v2 === index || v1 === index) {
+        throw new Error(
+          `writeThreeMf: "${name}" triangle has repeated vertex indices`,
+        );
+      }
     }
   }
 }
@@ -322,12 +310,12 @@ function buildBambuModelSettings(
   return parts.join("");
 }
 
-/** 1e-4 mm resolution, trailing zeros trimmed, "-0" normalised. */
+/** Nine significant digits round-trip every finite Float32 coordinate. */
 function coord(value: number): string {
   if (!Number.isFinite(value)) {
     throw new Error(`writeThreeMf: non-finite coordinate ${value}`);
   }
-  const text = value.toFixed(4).replace(/\.?0+$/, "");
+  const text = Number(value.toPrecision(9)).toString();
   return text === "-0" ? "0" : text;
 }
 


### PR DESCRIPTION
## Summary

- preserve geometry-kernel vertex identities during 3MF serialization
- stop coordinate rounding from collapsing small valid triangles
- reject repeated triangle indices at the writer boundary
- add touching-component and 4x4 multicolor-bin topology regressions

## Root cause

The previous Bambu repair globally welded vertices by emitted coordinates. That closed preview-normal seams, but it also merged intentionally separate closed components where Gridfinity geometry touches along an edge. Bambu then saw four incident faces on each welded edge and reported 12 non-manifold edges on the reported 4x4x6.5 body.

Export builds already request the kernel's topology mesh without preview normals. This change preserves that topology instead of welding it again.

## Verification

- `npm run check`
- `npm test` — 69 files, 921 tests passed
- `npm run build`
- `git diff --check`
- Bambu Studio 02.08.02.61 CLI on a generated 4x4 multicolor regression 3MF: `manifold = yes`

The pocket-floor material geometry is unchanged.
