### PR TITLE
Add finger-hole edge finishing controls

### DIFF
--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -28,6 +28,7 @@ import { useLocation } from "wouter";
 
 import {
   DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
+  DEFAULT_TOP_EDGE_FILLET_MM,
   MAX_OBLONG_DEEP_SCOOP_LENGTH_MM,
   MIN_OBLONG_DEEP_SCOOP_SPAN_MM,
   type FingerHole,
@@ -1122,7 +1123,7 @@ export function BinControlsPanel({
                 label="Top edge round"
                 value={selectedCutout.topFilletMm}
                 min={0}
-                max={3}
+                max={5}
                 step={0.2}
                 onChange={(topFilletMm, transient) =>
                   dispatch({
@@ -1187,6 +1188,8 @@ export function BinControlsPanel({
                       diameterMm: 18,
                       kind: "straight",
                       depthMm: 12,
+                      topFilletMm: DEFAULT_TOP_EDGE_FILLET_MM,
+                      bottomFilletMm: 0,
                     },
                   })
                 }
@@ -1500,6 +1503,44 @@ export function BinControlsPanel({
                       <span className="text-xs text-muted-foreground">°</span>
                     </div>
                   </div>
+                )}
+
+                <MmSlider
+                  label="Top edge round"
+                  value={selectedFingerHole.topFilletMm}
+                  min={0}
+                  max={5}
+                  step={0.2}
+                  onChange={(topFilletMm, transient) =>
+                    dispatch({
+                      type: "UPDATE_FINGER_HOLE",
+                      id: selectedFingerHole.id,
+                      patch: { topFilletMm },
+                      historyLabel: "Change finger hole top edge round",
+                      transient,
+                    })
+                  }
+                  hint="Rounds the opening into the bin's top surface."
+                />
+
+                {selectedFingerHole.kind === "straight" && (
+                  <MmSlider
+                    label="Bottom edge fillet"
+                    value={selectedFingerHole.bottomFilletMm}
+                    min={0}
+                    max={Math.min(4, selectedFingerHole.diameterMm / 2)}
+                    step={0.2}
+                    onChange={(bottomFilletMm, transient) =>
+                      dispatch({
+                        type: "UPDATE_FINGER_HOLE",
+                        id: selectedFingerHole.id,
+                        patch: { bottomFilletMm },
+                        historyLabel: "Change finger hole bottom fillet",
+                        transient,
+                      })
+                    }
+                    hint="Rounds the straight wall into its flat floor."
+                  />
                 )}
                 <p className="text-[11px] text-muted-foreground">
                   Drag the shape to move it. Drag the white size handle to change

--- a/client/src/components/trace/trace-controls-panel.test.tsx
+++ b/client/src/components/trace/trace-controls-panel.test.tsx
@@ -528,7 +528,7 @@ describe("TraceControlsPanel guided workflow", () => {
     expect(section("contours")).toBeNull();
     expect(
       section("detect")?.querySelector<HTMLButtonElement>("#margin")?.textContent,
-    ).toContain("1.5 mm");
+    ).toContain("0.5 mm");
     expect(section("detect")?.textContent).not.toContain(
       "Bin clearance is added on top",
     );

--- a/client/src/components/trace/trace-controls-panel.tsx
+++ b/client/src/components/trace/trace-controls-panel.tsx
@@ -1088,7 +1088,7 @@ export function TraceControlsPanel({
             </Select>
             <p className="text-[11px] text-muted-foreground">
               Offsets the current edited contour without re-detecting it. Margin
-              changes are saved in Edit history. Defaults to 1.5 mm.
+              changes are saved in Edit history. Defaults to 0.5 mm.
             </p>
           </div>
 

--- a/client/src/components/trace/use-outline-refinement.test.tsx
+++ b/client/src/components/trace/use-outline-refinement.test.tsx
@@ -125,7 +125,7 @@ describe("useOutlineRefinement", () => {
 
     expect(refiner).not.toHaveBeenCalled();
     expect(offsetter).toHaveBeenCalledOnce();
-    expect(offsetter).toHaveBeenCalledWith(edited, -1.5);
+    expect(offsetter).toHaveBeenCalledWith(edited, -0.5);
     expect(mounted.store().outline).toEqual(adjusted);
     expect(mounted.store().outline[0].holes).toEqual([]);
     mounted.unmount();

--- a/client/src/lib/export/layout.test.ts
+++ b/client/src/lib/export/layout.test.ts
@@ -68,6 +68,8 @@ describe("layoutRingsMm", () => {
         diameterMm: 18,
         kind: "straight",
         depthMm: 12,
+        topFilletMm: 0,
+        bottomFilletMm: 0,
       },
       {
         id: "f2",
@@ -77,6 +79,8 @@ describe("layoutRingsMm", () => {
         depthMm: 24,
         lengthMm: 30,
         rotationDeg: 90,
+        topFilletMm: 0,
+        bottomFilletMm: 0,
       },
     ]);
     // footprint + outline + hole circle + scoop circle

--- a/client/src/lib/gridfinity/autoplace.test.ts
+++ b/client/src/lib/gridfinity/autoplace.test.ts
@@ -53,6 +53,7 @@ describe("autoPlaceFresh", () => {
     expect(result.cutouts).toHaveLength(1);
     expect(result.cutouts[0].position.x).toBeCloseTo(0, 9);
     expect(result.cutouts[0].position.y).toBeCloseTo(0, 9);
+    expect(result.cutouts[0].topFilletMm).toBe(1);
   });
 
   it("packs multiple shapes with a printable divider and stays valid", () => {
@@ -106,7 +107,7 @@ describe("autoPlaceFresh", () => {
   it("sizes and validates placements in quarter-pitch cells", () => {
     const shape = rectShape("small", 12, 6);
     const result = autoPlaceFresh([shape], "none", "quarter");
-    expect(result).toMatchObject({ gridX: 2, gridY: 1, overflow: false });
+    expect(result).toMatchObject({ gridX: 2, gridY: 2, overflow: false });
     const spec = parseBinSpec({
       gridX: result.gridX,
       gridY: result.gridY,
@@ -219,6 +220,8 @@ describe("fitLayoutToPlacements", () => {
       diameterMm: 18,
       kind: "straight" as const,
       depthMm: 12,
+      topFilletMm: 0,
+      bottomFilletMm: 0,
     };
     const fitted = fitLayoutToPlacements(
       [],
@@ -232,6 +235,37 @@ describe("fitLayoutToPlacements", () => {
     expect(fitted.fingerHoles[0].center).toEqual({ x: 0, y: 0 });
     expect(fitted.gridX).toBe(1);
     expect(fitted.gridY).toBe(1);
+  });
+
+  it("includes a finger hole's top edge round when fitting the bin", () => {
+    const baseHole = {
+      id: "f1",
+      center: { x: 0, y: 0 },
+      diameterMm: 32,
+      kind: "straight" as const,
+      depthMm: 12,
+      topFilletMm: 0,
+      bottomFilletMm: 0,
+    };
+    const sharp = fitLayoutToPlacements(
+      [],
+      new Map(),
+      "standard",
+      "full",
+      [baseHole],
+    );
+    const rounded = fitLayoutToPlacements(
+      [],
+      new Map(),
+      "standard",
+      "full",
+      [{ ...baseHole, topFilletMm: 2 }],
+    );
+
+    expect(sharp.gridX).toBe(1);
+    expect(sharp.gridY).toBe(1);
+    expect(rounded.gridX).toBe(2);
+    expect(rounded.gridY).toBe(2);
   });
 });
 
@@ -307,6 +341,28 @@ describe("fitRectangularBinToPlacements", () => {
 });
 
 describe("autoArrangeLayout", () => {
+  it("keeps maximum top-edge rounds separated", () => {
+    const shapes = [rectShape("a", 20, 20), rectShape("b", 20, 20)];
+    const byId = new Map(shapes.map((shape) => [shape.id, shape]));
+    const cutouts = autoPlaceFresh(shapes, "standard").cutouts.map((cutout) => ({
+      ...cutout,
+      topFilletMm: 5,
+    }));
+    const arranged = autoArrangeLayout(cutouts, byId, "standard")!;
+    const arrangedSpec = parseBinSpec({
+      gridX: arranged.gridX,
+      gridY: arranged.gridY,
+      heightUnits: 6,
+      fill: "solid",
+    });
+
+    expect(
+      validateLayout(arrangedSpec, arranged.cutouts, byId).filter(
+        (issue) => issue.severity === "error",
+      ),
+    ).toEqual([]);
+  });
+
   /** A rectangle pre-rotated in its own local frame — OBB bait. */
   function diagonalShape(id: string, width: number, height: number, deg: number): TracedShape {
     const r = (deg * Math.PI) / 180;
@@ -376,6 +432,8 @@ describe("autoArrangeLayout", () => {
           diameterMm: 14,
           kind: "straight" as const,
           depthMm: 12,
+          topFilletMm: 0,
+          bottomFilletMm: 0,
         },
       ],
     }));
@@ -400,6 +458,8 @@ describe("autoArrangeLayout", () => {
       diameterMm: 18,
       kind: "deep-scoop" as const,
       depthMm: 18,
+      topFilletMm: 0,
+      bottomFilletMm: 0,
     };
 
     const arranged = autoArrangeLayout(
@@ -442,6 +502,8 @@ describe("autoArrangeLayout", () => {
           diameterMm: i % 2 === 0 ? 16 : 22,
           kind: i % 2 === 0 ? ("straight" as const) : ("scoop" as const),
           depthMm: i % 2 === 0 ? 12 : 8,
+          topFilletMm: 0,
+          bottomFilletMm: 0,
         },
       ],
     }));

--- a/client/src/lib/gridfinity/autoplace.ts
+++ b/client/src/lib/gridfinity/autoplace.ts
@@ -1,5 +1,6 @@
 import {
   cutoutPlacementSchema,
+  DEFAULT_TOP_EDGE_FILLET_MM,
   fingerHoleFootprintRing,
   placementFootprint,
   type CutoutPlacement,
@@ -38,7 +39,7 @@ import type { Bounds, Point } from "@shared/geometry/types";
  * them.
  */
 
-/** New pockets have no extra clearance; retain one printable divider plus epsilon. */
+/** Gap between expanded cutter bounds: retain one printable divider plus epsilon. */
 const ITEM_GAP_MM = D_DIV + 0.01;
 
 /**
@@ -125,8 +126,14 @@ function shelfPack(targets: readonly PackTarget[], maxWidthMm: number): PackedBl
 function shapeTargets(shapes: readonly TracedShape[]): PackTarget[] {
   return shapes.map((shape) => ({
     key: shape.id,
-    widthMm: shape.bboxMm.maxX - shape.bboxMm.minX,
-    heightMm: shape.bboxMm.maxY - shape.bboxMm.minY,
+    widthMm:
+      shape.bboxMm.maxX -
+      shape.bboxMm.minX +
+      2 * DEFAULT_TOP_EDGE_FILLET_MM,
+    heightMm:
+      shape.bboxMm.maxY -
+      shape.bboxMm.minY +
+      2 * DEFAULT_TOP_EDGE_FILLET_MM,
   }));
 }
 
@@ -174,6 +181,7 @@ function toPlacement(
     // The shape's outline is bbox-centred at ~0; compensate for any residue
     // so the *bbox* centre lands exactly on the packed position.
     position: { x: item.x + offsetX - centre.x, y: item.y + offsetY - centre.y },
+    topFilletMm: DEFAULT_TOP_EDGE_FILLET_MM,
   });
 }
 
@@ -268,7 +276,7 @@ function existingBounds(
       mirrored: false,
     });
     for (const point of ring) {
-      includePoint(point, 0);
+      includePoint(point, hole.topFilletMm);
     }
   }
   return bounds;
@@ -624,8 +632,12 @@ export function autoArrangeLayout(
   const byKey = new Map(items.map((item) => [item.cutout.id, item]));
   const targets: PackTarget[] = items.map((item) => ({
     key: item.cutout.id,
-    widthMm: item.widthMm,
-    heightMm: item.heightMm,
+    widthMm:
+      item.widthMm +
+      2 * (item.cutout.clearanceMm + item.cutout.topFilletMm),
+    heightMm:
+      item.heightMm +
+      2 * (item.cutout.clearanceMm + item.cutout.topFilletMm),
   }));
   const inset = placementInsetMm(lip);
   const fixedHoleBounds = existingBounds([], shapesById, fingerHoles);

--- a/client/src/lib/gridfinity/cutouts.test.ts
+++ b/client/src/lib/gridfinity/cutouts.test.ts
@@ -16,7 +16,11 @@ import { Arena } from "@/lib/manifold/arena";
 import { createKernel, loadManifold, type Kernel } from "@/lib/manifold/runtime";
 
 import { buildBin, buildBinWithCutouts, type BinLayout } from "./bin";
-import { budgetOutline, budgetedPointCount } from "./cutouts";
+import {
+  budgetOutline,
+  budgetedPointCount,
+  buildFingerHoleCutters,
+} from "./cutouts";
 
 let arena: Arena;
 let kernel: Kernel;
@@ -539,6 +543,8 @@ describe("buildBinWithCutouts", () => {
           diameterMm: radius * 2,
           depthMm,
           kind: "straight",
+          topFilletMm: 0,
+          bottomFilletMm: 0,
         },
       ]),
       QUALITY,
@@ -548,6 +554,101 @@ describe("buildBinWithCutouts", () => {
     const removed = plain.solid.volume() - withHole.solid.volume();
     expect(Math.abs(removed - polygonArea * depthMm) / removed).toBeLessThan(1e-6);
   });
+
+  it("rounds both edges of a straight finger hole", () => {
+    const plain = buildBin(kernel, SPEC, QUALITY);
+    const makeHole = (topFilletMm: number, bottomFilletMm: number) =>
+      buildBinWithCutouts(
+        kernel,
+        SPEC,
+        layoutFor([], [], [
+          {
+            id: `straight-${topFilletMm}-${bottomFilletMm}`,
+            center: { x: 0, y: 0 },
+            diameterMm: 18,
+            depthMm: 12,
+            kind: "straight",
+            topFilletMm,
+            bottomFilletMm,
+          },
+        ]),
+        QUALITY,
+      ).solid;
+
+    const sharp = makeHole(0, 0);
+    const topRounded = makeHole(1.2, 0);
+    const bottomFilleted = makeHole(0, 2);
+    expect(sharp.status()).toBe("NoError");
+    expect(topRounded.status()).toBe("NoError");
+    expect(bottomFilleted.status()).toBe("NoError");
+    expect(topRounded.volume()).toBeLessThan(sharp.volume());
+    expect(bottomFilleted.volume()).toBeGreaterThan(sharp.volume());
+    expect(topRounded.volume()).toBeLessThan(plain.solid.volume());
+  });
+
+  it.each(["scoop", "deep-scoop", "oblong-deep-scoop"] as const)(
+    "ignores an extra bottom fillet for the already-curved %s bottom",
+    (kind) => {
+      const base = {
+        id: `curved-${kind}`,
+        center: { x: 0, y: 0 },
+        diameterMm: 14,
+        depthMm: kind === "scoop" ? 6 : 24,
+        kind,
+        topFilletMm: 0,
+        bottomFilletMm: 0,
+        ...(kind === "oblong-deep-scoop"
+          ? { lengthMm: 30, rotationDeg: 20 }
+          : {}),
+      } satisfies FingerHole;
+      const sharpBottom = buildFingerHoleCutters(
+        kernel,
+        [base],
+        SPEC,
+        QUALITY,
+      )[0];
+      const requestedBottomFillet = buildFingerHoleCutters(
+        kernel,
+        [{ ...base, bottomFilletMm: 3 }],
+        SPEC,
+        QUALITY,
+      )[0];
+
+      expect(requestedBottomFillet.status()).toBe("NoError");
+      expect(requestedBottomFillet.volume()).toBeCloseTo(
+        sharpBottom.volume(),
+        8,
+      );
+    },
+  );
+
+  it.each(["straight", "scoop", "deep-scoop", "oblong-deep-scoop"] as const)(
+    "adds a top edge round to a %s finger hole",
+    (kind) => {
+      const base = {
+        id: `top-${kind}`,
+        center: { x: 0, y: 0 },
+        diameterMm: 14,
+        depthMm: kind === "scoop" ? 6 : 24,
+        kind,
+        topFilletMm: 0,
+        bottomFilletMm: 0,
+        ...(kind === "oblong-deep-scoop"
+          ? { lengthMm: 30, rotationDeg: 20 }
+          : {}),
+      } satisfies FingerHole;
+      const sharp = buildFingerHoleCutters(kernel, [base], SPEC, QUALITY)[0];
+      const rounded = buildFingerHoleCutters(
+        kernel,
+        [{ ...base, topFilletMm: 5 }],
+        SPEC,
+        QUALITY,
+      )[0];
+
+      expect(rounded.status()).toBe("NoError");
+      expect(rounded.volume()).toBeGreaterThan(sharp.volume());
+    },
+  );
 
   it("a scoop in open surface removes its spherical cap, within facet error", () => {
     // Scoop centred away from the pocket: the extra removal against the

--- a/client/src/lib/gridfinity/cutouts.ts
+++ b/client/src/lib/gridfinity/cutouts.ts
@@ -310,54 +310,83 @@ export function buildFingerHoleCutters(
   const { arena } = kernel;
   const cutters: Manifold[] = [];
   const segments = quality.circularSegments;
+  const filletProfileStepMm =
+    quality.filletProfileStepMm ?? FILLET_PROFILE_STEP_MM;
 
   for (const hole of fingerHoles) {
     const pocket = resolvePocketDepth(spec, { mode: "mm", value: hole.depthMm });
+    const ring = fingerHoleFootprintRing(
+      hole,
+      BIN_LOCAL_PLACEMENT,
+      segments,
+    );
+    const section = toCrossSection(kernel, [{ outer: ring, holes: [] }]);
+    let cutter: Manifold;
     if (hole.kind === "straight") {
       const floorZ = pocket.floorZ ?? -1;
-      const circle = arena.track(
-        arena
-          .track(kernel.CrossSection.circle(hole.diameterMm / 2, segments))
-          .translate([hole.center.x, hole.center.y]),
+      const effectiveBottomFillet = Math.min(
+        hole.bottomFilletMm,
+        hole.depthMm / 2,
+        hole.diameterMm / 2,
       );
-      cutters.push(
-        arena.track(
-          arena
-            .track(circle.extrude(pocket.cutterTopZ - floorZ))
-            .translate([0, 0, floorZ]),
-        ),
+      const localCutter = bottomFilletCutter(
+        kernel,
+        section,
+        pocket.cutterTopZ - floorZ,
+        {
+          radiusMm: effectiveBottomFillet,
+          profileStepMm: filletProfileStepMm,
+          circularSegments: segments,
+        },
       );
+      cutter = arena.track(localCutter.translate([0, 0, floorZ]));
     } else if (hole.kind === "scoop") {
-      cutters.push(
-        buildRoundScoopCutter(
-          kernel,
-          hole,
-          BIN_LOCAL_PLACEMENT,
-          pocket,
-          segments,
-        ),
+      cutter = buildRoundScoopCutter(
+        kernel,
+        hole,
+        BIN_LOCAL_PLACEMENT,
+        pocket,
+        segments,
       );
     } else if (hole.kind === "deep-scoop") {
-      cutters.push(
-        buildDeepScoopCutter(
-          kernel,
-          hole,
-          BIN_LOCAL_PLACEMENT,
-          pocket,
-          segments,
-        ),
+      cutter = buildDeepScoopCutter(
+        kernel,
+        hole,
+        BIN_LOCAL_PLACEMENT,
+        pocket,
+        segments,
       );
     } else if (hole.kind === "oblong-deep-scoop") {
-      cutters.push(
-        buildOblongDeepScoopCutter(
-          kernel,
-          hole,
-          BIN_LOCAL_PLACEMENT,
-          pocket,
-          segments,
-        ),
+      cutter = buildOblongDeepScoopCutter(
+        kernel,
+        hole,
+        BIN_LOCAL_PLACEMENT,
+        pocket,
+        segments,
       );
+    } else {
+      continue;
     }
+
+    const cutDepth =
+      hole.kind === "scoop"
+        ? effectiveScoopDepthMm(hole)
+        : hole.kind === "deep-scoop" || hole.kind === "oblong-deep-scoop"
+          ? effectiveDeepScoopDepthMm(hole)
+          : hole.depthMm;
+    const effectiveTopFillet = Math.min(hole.topFilletMm, cutDepth / 2);
+    if (effectiveTopFillet > 0) {
+      const topRound = topEdgeFilletCutter(kernel, section, {
+        radiusMm: effectiveTopFillet,
+        profileStepMm: filletProfileStepMm,
+        circularSegments: segments,
+      });
+      const positionedTopRound = arena.track(
+        topRound.translate([0, 0, pocket.infillTopZ - effectiveTopFillet]),
+      );
+      cutter = arena.track(cutter.add(positionedTopRound));
+    }
+    cutters.push(cutter);
   }
   return cutters;
 }

--- a/client/src/lib/image-processor.ts
+++ b/client/src/lib/image-processor.ts
@@ -31,7 +31,7 @@ export const MARGIN_MM_OPTIONS = [
 ] as const;
 
 /** The clearance selected when a Trace image first receives a valid scale. */
-export const DEFAULT_MARGIN_MM = 1.5;
+export const DEFAULT_MARGIN_MM = 0.5;
 
 /** A physical margin in millimetres, or null while the image is unscaled. */
 export type Margin = number | null;

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -374,6 +374,8 @@ describe("BinDesignerPage", () => {
           center: { x: 15, y: 0 },
           diameterMm: 16,
           depthMm: 30,
+          topFilletMm: 0,
+          bottomFilletMm: 0,
         },
       ],
     });
@@ -394,6 +396,15 @@ describe("BinDesignerPage", () => {
     ).toContain("Deep scoop");
     expect(container.querySelector('[aria-label="Diameter"]')).not.toBeNull();
     expect(container.querySelector('[aria-label="Total depth"]')).not.toBeNull();
+    const fingerHoleSection = container.querySelector(
+      '#bin-settings-finger-holes',
+    );
+    expect(
+      fingerHoleSection?.querySelector('[aria-label="Top edge round"]'),
+    ).not.toBeNull();
+    expect(
+      fingerHoleSection?.querySelector('[aria-label="Bottom edge fillet"]'),
+    ).toBeNull();
     expect(container.querySelector('[aria-label="Reach"]')).toBeNull();
     expect(container.textContent).toContain("Vertical walls: 22.0 mm");
     expect(container.textContent).toContain("rounded bottom radius: 8.0 mm");
@@ -428,6 +439,8 @@ describe("BinDesignerPage", () => {
           depthMm: 30,
           lengthMm: 40,
           rotationDeg: 0,
+          topFilletMm: 0,
+          bottomFilletMm: 0,
         },
       ],
     });
@@ -1028,6 +1041,11 @@ describe("BinDesignerPage", () => {
     expect(text).toContain("Top edge round");
     expect(text).toContain("Bottom fillet");
     expect(text).toContain("Finger Holes");
+    const pocketTopRound = container.querySelector(
+      '[aria-label="Top edge round"] [role="slider"]',
+    );
+    expect(pocketTopRound?.getAttribute("aria-valuemax")).toBe("5");
+    expect(pocketTopRound?.getAttribute("aria-valuenow")).toBe("1");
     const renameButton = container.querySelector(
       '[data-testid="button-edit-shape-name"]',
     ) as HTMLButtonElement;
@@ -1110,6 +1128,20 @@ describe("BinDesignerPage", () => {
     expect(kind).not.toBeNull();
     expect(kind!.textContent).toContain("Straight");
     expect(container.textContent).not.toContain("Scoop depth");
+    const fingerHoleSection = container.querySelector(
+      '#bin-settings-finger-holes',
+    );
+    expect(
+      fingerHoleSection?.querySelector('[aria-label="Top edge round"]'),
+    ).not.toBeNull();
+    const fingerTopRoundSlider = fingerHoleSection?.querySelector(
+      '[aria-label="Top edge round"] [role="slider"]',
+    );
+    expect(fingerTopRoundSlider?.getAttribute("aria-valuemax")).toBe("5");
+    expect(fingerTopRoundSlider?.getAttribute("aria-valuenow")).toBe("1");
+    expect(
+      fingerHoleSection?.querySelector('[aria-label="Bottom edge fillet"]'),
+    ).not.toBeNull();
 
     React.act(() => {
       (container.querySelector('[data-testid="view-toggle-2d"]') as HTMLButtonElement).click();

--- a/client/src/state/bin-store.test.tsx
+++ b/client/src/state/bin-store.test.tsx
@@ -320,6 +320,8 @@ describe("bin store history (G4 undo/redo)", () => {
           diameterMm: 18,
           depthMm: 12,
           kind: "scoop",
+          topFilletMm: 0,
+          bottomFilletMm: 0,
         },
       }),
     );

--- a/client/src/state/trace-store.test.ts
+++ b/client/src/state/trace-store.test.ts
@@ -181,7 +181,7 @@ describe("undo / redo", () => {
 
     const undone = traceReducer(changed, { type: "UNDO" });
     expect(undone.outline).toBe(ringB);
-    expect(undone.margin).toBe(1.5);
+    expect(undone.margin).toBe(0.5);
 
     const redone = traceReducer(undone, { type: "REDO" });
     expect(redone.outline).toBe(ringC);
@@ -243,7 +243,7 @@ describe("loading a new image", () => {
       fileName: "c",
     });
     expect(state.sensitivity).toBe(90);
-    expect(state.margin).toBe(1.5);
+    expect(state.margin).toBe(0.5);
     expect(state.extrusionHeight).toBe(22);
   });
 
@@ -423,7 +423,7 @@ describe("modes and calibration", () => {
     expect(state.svg).toBeNull();
     expect(state.detectedImageUrl).toBeNull();
     expect(state.history.stack).toEqual([
-      { outline: [], label: "Start", margin: 1.5 },
+      { outline: [], label: "Start", margin: 0.5 },
     ]);
   });
 
@@ -492,7 +492,7 @@ describe("modes and calibration", () => {
     expect(state.draftCalibration).toBeNull();
     expect(state.calibration?.endX).toBe(9);
     expect(state.calibrationSource).toBe("manual");
-    expect(state.margin).toBe(1.5);
+    expect(state.margin).toBe(0.5);
   });
 
   it("starts a fresh ruler when replacing a completed manual calibration", () => {
@@ -555,7 +555,7 @@ describe("modes and calibration", () => {
     expect(accepted.calibration).toBe(calibration);
     expect(accepted.pendingAutoCalibration).toBeNull();
     expect(accepted.calibrationSource).toBe("sheet");
-    expect(accepted.margin).toBe(1.5);
+    expect(accepted.margin).toBe(0.5);
   });
 
   it("rejects a late automatic calibration from a replaced image", () => {
@@ -603,7 +603,7 @@ describe("modes and calibration", () => {
     expect(state.calibration).toBe(manual);
     expect(state.pendingAutoCalibration).toBeNull();
     expect(state.calibrationSource).toBe("manual");
-    expect(state.margin).toBe(1.5);
+    expect(state.margin).toBe(0.5);
   });
 
   it("removes a pending automatic ruler when manual placement begins", () => {

--- a/shared/gridfinity/cutout.test.ts
+++ b/shared/gridfinity/cutout.test.ts
@@ -349,12 +349,18 @@ describe("typed finger holes (straight and scoop)", () => {
     });
     expect(parsed.fingerHoles[0].diameterMm).toBe(18);
     expect(parsed.fingerHoles[0].kind).toBe("straight");
+    expect(parsed.fingerHoles[0]).toMatchObject({
+      topFilletMm: 0,
+      bottomFilletMm: 0,
+    });
     expect(parsed.fingerHoles[1]).toMatchObject({
       id: "legacy-scoop",
       kind: "scoop",
       center: { x: -5, y: 0 },
       diameterMm: 30,
       depthMm: 12,
+      topFilletMm: 0,
+      bottomFilletMm: 0,
     });
   });
 
@@ -394,6 +400,8 @@ describe("typed finger holes (straight and scoop)", () => {
           diameterMm: 6,
           kind: "straight",
           depthMm: 12,
+          topFilletMm: 0,
+          bottomFilletMm: 0,
         },
       ],
     });

--- a/shared/gridfinity/cutout.ts
+++ b/shared/gridfinity/cutout.ts
@@ -134,6 +134,10 @@ export const fingerHoleSchema = z
       .default("straight"),
     /** Used only for scoops; retained on straight holes so type changes are reversible. */
     depthMm: z.number().min(1).max(120).default(12),
+    /** Rounds the hole wall outward into the bin's top surface. */
+    topFilletMm: z.number().min(0).max(5).default(0),
+    /** Used only by straight holes; curved scoop bottoms already provide this transition. */
+    bottomFilletMm: z.number().min(0).max(6).default(0),
     /** Compatibility only; removed with the directed-trough prototype. */
     reachMm: z.number().min(1).max(120).optional(),
     /** Compatibility only; removed with the directed-trough prototype. */
@@ -153,6 +157,8 @@ export type FingerHole = z.infer<typeof fingerHoleSchema>;
 
 export const MIN_FINGER_HOLE_DIAMETER_MM = 6;
 export const MAX_FINGER_HOLE_DIAMETER_MM = 80;
+/** Default top-surface round for newly created pockets and finger holes. */
+export const DEFAULT_TOP_EDGE_FILLET_MM = 1;
 export const DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM = 36;
 export const MAX_OBLONG_DEEP_SCOOP_LENGTH_MM = 160;
 export const MIN_OBLONG_DEEP_SCOOP_SPAN_MM = 2;
@@ -372,6 +378,8 @@ export const cutoutPlacementSchema = cutoutPlacementInputSchema.transform(
           id,
           kind: "scoop" as const,
           ...scoop,
+          topFilletMm: 0,
+          bottomFilletMm: 0,
         },
       ],
     };

--- a/shared/gridfinity/project.test.ts
+++ b/shared/gridfinity/project.test.ts
@@ -67,6 +67,27 @@ describe("parseProjectDoc", () => {
     });
   });
 
+  it("migrates schema v8 finger holes with sharp edge defaults", () => {
+    const previous = JSON.parse(JSON.stringify(VALID)) as Record<string, unknown>;
+    previous.schemaVersion = 8;
+    previous.fingerHoles = [
+      {
+        id: "f1",
+        kind: "straight",
+        center: { x: 4, y: 1 },
+        diameterMm: 20,
+        depthMm: 12,
+      },
+    ];
+
+    const doc = parseProjectDoc(previous);
+    expect(doc?.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
+    expect(doc?.fingerHoles[0]).toMatchObject({
+      topFilletMm: 0,
+      bottomFilletMm: 0,
+    });
+  });
+
   it("returns null rather than throwing on garbage", () => {
     expect(parseProjectDoc(undefined)).toBeNull();
     expect(parseProjectDoc({ schemaVersion: 3, shapes: [], spec: {}, cutouts: [] })).toBeNull();
@@ -87,6 +108,8 @@ describe("project file round trip", () => {
           center: { x: 4, y: 1 },
           diameterMm: 20,
           depthMm: 12,
+          topFilletMm: 1.2,
+          bottomFilletMm: 2.4,
         },
         {
           id: "f2",
@@ -117,6 +140,10 @@ describe("project file round trip", () => {
     expect(doc).not.toBeNull();
     expect(doc!.cutouts[0].fingerHoles).toEqual([]);
     expect(doc!.fingerHoles).toHaveLength(4);
+    expect(doc!.fingerHoles[0]).toMatchObject({
+      topFilletMm: 1.2,
+      bottomFilletMm: 2.4,
+    });
     expect(doc!.fingerHoles[1]).toMatchObject({
       id: "f2",
       kind: "scoop",
@@ -234,6 +261,9 @@ describe("project file round trip", () => {
       center: { x: 4, y: 0 },
       diameterMm: 18,
       depthMm: 24,
+      topFilletMm: 0,
+      bottomFilletMm: 0,
+      rotationDeg: undefined,
     });
   });
 

--- a/shared/gridfinity/project.ts
+++ b/shared/gridfinity/project.ts
@@ -22,10 +22,11 @@ import { binSpecSchema } from "./types";
  * label-tab anchors; version 5 adds straight-shaft deep finger scoops; version
  * 6 adds resizable, rotated oblong deep scoops; version 7 promotes finger
  * holes from pocket-relative children to independent, bin-local objects;
- * version 8 adds per-placement X/Y scale and an aspect-ratio-lock preference.
+ * version 8 adds per-placement X/Y scale and an aspect-ratio-lock preference;
+ * version 9 adds per-finger-hole top and bottom edge fillets.
  */
 
-export const PROJECT_SCHEMA_VERSION = 8 as const;
+export const PROJECT_SCHEMA_VERSION = 9 as const;
 
 const projectFields = {
   shapes: z.array(tracedShapeSchema),
@@ -43,6 +44,13 @@ const legacyProjectFields = {
 const version7ProjectSchema = z
   .object({
     schemaVersion: z.literal(7),
+    ...projectFields,
+  })
+  .strict();
+
+const version8ProjectSchema = z
+  .object({
+    schemaVersion: z.literal(8),
     ...projectFields,
   })
   .strict();
@@ -123,6 +131,13 @@ function migrateLegacyProject(doc: LegacyProjectDoc): ProjectDoc {
 export function parseProjectDoc(input: unknown): ProjectDoc | null {
   const result = projectDocSchema.safeParse(input);
   if (result.success) return result.data;
+  const version8 = version8ProjectSchema.safeParse(input);
+  if (version8.success) {
+    return projectDocSchema.parse({
+      ...version8.data,
+      schemaVersion: PROJECT_SCHEMA_VERSION,
+    });
+  }
   const version7 = version7ProjectSchema.safeParse(input);
   if (version7.success) {
     return projectDocSchema.parse({

--- a/shared/gridfinity/validate-layout.test.ts
+++ b/shared/gridfinity/validate-layout.test.ts
@@ -319,6 +319,30 @@ describe("validateLayout: finger holes and scoops (G4)", () => {
     expect(result).not.toContain("finger-hole-out-of-bounds");
   });
 
+  it("reserves wall clearance for a finger hole's top edge round", () => {
+    const shape = makeShape("s1", 20, 20);
+    const sharp = makeCutout("c1", "s1", 0, 0, {
+      fingerHoles: [{ id: "f1", center: { x: 31.5, y: 0 }, diameterMm: 18 }],
+    });
+    const rounded = makeCutout("c1", "s1", 0, 0, {
+      fingerHoles: [
+        {
+          id: "f1",
+          center: { x: 31.5, y: 0 },
+          diameterMm: 18,
+          topFilletMm: 0.4,
+        },
+      ],
+    });
+
+    expect(codes(spec(), [sharp], [shape])).not.toContain(
+      "finger-hole-wall-breach",
+    );
+    const roundedCodes = codes(spec(), [rounded], [shape]);
+    expect(roundedCodes).toContain("finger-hole-wall-breach");
+    expect(roundedCodes).not.toContain("finger-hole-out-of-bounds");
+  });
+
   it("validates a deep scoop by its round mouth, not its vertical depth", () => {
     const shape = makeShape("s1", 20, 20);
     const cutout = makeCutout("c1", "s1", 0, 0, {

--- a/shared/gridfinity/validate.ts
+++ b/shared/gridfinity/validate.ts
@@ -486,17 +486,18 @@ function validateFingerHoleAgainstBin(
   );
   const bounds = ringBounds(ring);
   if (!bounds) return issues;
+  const topAllowanceMm = hole.topFilletMm;
 
   const halfW = binFootprintMm(spec.gridX, spec.gridPitch) / 2;
   const halfL = binFootprintMm(spec.gridY, spec.gridPitch) / 2;
   const outerBoundary =
     spec.footprint.kind === "custom" ? footprintOuterRingMm(spec) : null;
   const outside = outerBoundary
-    ? !ringInsideBoundary(ring, outerBoundary)
-    : bounds.minX < -halfW ||
-      bounds.maxX > halfW ||
-      bounds.minY < -halfL ||
-      bounds.maxY > halfL;
+    ? ringSignedClearance(ring, outerBoundary) < topAllowanceMm
+    : bounds.minX - topAllowanceMm < -halfW ||
+      bounds.maxX + topAllowanceMm > halfW ||
+      bounds.minY - topAllowanceMm < -halfL ||
+      bounds.maxY + topAllowanceMm > halfL;
   if (outside) {
     issues.push({
       code: "finger-hole-out-of-bounds",
@@ -508,9 +509,11 @@ function validateFingerHoleAgainstBin(
 
   const interiorBoundary =
     spec.footprint.kind === "custom" ? footprintInteriorRingMm(spec) : null;
-  const wallMargin = interiorBoundary
-    ? ringSignedClearance(ring, interiorBoundary)
-    : Math.min(...ring.map((point) => signedDistanceToInterior(point, spec)));
+  const wallMargin =
+    (interiorBoundary
+      ? ringSignedClearance(ring, interiorBoundary)
+      : Math.min(...ring.map((point) => signedDistanceToInterior(point, spec)))) -
+    topAllowanceMm;
   if (wallMargin < 0) {
     issues.push({
       code: "finger-hole-wall-breach",


### PR DESCRIPTION
## Summary
- add 0-5 mm top-edge rounds to every finger-hole type and a straight-hole-only bottom fillet
- default new tool-pocket and finger-hole top rounds to 1 mm, while preserving existing saved values through the v9 project migration
- account for edge-round extents in validation and automatic layout, including 5 mm rounds
- change the default Trace contour margin from 1.5 mm to 0.5 mm

## Verification
- npm run check
- npm test (69 files, 933 tests)
- npm run build
- git diff --check
- live UI verified at http://127.0.0.1:5001 with no runtime errors