### PR TITLE
Preserve saved projects and back up model exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ processing, project storage, and model generation kept on the user's device.
 - Export traced geometry as SVG, DXF, DWG-compatible DXF, or STL.
 - Arrange traced tools as pockets in Gridfinity bins.
 - Configure full-, half-, and quarter-pitch bins and export STL or 3MF models.
+- Every bin STL/3MF export (including fit tests) downloads a matching portable
+  `.pocketry.json` backup of the full design. Filenames include the saved project
+  name, bin size, and local date/time; allow multiple downloads when prompted.
 - Export top-down layouts for shadow boards and CNC workflows.
 
 Pocketry is still subject to physical print validation. Inspect generated files

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -1812,6 +1812,12 @@ export function BinControlsPanel({
             </p>
           ))}
 
+          <p className="text-xs text-muted-foreground">
+            Every STL or 3MF also saves a portable JSON backup of the full project.
+            Both filenames include the project name, bin size, and date/time.
+            Allow multiple downloads if your browser asks.
+          </p>
+
           <div
             className="space-y-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 p-2.5"
             data-testid="export-final-model"

--- a/client/src/components/help/help-dialog.tsx
+++ b/client/src/components/help/help-dialog.tsx
@@ -213,6 +213,14 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
                 STL for an inexpensive physical fit check.
               </li>
               <li>
+                Every bin STL or 3MF export, including fit tests, also downloads
+                a portable <strong>.pocketry.json</strong> backup of the full
+                editable project. The files share a name with the project name
+                (when saved), bin size, and local date/time. Allow multiple
+                downloads if your browser asks, and keep the JSON to restore
+                the design later with Import backup.
+              </li>
+              <li>
                 <strong>Complete surface fit test</strong> exports every pocket
                 and finger-access opening together as one thin STL, without the
                 base, walls, label tab, or stacking lip. It checks the surface

--- a/client/src/lib/project/export.test.ts
+++ b/client/src/lib/project/export.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { PROJECT_SCHEMA_VERSION, parseProjectDoc, type ProjectDoc } from "@shared/gridfinity/project";
+import { parseBinSpec } from "@shared/gridfinity/types";
+import { prepareProjectExport } from "./export";
+
+const doc: ProjectDoc = {
+  schemaVersion: PROJECT_SCHEMA_VERSION,
+  spec: parseBinSpec({ gridX: 4, gridY: 4, heightUnits: 6.5 }),
+  shapes: [],
+  cutouts: [],
+  fingerHoles: [],
+};
+const date = new Date(2026, 8, 5, 14, 30, 12, 456);
+
+describe("portable model export naming", () => {
+  it("includes the project, full bin size, and local timestamp", () => {
+    expect(prepareProjectExport(doc, "Layout 2", "", date).baseName)
+      .toBe("Layout-2-bin-4x4x6.5-2026-09-05_14-30-12-456");
+  });
+
+  it.each([null, "  ", "../:*?"])("falls back to the bin size for name %s", (name) => {
+    expect(prepareProjectExport(doc, name, "", date).baseName)
+      .toBe("bin-4x4x6.5-2026-09-05_14-30-12-456");
+  });
+
+  it("keeps Unicode names and exact test thickness while removing path characters", () => {
+    expect(prepareProjectExport(doc, "../Café / Tools: 2?", "surface-fit-test-0.75mm", date).baseName)
+      .toBe("Café-Tools-2-bin-4x4x6.5-surface-fit-test-0.75mm-2026-09-05_14-30-12-456");
+  });
+
+  it("distinguishes partial pitches and custom bin footprints", () => {
+    const custom = { ...doc, spec: parseBinSpec({
+      gridX: 2, gridY: 2, heightUnits: 3, gridPitch: "half",
+      footprint: { kind: "custom", cells: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 0, y: 1 }] },
+    }) };
+    expect(prepareProjectExport(custom, null, "multicolor", date).baseName)
+      .toBe("bin-2x2x3-half-custom-3cell-multicolor-2026-09-05_14-30-12-456");
+  });
+
+  it("captures an importable snapshot before later edits", async () => {
+    const source = structuredClone(doc);
+    const project = prepareProjectExport(source, "Layout 2", "", date);
+    source.spec.gridX = 6;
+    expect(parseProjectDoc(JSON.parse(await project.backup.text()))).toEqual(doc);
+    expect(project.backup.type).toBe("application/json");
+  });
+});

--- a/client/src/lib/project/export.ts
+++ b/client/src/lib/project/export.ts
@@ -1,0 +1,57 @@
+import type { ProjectDoc } from "@shared/gridfinity/project";
+import type { BinSpec } from "@shared/gridfinity/types";
+
+import { downloadBlob } from "@/lib/download";
+
+/** Keep readable names while removing path separators and unsafe filename characters. */
+export function exportFilePart(value: string): string {
+  return value.trim()
+    .replace(/[^\p{L}\p{N}._-]+/gu, "-")
+    .replace(/^[.-]+|[.-]+$/g, "")
+    .slice(0, 80)
+    .replace(/[.-]+$/g, "");
+}
+
+export function binSizeLabel(spec: BinSpec): string {
+  return `${spec.gridX}x${spec.gridY}x${spec.heightUnits}${
+    spec.gridPitch === "full" ? "" : `-${spec.gridPitch}`
+  }${spec.footprint.kind === "custom" ? `-custom-${spec.footprint.cells.length}cell` : ""}`;
+}
+
+export interface ProjectExport {
+  baseName: string;
+  backup: Blob;
+}
+
+/** Snapshot before awaiting geometry so both downloads describe the same design. */
+export function prepareProjectExport(
+  doc: ProjectDoc,
+  projectName: string | null,
+  variant = "",
+  date = new Date(),
+): ProjectExport {
+  const pad = (value: number, width = 2) => String(value).padStart(width, "0");
+  // Local date/time is recognizable beside the user's other downloads; include
+  // milliseconds so repeated exports do not normally reuse a backup filename.
+  const stamp = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}_${pad(date.getHours())}-${pad(date.getMinutes())}-${pad(date.getSeconds())}-${pad(date.getMilliseconds(), 3)}`;
+  const baseName = [
+    exportFilePart(projectName ?? ""),
+    `bin-${binSizeLabel(doc.spec)}`,
+    exportFilePart(variant),
+    stamp,
+  ].filter(Boolean).join("-");
+  return {
+    baseName,
+    backup: new Blob([JSON.stringify(doc, null, 2)], { type: "application/json" }),
+  };
+}
+
+/** Download the recovery copy first, even if the browser blocks a second download. */
+export function downloadModelWithProject(
+  model: Blob,
+  format: "stl" | "3mf",
+  project: ProjectExport,
+): void {
+  downloadBlob(project.backup, `${project.baseName}.pocketry.json`);
+  downloadBlob(model, `${project.baseName}.${format}`);
+}

--- a/client/src/lib/project/persist.test.ts
+++ b/client/src/lib/project/persist.test.ts
@@ -130,6 +130,61 @@ describe("named project library", () => {
     expect(second.projects).toHaveLength(2);
   });
 
+  it("migrates older documents inside the named project library", async () => {
+    const version8 = JSON.parse(JSON.stringify(WIDE_DOC)) as Record<string, unknown>;
+    version8.schemaVersion = 8;
+    memory.set("tooltrace:project-library:v1", {
+      schemaVersion: 1,
+      activeProjectId: "legacy-project",
+      projects: [
+        {
+          id: "legacy-project",
+          name: "Layout 2",
+          updatedAt: "2026-09-04T18:30:17.089Z",
+          doc: version8,
+        },
+      ],
+    });
+
+    expect(await loadProjectLibrary()).toEqual({
+      activeProjectId: "legacy-project",
+      projects: [
+        {
+          id: "legacy-project",
+          name: "Layout 2",
+          updatedAt: "2026-09-04T18:30:17.089Z",
+        },
+      ],
+    });
+    const opened = await openProjectFromLibrary("legacy-project");
+    expect(opened.doc.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
+    expect(opened.doc.spec.gridX).toBe(4);
+  });
+
+  it("preserves unreadable project records when saving a readable project", async () => {
+    memory.set("tooltrace:project-library:v1", {
+      schemaVersion: 1,
+      activeProjectId: null,
+      projects: [
+        {
+          id: "future-project",
+          name: "Future project",
+          updatedAt: "2026-09-04T18:30:17.089Z",
+          doc: { schemaVersion: 999 },
+        },
+      ],
+    });
+
+    expect((await loadProjectLibrary()).projects).toEqual([]);
+    await saveProjectToLibrary(DOC, "Current project", null);
+    const stored = memory.get("tooltrace:project-library:v1") as {
+      projects: Array<{ id: string; doc: unknown }>;
+    };
+    expect(stored.projects.find((project) => project.id === "future-project")?.doc).toEqual({
+      schemaVersion: 999,
+    });
+  });
+
   it("deleting the active named project keeps the working copy as an unnamed draft", async () => {
     const created = await saveProjectToLibrary(WIDE_DOC, "Wide tray", null);
     const deleted = await deleteProjectFromLibrary(created.projects[0].id);

--- a/client/src/lib/project/persist.ts
+++ b/client/src/lib/project/persist.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 
 import {
   parseProjectDoc,
-  projectDocSchema,
   type ProjectDoc,
 } from "@shared/gridfinity/project";
 
@@ -29,7 +28,10 @@ const storedProjectSchema = z
     id: z.string().min(1).max(128),
     name: z.string().min(1).max(PROJECT_NAME_MAX_LENGTH),
     updatedAt: z.string().datetime(),
-    doc: projectDocSchema,
+    // Validate and migrate documents separately so a project-schema bump does
+    // not make the entire named library appear empty. Unreadable/future docs
+    // remain in storage instead of being discarded by the next library write.
+    doc: z.record(z.unknown()),
   })
   .strict();
 
@@ -95,12 +97,17 @@ function makeProjectId(): string {
 function parseStoredLibrary(input: unknown): StoredProjectLibrary {
   const result = projectLibrarySchema.safeParse(input);
   if (!result.success) return EMPTY_LIBRARY;
-  const activeProjectId = result.data.projects.some(
-    (project) => project.id === result.data.activeProjectId,
+  const projects = result.data.projects.map((project) => {
+    const doc = parseProjectDoc(project.doc);
+    return doc ? { ...project, doc } : project;
+  });
+  const activeProjectId = projects.some(
+    (project) =>
+      project.id === result.data.activeProjectId && parseProjectDoc(project.doc) !== null,
   )
     ? result.data.activeProjectId
     : null;
-  return { ...result.data, activeProjectId };
+  return { ...result.data, activeProjectId, projects };
 }
 
 async function readStoredLibrary(): Promise<StoredProjectLibrary> {
@@ -115,6 +122,7 @@ function toSnapshot(library: StoredProjectLibrary): ProjectLibrarySnapshot {
   return {
     activeProjectId: library.activeProjectId,
     projects: library.projects
+      .filter((project) => parseProjectDoc(project.doc) !== null)
       .map(({ id, name, updatedAt }) => ({ id, name, updatedAt }))
       .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)),
   };
@@ -208,11 +216,13 @@ export async function openProjectFromLibrary(
   return mutateLibrary(async (library) => {
     const stored = library.projects.find((project) => project.id === projectId);
     if (!stored) throw new Error("That project is no longer in this browser's library.");
+    const doc = parseProjectDoc(stored.doc);
+    if (!doc) throw new Error("That project was saved by an unsupported Pocketry version.");
     const next = { ...library, activeProjectId: stored.id };
-    await set(CURRENT_PROJECT_KEY, stored.doc);
+    await set(CURRENT_PROJECT_KEY, doc);
     await set(PROJECT_LIBRARY_KEY, next);
     return {
-      doc: stored.doc,
+      doc,
       project: { id: stored.id, name: stored.name, updatedAt: stored.updatedAt },
       library: toSnapshot(next),
     };

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -7,9 +7,10 @@ import { PanelProvider } from "@/components/layout/panel-context";
 import { WORKSPACES } from "@/components/layout/workspaces";
 import * as ShapeLibraryModule from "@/state/shape-library";
 import { ShapeLibraryProvider } from "@/state/shape-library";
-import { PROJECT_SCHEMA_VERSION, type ProjectDoc } from "@shared/gridfinity/project";
-import { parseCutoutPlacement, type TracedShape } from "@shared/gridfinity/cutout";
+import { PROJECT_SCHEMA_VERSION, parseProjectDoc, type ProjectDoc } from "@shared/gridfinity/project";
+import { fingerHoleSchema, parseCutoutPlacement, type TracedShape } from "@shared/gridfinity/cutout";
 import { parseBinSpec } from "@shared/gridfinity/types";
+import { downloadBlob } from "@/lib/download";
 
 /**
  * Structure smoke tests for the bin designer page, following the pattern of
@@ -71,7 +72,12 @@ const binGeometryMock = vi.hoisted(() => ({
   builtSpec: null as ReturnType<typeof parseBinSpec> | null,
   hasPocketFloor: false,
   hasStackingRim: true,
+  buildOnce: vi.fn(),
+  buildFitCheck: vi.fn(),
+  buildSurfaceFitCheck: vi.fn(),
 }));
+
+vi.mock("@/lib/download", () => ({ downloadBlob: vi.fn() }));
 
 vi.mock("@/lib/gridfinity/use-bin-geometry", () => ({
   useBinGeometry: () => ({
@@ -84,9 +90,9 @@ vi.mock("@/lib/gridfinity/use-bin-geometry", () => ({
     building: binGeometryMock.building,
     progress: binGeometryMock.progress,
     error: null,
-    buildOnce: vi.fn(),
-    buildFitCheck: vi.fn(),
-    buildSurfaceFitCheck: vi.fn(),
+    buildOnce: binGeometryMock.buildOnce,
+    buildFitCheck: binGeometryMock.buildFitCheck,
+    buildSurfaceFitCheck: binGeometryMock.buildSurfaceFitCheck,
   }),
 }));
 
@@ -243,6 +249,85 @@ function openSettingsSection(
 }
 
 describe("BinDesignerPage", () => {
+  it.each([
+    ["stl", "", "stl"],
+    ["single-color-3mf", "", "3mf"],
+    ["multicolor-3mf", "-multicolor", "3mf"],
+    ["surface-fit-test", "-surface-fit-test-1.2mm", "stl"],
+    ["fit-check", "-Wrench-fit-template-2mm", "stl"],
+  ])("saves the full portable project beside the %s export", async (kind, suffix, extension) => {
+    const shape = rectangularShape("tool", "Wrench");
+    const project: ProjectDoc = {
+      ...EMPTY_PROJECT,
+      spec: parseBinSpec({ gridX: 4, gridY: 4, heightUnits: 6.5 }),
+      shapes: [shape, rectangularShape("unused", "Unplaced tool")],
+      cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 } })],
+      fingerHoles: [fingerHoleSchema.parse({ id: "hole", kind: "straight", center: { x: 40, y: 0 } })],
+    };
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue(project);
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({
+      activeProjectId: "layout-2",
+      projects: [{ id: "layout-2", name: "Layout 2", updatedAt: "2026-09-05T12:00:00Z" }],
+    });
+    const mesh = {
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1]),
+      indices: new Uint32Array([0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3]),
+      normals: null,
+    };
+    const result = { mesh, materialMeshes: { body: mesh, pocketFloors: mesh, stackingRim: mesh } };
+    binGeometryMock.buildOnce.mockResolvedValue(result);
+    binGeometryMock.buildFitCheck.mockResolvedValue(result);
+    binGeometryMock.buildSurfaceFitCheck.mockResolvedValue(result);
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    try {
+      if (kind === "fit-check") {
+        openSettingsSection(container, "tool-cutouts");
+        React.act(() => {
+          container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click();
+        });
+      }
+      openSettingsSection(container, "export");
+      await React.act(async () => {
+        const button = kind.endsWith("3mf") ? "3mf" : kind;
+        container.querySelector<HTMLButtonElement>(`[data-testid="button-export-${button}"]`)!.click();
+      });
+      if (kind.endsWith("3mf") || kind === "stl") {
+        await React.act(async () => {
+          const button = kind === "stl" ? "button-confirm-stl-without-colors" : `button-export-${kind}`;
+          document.querySelector<HTMLButtonElement>(`[data-testid="${button}"]`)!.click();
+        });
+      }
+      expect(downloadBlob).toHaveBeenCalledTimes(2);
+      const [[backup, backupName], [model, modelName]] = vi.mocked(downloadBlob).mock.calls;
+      expect(modelName).toMatch(new RegExp(`^Layout-2-bin-4x4x6\\.5${suffix.replaceAll(".", "\\.")}-\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}\\.${extension}$`));
+      expect(backupName).toBe(modelName.replace(/\.(stl|3mf)$/, ".pocketry.json"));
+      expect(model.size).toBeGreaterThan(84);
+      const json = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(String(reader.result));
+        reader.onerror = () => reject(reader.error);
+        reader.readAsText(backup);
+      });
+      expect(parseProjectDoc(JSON.parse(json))).toEqual(project);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("does not download an export pair when geometry generation fails", async () => {
+    binGeometryMock.buildOnce.mockRejectedValueOnce(new Error("Mesh failed"));
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "export");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-export-stl"]')!.click());
+    await React.act(async () => {
+      document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-stl-without-colors"]')!.click();
+    });
+    expect(downloadBlob).not.toHaveBeenCalled();
+    unmount();
+  });
+
   it("is registered as the /bin workspace", () => {
     const entry = WORKSPACES.find((workspace) => workspace.path === "/bin");
     expect(entry).toBeDefined();

--- a/client/src/pages/bin-designer.tsx
+++ b/client/src/pages/bin-designer.tsx
@@ -31,6 +31,12 @@ import {
 import { useBinGeometry } from "@/lib/gridfinity/use-bin-geometry";
 import type { BuildBinSection } from "@/lib/gridfinity/worker-api";
 import { downloadBlob } from "@/lib/download";
+import {
+  binSizeLabel,
+  downloadModelWithProject,
+  exportFilePart,
+  prepareProjectExport,
+} from "@/lib/project/export";
 import { generateLayoutDXF, generateLayoutSVG } from "@/lib/export/layout";
 import { writeBinarySTL } from "@/lib/export/stl-writer";
 import { writeThreeMf, type ThreeMfObject } from "@/lib/mesh/threemf";
@@ -165,6 +171,17 @@ function BinDesignerWorkspace(): JSX.Element {
         (project) => project.id === projectLibrary.activeProjectId,
       )?.name ?? null,
     [projectLibrary],
+  );
+
+  const exportProjectDoc = useMemo<ProjectDoc>(
+    () => ({
+      schemaVersion: PROJECT_SCHEMA_VERSION,
+      shapes: library.shapes,
+      spec: committedSpec,
+      cutouts: committedCutouts,
+      fingerHoles: committedFingerHoles,
+    }),
+    [library.shapes, committedSpec, committedCutouts, committedFingerHoles],
   );
 
   // Consume shapes freshly arrived from the trace workspace: auto-place them
@@ -359,15 +376,10 @@ function BinDesignerWorkspace(): JSX.Element {
   );
 
   const handleExportProject = useCallback(() => {
-    const baseName = (currentProjectName ?? "project")
-      .trim()
-      .replace(/[^a-z0-9._-]+/gi, "-")
-      .replace(/^-+|-+$/g, "") || "project";
+    const project = prepareProjectExport(currentProjectDoc, currentProjectName);
     downloadBlob(
-      new Blob([JSON.stringify(currentProjectDoc, null, 2)], {
-        type: "application/json",
-      }),
-      `${baseName}.pocketry.json`,
+      project.backup,
+      `${project.baseName}.pocketry.json`,
     );
     toast({
       title: "Backup exported",
@@ -571,16 +583,19 @@ function BinDesignerWorkspace(): JSX.Element {
     async (format: "3mf" | "3mf-multicolor" | "stl") => {
       setExporting(true);
       try {
-        const label = `${spec.gridX}x${spec.gridY}x${spec.heightUnits}${
-          spec.gridPitch === "full" ? "" : `-${spec.gridPitch}`
-        }${spec.footprint.kind === "custom" ? `-custom-${spec.footprint.cells.length}cell` : ""}`;
+        const label = binSizeLabel(exportProjectDoc.spec);
         const multicolor = format === "3mf-multicolor";
+        const project = prepareProjectExport(
+          exportProjectDoc,
+          currentProjectName,
+          multicolor ? "multicolor" : "",
+        );
         const includePocketFloors =
           multicolor &&
           colorPocketFloors &&
-          cutouts.some((cutout) => cutout.depth.mode !== "through");
+          exportProjectDoc.cutouts.some((cutout) => cutout.depth.mode !== "through");
         const includeStackingRim =
-          multicolor && colorStackingRim && spec.lip === "standard";
+          multicolor && colorStackingRim && exportProjectDoc.spec.lip === "standard";
         const result = await buildOnce(EXPORT_QUALITY, {
           pocketFloorMaterialThicknessMm: includePocketFloors
             ? pocketFloorThicknessMm
@@ -637,9 +652,10 @@ function BinDesignerWorkspace(): JSX.Element {
               assemble: true,
             },
           );
-          downloadBlob(
+          downloadModelWithProject(
             new Blob([bytes], { type: "model/3mf" }),
-            `bin-${label}-multicolor.3mf`,
+            "3mf",
+            project,
           );
         } else if (format === "3mf") {
           const bytes = writeThreeMf(
@@ -655,22 +671,23 @@ function BinDesignerWorkspace(): JSX.Element {
             ],
             { title: `Pocketry Gridfinity bin ${label}` },
           );
-          downloadBlob(new Blob([bytes], { type: "model/3mf" }), `bin-${label}.3mf`);
+          downloadModelWithProject(new Blob([bytes], { type: "model/3mf" }), "3mf", project);
         } else {
           const stl = writeBinarySTL(
             { positions: result.mesh.positions, indices: result.mesh.indices },
             `Pocketry Gridfinity bin ${label}`,
           );
-          downloadBlob(
+          downloadModelWithProject(
             new Blob([stl], { type: "application/octet-stream" }),
-            `bin-${label}.stl`,
+            "stl",
+            project,
           );
         }
         toast({
           title: "Saved",
           description: multicolor
-            ? `Exported bin ${label} as a multi-color 3MF at print quality.`
-            : `Exported bin ${label} as ${format.toUpperCase()} at print quality.`,
+            ? `Exported bin ${label} as a multi-color 3MF with a matching portable JSON backup.`
+            : `Exported bin ${label} as ${format.toUpperCase()} with a matching portable JSON backup.`,
         });
       } catch (cause) {
         if (!(cause instanceof WorkerCancelledError)) {
@@ -685,8 +702,8 @@ function BinDesignerWorkspace(): JSX.Element {
       }
     },
     [
-      spec,
-      cutouts,
+      exportProjectDoc,
+      currentProjectName,
       buildOnce,
       colorPocketFloors,
       colorStackingRim,
@@ -701,7 +718,7 @@ function BinDesignerWorkspace(): JSX.Element {
 
   const handleExportFitCheck = useCallback(
     async (cutoutId: string, depthMm: number) => {
-      const cutout = cutouts.find((candidate) => candidate.id === cutoutId);
+      const cutout = exportProjectDoc.cutouts.find((candidate) => candidate.id === cutoutId);
       const shape = cutout
         ? library.shapes.find((candidate) => candidate.id === cutout.shapeId)
         : null;
@@ -716,26 +733,25 @@ function BinDesignerWorkspace(): JSX.Element {
 
       setExporting(true);
       try {
+        const depthLabel = String(depthMm);
+        const project = prepareProjectExport(
+          exportProjectDoc,
+          currentProjectName,
+          `${exportFilePart(shape.name) || "tool"}-fit-template-${depthLabel}mm`,
+        );
         const result = await buildFitCheck(shape, cutout, depthMm, EXPORT_QUALITY);
-        const baseName =
-          shape.name
-            .trim()
-            .replace(/[^a-z0-9._-]+/gi, "-")
-            .replace(/^-+|-+$/g, "") || "tool";
-        const depthLabel = Number.isInteger(depthMm)
-          ? String(depthMm)
-          : depthMm.toFixed(1);
         const stl = writeBinarySTL(
           { positions: result.mesh.positions, indices: result.mesh.indices },
           `Pocketry ${shape.name} fit template ${depthLabel} mm`,
         );
-        downloadBlob(
+        downloadModelWithProject(
           new Blob([stl], { type: "application/octet-stream" }),
-          `${baseName}-fit-template-${depthLabel}mm.stl`,
+          "stl",
+          project,
         );
         toast({
           title: "Fit template saved",
-          description: `Exported “${shape.name}” as a ${depthLabel} mm filled outline.`,
+          description: `Exported “${shape.name}” as a ${depthLabel} mm filled outline with a portable JSON backup of the full project.`,
         });
       } catch (cause) {
         if (!(cause instanceof WorkerCancelledError)) {
@@ -749,35 +765,33 @@ function BinDesignerWorkspace(): JSX.Element {
         setExporting(false);
       }
     },
-    [buildFitCheck, cutouts, library.shapes, toast],
+    [buildFitCheck, exportProjectDoc, currentProjectName, library.shapes, toast],
   );
 
   const handleExportSurfaceFitCheck = useCallback(
     async (thicknessMm: number) => {
       setExporting(true);
       try {
+        const label = binSizeLabel(exportProjectDoc.spec);
+        const thicknessLabel = String(thicknessMm);
+        const project = prepareProjectExport(
+          exportProjectDoc,
+          currentProjectName,
+          `surface-fit-test-${thicknessLabel}mm`,
+        );
         const result = await buildSurfaceFitCheck(thicknessMm, EXPORT_QUALITY);
-        const label = `${spec.gridX}x${spec.gridY}${
-          spec.gridPitch === "full" ? "" : `-${spec.gridPitch}`
-        }${
-          spec.footprint.kind === "custom"
-            ? `-custom-${spec.footprint.cells.length}cell`
-            : ""
-        }`;
-        const thicknessLabel = Number.isInteger(thicknessMm)
-          ? String(thicknessMm)
-          : thicknessMm.toFixed(1);
         const stl = writeBinarySTL(
           { positions: result.mesh.positions, indices: result.mesh.indices },
           `Pocketry ${label} surface fit test ${thicknessLabel} mm`,
         );
-        downloadBlob(
+        downloadModelWithProject(
           new Blob([stl], { type: "application/octet-stream" }),
-          `bin-${label}-surface-fit-test-${thicknessLabel}mm.stl`,
+          "stl",
+          project,
         );
         toast({
           title: "Surface fit test saved",
-          description: `Exported the complete pocket-layout surface at ${thicknessLabel} mm thick, without the base, walls, label tab, or stacking lip.`,
+          description: `Exported the complete pocket-layout surface at ${thicknessLabel} mm thick with a portable JSON backup of the full project.`,
         });
       } catch (cause) {
         if (!(cause instanceof WorkerCancelledError)) {
@@ -791,7 +805,7 @@ function BinDesignerWorkspace(): JSX.Element {
         setExporting(false);
       }
     },
-    [buildSurfaceFitCheck, spec, toast],
+    [buildSurfaceFitCheck, exportProjectDoc, currentProjectName, toast],
   );
 
   return (


### PR DESCRIPTION
Saved projects could disappear from the library after the project schema changed because the library required every document to match the newest schema. This change migrates readable documents individually and retains unsupported document records when other projects are saved.

Every bin STL or 3MF export now also downloads a portable `.pocketry.json` copy of the full editable project, including surface and individual-pocket fit tests. Both files share a filename containing the saved project name when available, full bin size, export variant, and local date/time. Manual JSON exports use the same naming convention.

The backup captures the design before geometry generation and downloads first. The export controls and help explain the second file and the browser's multiple-download prompt.

Validation:

- TypeScript check and production build passed.
- All 948 tests across 70 files passed, including legacy-library migration, unreadable-record preservation, all five model export paths, filename handling, complete JSON round trips, and failed-generation behavior.
- A live browser export downloaded both files with matching names; the downloaded JSON passed the project importer schema.

This fixes schema-related library visibility and adds recoverable export copies; it does not reconstruct previously overwritten project contents.
