### PR TITLE
Improve pocket editing and export feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ processing, project storage, and model generation kept on the user's device.
 - Export traced geometry as SVG, DXF, DWG-compatible DXF, or STL.
 - Arrange traced tools as pockets in Gridfinity bins.
 - Configure full-, half-, and quarter-pitch bins and export STL or 3MF models.
-- Every bin STL/3MF export (including fit tests) downloads a matching portable
-  `.pocketry.json` backup of the full design. Filenames include the saved project
-  name, bin size, and local date/time; allow multiple downloads when prompted.
+- Model, fit-test, and outline export dialogs include an optional, unchecked
+  `.pocketry.json` download. Bin exports preserve the full design; Trace exports
+  preserve the calibrated outline as an editable pocket in a new Bin project.
+  When selected, both files share a filename stem.
 - Export top-down layouts for shadow boards and CNC workflows.
 
 Pocketry is still subject to physical print validation. Inspect generated files

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -2106,7 +2106,7 @@ export function BinControlsPanel({
       </AlertDialog>
 
       <Dialog open={threeMfDialogOpen} onOpenChange={setThreeMfDialogOpen}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="w-[calc(100%-2rem)] sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Include multiple colors in the 3MF?</DialogTitle>
             <DialogDescription>
@@ -2114,10 +2114,10 @@ export function BinControlsPanel({
               selected in Materials.
             </DialogDescription>
           </DialogHeader>
-          <div className="grid gap-2">
+          <div className="grid min-w-0 gap-2">
             <Button
               variant="outline"
-              className="h-auto justify-start px-3 py-2.5 text-left"
+              className="h-auto w-full min-w-0 items-start justify-start whitespace-normal px-3 py-2.5 text-left"
               disabled={exporting || hasErrors}
               onClick={() => {
                 setThreeMfDialogOpen(false);
@@ -2125,8 +2125,8 @@ export function BinControlsPanel({
               }}
               data-testid="button-export-single-color-3mf"
             >
-              <Box className="mr-2 h-4 w-4 shrink-0" />
-              <span>
+              <Box className="mr-2 mt-0.5 h-4 w-4 shrink-0" />
+              <span className="min-w-0 flex-1">
                 <span className="block text-sm font-medium">Single-color 3MF</span>
                 <span className="block text-[11px] font-normal text-muted-foreground">
                   One body using the selected bin color.
@@ -2134,7 +2134,7 @@ export function BinControlsPanel({
               </span>
             </Button>
             <Button
-              className="h-auto justify-start px-3 py-2.5 text-left"
+              className="h-auto w-full min-w-0 items-start justify-start whitespace-normal px-3 py-2.5 text-left"
               disabled={exporting || hasErrors || !hasSelectedMulticolor}
               onClick={() => {
                 setThreeMfDialogOpen(false);
@@ -2142,8 +2142,8 @@ export function BinControlsPanel({
               }}
               data-testid="button-export-multicolor-3mf"
             >
-              <Palette className="mr-2 h-4 w-4 shrink-0" />
-              <span>
+              <Palette className="mr-2 mt-0.5 h-4 w-4 shrink-0" />
+              <span className="min-w-0 flex-1">
                 <span className="block text-sm font-medium">Multi-color 3MF</span>
                 <span className="block text-[11px] font-normal opacity-80">
                   {hasSelectedMulticolor

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -1,5 +1,7 @@
 import {
   Box,
+  ChevronDown,
+  ChevronRight,
   CircleDot,
   ClipboardCheck,
   Copy,
@@ -20,6 +22,7 @@ import {
   Scaling,
   Save,
   Scissors,
+  SlidersHorizontal,
   Spline,
   Trash2,
   Unlock,
@@ -46,7 +49,7 @@ import {
   type GridPitch,
 } from "@shared/gridfinity/standard";
 import { MAX_GRID, type BinSpecInput } from "@shared/gridfinity/types";
-import { validateBinSpec, validateLayout, type ValidationIssue } from "@shared/gridfinity/validate";
+import { validateBinSpec, validateLayout, validatePocketFloorMaterials, type ValidationIssue } from "@shared/gridfinity/validate";
 
 import {
   PanelBody,
@@ -105,6 +108,7 @@ import {
 import type { ProjectLibraryItem } from "@/lib/project/persist";
 import { cn } from "@/lib/utils";
 import { PocketMeasurements, PositionInputs } from "./pocket-measurements";
+import { ExportConfirmationDialog, ProjectBackupOption } from "./export-confirmation-dialog";
 import { useBin } from "@/state/bin-store";
 import { useShapeLibrary } from "@/state/shape-library";
 
@@ -195,14 +199,16 @@ function EditableShapeName({
   return (
     <button
       type="button"
-      className="group flex min-w-0 items-center gap-1.5 rounded px-1 py-0.5 text-left font-medium hover:bg-violet-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="group flex w-full min-w-0 items-center justify-between gap-2 rounded py-1 text-left text-sm font-medium hover:bg-violet-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       onClick={() => setEditing(true)}
       aria-label={`Rename ${shape.name}`}
       title="Click to rename"
       data-testid="button-edit-shape-name"
     >
       <span className="truncate">{shape.name}</span>
-      <Pencil className="h-3 w-3 shrink-0 text-muted-foreground opacity-60 group-hover:opacity-100" />
+      <span className="flex shrink-0 items-center gap-1 text-[11px] font-normal text-muted-foreground">
+        <Pencil className="h-3 w-3" />Rename
+      </span>
     </button>
   );
 }
@@ -226,10 +232,10 @@ export interface BinControlsPanelProps {
   stats: BuildBinStats | null;
   building: boolean;
   exporting: boolean;
-  onExport: (format: "3mf" | "3mf-multicolor" | "stl") => void;
-  onExportFitCheck: (cutoutId: string, depthMm: number) => void;
-  onExportSurfaceFitCheck: (thicknessMm: number) => void;
-  onExportLayout: (format: "dxf" | "svg") => void;
+  onExport: (format: "3mf" | "3mf-multicolor" | "stl", includeProject: boolean) => void;
+  onExportFitCheck: (cutoutId: string, depthMm: number, includeProject: boolean) => void;
+  onExportSurfaceFitCheck: (thicknessMm: number, includeProject: boolean) => void;
+  onExportLayout: (format: "dxf" | "svg", includeProject: boolean) => void;
   onAutoArrange: () => void;
   onExportProject: () => void;
   onImportProject: (file: File) => void;
@@ -321,6 +327,12 @@ export function BinControlsPanel({
   } = useBin();
   const [, navigate] = useLocation();
   const { shapes, storeShape } = useShapeLibrary();
+  const pocketPropertiesHeadingRef = useRef<HTMLDivElement>(null);
+  const selectPocketProperties = (id: string) => {
+    dispatch({ type: "SELECT_CUTOUT", id });
+    // Reveal the heading after the selected pocket's controls have rendered.
+    requestAnimationFrame(() => pocketPropertiesHeadingRef.current?.scrollIntoView?.({ block: "nearest" }));
+  };
   const shapesById = useMemo(
     () => new Map(shapes.map((shape) => [shape.id, shape])),
     [shapes],
@@ -329,12 +341,17 @@ export function BinControlsPanel({
   const dims = useMemo(() => binDimensionsMm(spec), [spec]);
   const widthCellSpan = standardCellSpan(spec.gridX, spec.gridPitch);
   const lengthCellSpan = standardCellSpan(spec.gridY, spec.gridPitch);
+  const floorMaterialIssues = useMemo(
+    () => validatePocketFloorMaterials(spec, cutouts, shapesById, colorPocketFloors ? pocketFloorThicknessMm : 0),
+    [spec, cutouts, shapesById, colorPocketFloors, pocketFloorThicknessMm],
+  );
   const issues = useMemo(
     () => [
       ...validateBinSpec(spec).issues,
       ...validateLayout(spec, cutouts, shapesById, fingerHoles),
+      ...floorMaterialIssues,
     ],
-    [spec, cutouts, shapesById, fingerHoles],
+    [spec, cutouts, shapesById, fingerHoles, floorMaterialIssues],
   );
   const revealIssue = (issue: ValidationIssue) => {
     dispatch({ type: "SET_VIEW_MODE", viewMode: "2d" });
@@ -347,7 +364,7 @@ export function BinControlsPanel({
       revealPanelSection("bin-settings-finger-holes", BIN_SETTINGS_SECTIONS);
     } else revealPanelSection("bin-settings-size", BIN_SETTINGS_SECTIONS);
   };
-  const issueButton = (issue: ValidationIssue, index: number) => <button type="button" key={`${issue.code}-${index}`} onClick={() => revealIssue(issue)}
+  const issueButton = (issue: ValidationIssue, index: number) => <button type="button" key={`${issue.code}-${index}`} data-issue-code={issue.code} onClick={() => revealIssue(issue)}
     className={`block w-full rounded border px-2 py-1.5 text-left text-xs hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring ${issue.code === "cutout-overlap" ? "border-orange-500/40 text-orange-700 dark:text-orange-300" : issue.severity === "error" ? "border-destructive/40 text-destructive" : "border-amber-500/40 text-amber-700 dark:text-amber-300"}`}>
     {issue.message} <span className="underline">Show {issue.cutoutIds?.length === 2 ? "pockets (click to switch)" : "location"}</span>
   </button>;
@@ -366,7 +383,13 @@ export function BinControlsPanel({
     SURFACE_FIT_CHECK_DEFAULT_THICKNESS_MM,
   );
   const [threeMfDialogOpen, setThreeMfDialogOpen] = useState(false);
-  const [stlWarningOpen, setStlWarningOpen] = useState(false);
+  const [includeThreeMfProject, setIncludeThreeMfProject] = useState(false);
+  const [pendingExport, setPendingExport] = useState<{
+    title: string;
+    description: string;
+    confirmLabel: string;
+    onConfirm: (includeProject: boolean) => void;
+  } | null>(null);
   const hasBlindPocket = cutouts.some(
     (cutout) => cutout.depth.mode !== "through",
   );
@@ -819,7 +842,7 @@ export function BinControlsPanel({
               >
                 <MousePointerClick className="mt-0.5 h-4 w-4 shrink-0" />
                 <p>
-                  Select a pocket in the list or Layout view. Click its name to rename it.
+                  Choose a pocket below to edit its size, depth, and shape.
                 </p>
               </div>
               <Button
@@ -832,7 +855,7 @@ export function BinControlsPanel({
                 <LayoutGrid className="mr-1.5 h-3.5 w-3.5" />
                 Auto-arrange
               </Button>
-              <div className="space-y-1">
+              <div className="space-y-2" aria-label="Choose a pocket to edit">
                 {cutouts.map((cutout) => {
                   const shape = shapesById.get(cutout.shapeId);
                   const isSelected = cutout.id === selectedCutoutId;
@@ -840,48 +863,34 @@ export function BinControlsPanel({
                     <div
                       key={cutout.id}
                       className={cn(
-                        "flex items-center gap-1 rounded border px-1 py-1 text-xs",
+                        "flex items-center rounded-md border text-xs transition-colors",
                         isSelected
-                          ? "border-violet-500/40 bg-violet-500/10 text-accent-foreground"
-                          : "border-transparent hover:border-violet-500/20 hover:bg-accent/50",
+                          ? "border-violet-500 bg-violet-500/10 ring-1 ring-violet-500/30"
+                          : "border-input bg-background hover:border-violet-400 hover:bg-violet-500/5",
                       )}
                       data-testid={`cutout-row-${cutout.id}`}
                     >
-                      <div className="flex min-w-0 flex-1 items-center gap-2 px-1 py-0.5">
-                        {isSelected && shape ? (
-                          <div className="min-w-0 flex-1">
-                            <EditableShapeName
-                              shape={shape}
-                              onRename={(name) => storeShape({ ...shape, name })}
-                            />
-                          </div>
-                        ) : (
-                          <button
-                            type="button"
-                            className="min-w-0 flex-1 truncate rounded text-left font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                            aria-pressed={false}
-                            onClick={() =>
-                              dispatch({ type: "SELECT_CUTOUT", id: cutout.id })
-                            }
-                            data-testid={`button-select-${cutout.id}`}
-                          >
-                            {shape?.name ?? "missing shape"}
-                          </button>
-                        )}
-                        <span
-                          className={cn(
-                            "shrink-0 rounded-full px-1.5 py-0.5 text-[10px]",
-                            isSelected
-                              ? "bg-violet-600 text-white"
-                              : "bg-muted text-muted-foreground",
-                          )}
-                        >
-                          {isSelected ? "Selected" : "Select to edit"}
-                        </span>
-                      </div>
                       <button
                         type="button"
-                        className="shrink-0 text-muted-foreground hover:text-foreground"
+                        className="flex min-h-12 min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2"
+                        aria-label={`${shape?.name ?? "Missing shape"} — edit pocket properties`}
+                        aria-pressed={isSelected}
+                        aria-controls={selectedCutoutId ? "pocket-properties" : undefined}
+                        onClick={() => selectPocketProperties(cutout.id)}
+                        data-testid={`button-select-${cutout.id}`}
+                      >
+                        <SlidersHorizontal className="h-4 w-4 shrink-0 text-violet-600 dark:text-violet-300" />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate font-medium">{shape?.name ?? "Missing shape"}</span>
+                          <span className={cn("mt-0.5 block text-[11px]", isSelected ? "font-medium text-violet-700 dark:text-violet-300" : "text-muted-foreground")}>
+                            {isSelected ? "Properties shown below" : "Edit properties"}
+                          </span>
+                        </span>
+                        {isSelected ? <ChevronDown className="h-4 w-4 shrink-0 text-violet-600 dark:text-violet-300" /> : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
+                      </button>
+                      <button
+                        type="button"
+                        className="flex h-8 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                         aria-label="Duplicate pocket"
                         onClick={(event) => {
                           event.stopPropagation();
@@ -897,7 +906,7 @@ export function BinControlsPanel({
                       </button>
                       <button
                         type="button"
-                        className="shrink-0 text-muted-foreground hover:text-destructive"
+                        className="mr-1 flex h-8 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                         aria-label="Remove pocket"
                         onClick={(event) => {
                           event.stopPropagation();
@@ -915,8 +924,12 @@ export function BinControlsPanel({
           )}
 
           {selectedCutout && selectedShape && (
-            <div className="space-y-3 border-t pt-3">
-              <PocketMeasurements cutout={selectedCutout} shape={selectedShape} setScale={setPocketScale} inspect={onSectionChange} />
+            <div className="space-y-3 border-t pt-3" id="pocket-properties">
+              <div ref={pocketPropertiesHeadingRef} className="scroll-mt-3 rounded-md border border-violet-500/30 bg-violet-500/5 px-2.5 py-2" data-testid="pocket-properties-heading">
+                <h3 className="text-[11px] font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">Pocket properties</h3>
+                <EditableShapeName key={selectedCutout.id} shape={selectedShape} onRename={(name) => storeShape({ ...selectedShape, name })} />
+              </div>
+              <PocketMeasurements cutout={selectedCutout} shape={selectedShape} setScale={setPocketScale} section={section} inspect={onSectionChange} />
               <Button
                 variant={editorMode === "contour" ? "default" : "outline"}
                 size="sm"
@@ -1679,6 +1692,11 @@ export function BinControlsPanel({
                 <span className="text-[11px] text-muted-foreground">mm down</span>
               </div>
             </div>
+            {floorMaterialIssues.length > 0 && (
+              <div className="space-y-1" role="status" aria-label="Pocket floor color warnings">
+                {floorMaterialIssues.map(issueButton)}
+              </div>
+            )}
           </div>
           <div
             className="space-y-2 rounded-md border bg-background/60 px-2.5 py-2"
@@ -1846,7 +1864,12 @@ export function BinControlsPanel({
                   className="w-full"
                   disabled={exporting || hasErrors}
                   onClick={() =>
-                    onExportSurfaceFitCheck(surfaceFitCheckThicknessMm)
+                    setPendingExport({
+                      title: "Save surface fit test STL?",
+                      description: `Download the complete pocket layout as a ${surfaceFitCheckThicknessMm} mm thin plate.`,
+                      confirmLabel: "Download STL",
+                      onConfirm: (includeProject) => onExportSurfaceFitCheck(surfaceFitCheckThicknessMm, includeProject),
+                    })
                   }
                   data-testid="button-export-surface-fit-test"
                 >
@@ -1889,7 +1912,12 @@ export function BinControlsPanel({
                   size="sm"
                   className="w-full"
                   disabled={exporting}
-                  onClick={() => onExportFitCheck(selectedCutout.id, fitCheckDepthMm)}
+                  onClick={() => setPendingExport({
+                    title: "Save fit template STL?",
+                    description: `Download the filled outline of “${selectedShape.name}” at ${fitCheckDepthMm} mm thick.`,
+                    confirmLabel: "Download STL",
+                    onConfirm: (includeProject) => onExportFitCheck(selectedCutout.id, fitCheckDepthMm, includeProject),
+                  })}
                   data-testid="button-export-fit-check"
                 >
                   <Download className="mr-1.5 h-3.5 w-3.5" />
@@ -1933,7 +1961,12 @@ export function BinControlsPanel({
                     variant="outline"
                     size="sm"
                     className="flex-1"
-                    onClick={() => onExportLayout("dxf")}
+                    onClick={() => setPendingExport({
+                      title: "Save layout DXF?",
+                      description: "Download the bin footprint and pocket outlines in millimetres.",
+                      confirmLabel: "Download DXF",
+                      onConfirm: (includeProject) => onExportLayout("dxf", includeProject),
+                    })}
                     data-testid="button-layout-dxf"
                   >
                     Layout DXF
@@ -1942,7 +1975,12 @@ export function BinControlsPanel({
                     variant="outline"
                     size="sm"
                     className="flex-1"
-                    onClick={() => onExportLayout("svg")}
+                    onClick={() => setPendingExport({
+                      title: "Save layout SVG?",
+                      description: "Download the bin footprint and pocket outlines in millimetres.",
+                      confirmLabel: "Download SVG",
+                      onConfirm: (includeProject) => onExportLayout("svg", includeProject),
+                    })}
                     data-testid="button-layout-svg"
                   >
                     Layout SVG
@@ -1965,6 +2003,8 @@ export function BinControlsPanel({
           summary={
             hasErrors
               ? "Needs attention"
+              : issues.length > 0
+                ? `${issues.length} ${issues.length === 1 ? "warning" : "warnings"}`
               : building
                 ? stats
                   ? "Updating"
@@ -1981,11 +2021,13 @@ export function BinControlsPanel({
           <div className="space-y-1">
             <Label className="text-xs">Model validation</Label>
             {stats ? (
-              <p className="text-xs tabular-nums text-muted-foreground">
-                {stats.triangles.toLocaleString()} triangles ·{" "}
-                {(stats.volumeMm3 / 1000).toFixed(1)} cm³ · ≈
-                {((stats.volumeMm3 / 1000) * 1.24).toFixed(0)} g solid PLA
-              </p>
+              <div className="space-y-1 text-xs text-muted-foreground">
+                <p className="tabular-nums">
+                  {stats.triangles.toLocaleString()} triangles ·{" "}
+                  {(stats.volumeMm3 / 1000).toFixed(1)} cm³ model volume
+                </p>
+                <p className="text-[11px]">Estimate filament weight in your slicer using your infill and wall settings.</p>
+              </div>
             ) : (
               <p className="text-xs text-muted-foreground">
                 {building ? "Building preview…" : "No preview yet."}
@@ -2009,9 +2051,8 @@ export function BinControlsPanel({
           <div className="space-y-1.5">{issues.map(issueButton)}</div>
 
           <p className="text-xs text-muted-foreground">
-            Every STL or 3MF also saves a portable JSON backup of the full project.
-            Both filenames include the project name, bin size, and date/time.
-            Allow multiple downloads if your browser asks.
+            You can include an editable project JSON when downloading a model or
+            layout. Select the checkbox in the export dialog to save both files.
           </p>
 
           <div
@@ -2031,7 +2072,7 @@ export function BinControlsPanel({
                 className="flex-1"
                 size="sm"
                 disabled={exporting || hasErrors}
-                onClick={() => setThreeMfDialogOpen(true)}
+                onClick={() => { setIncludeThreeMfProject(false); setThreeMfDialogOpen(true); }}
                 data-testid="button-export-3mf"
               >
                 <Box className="mr-1.5 h-4 w-4" />
@@ -2042,11 +2083,14 @@ export function BinControlsPanel({
                 variant="outline"
                 size="sm"
                 disabled={exporting || hasErrors}
-                onClick={() =>
-                  hasSelectedMulticolor
-                    ? setStlWarningOpen(true)
-                    : onExport("stl")
-                }
+                onClick={() => setPendingExport({
+                  title: hasSelectedMulticolor ? "STL will not include your colors" : "Save bin STL?",
+                  description: hasSelectedMulticolor
+                    ? "STL stores geometry only. Use multi-color 3MF to preserve the selected pocket-floor and rim-top materials."
+                    : "Download the complete bin at print quality.",
+                  confirmLabel: hasSelectedMulticolor ? "Export STL without colors" : "Download STL",
+                  onConfirm: (includeProject) => onExport("stl", includeProject),
+                })}
                 data-testid="button-export-stl"
               >
                 Save STL
@@ -2106,22 +2150,29 @@ export function BinControlsPanel({
       </AlertDialog>
 
       <Dialog open={threeMfDialogOpen} onOpenChange={setThreeMfDialogOpen}>
-        <DialogContent className="w-[calc(100%-2rem)] sm:max-w-md">
-          <DialogHeader>
+        <DialogContent className="max-h-[calc(100dvh_-_2rem)] w-[calc(100%_-_2rem)] grid-cols-1 overflow-y-auto sm:max-w-md">
+          <DialogHeader className="min-w-0 pr-6 text-left">
             <DialogTitle>Include multiple colors in the 3MF?</DialogTitle>
             <DialogDescription>
               Choose a single printable body or preserve the material colors
               selected in Materials.
             </DialogDescription>
           </DialogHeader>
-          <div className="grid min-w-0 gap-2">
+          {floorMaterialIssues.length > 0 && (
+            <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 text-xs text-amber-900 dark:text-amber-100" role="status" data-testid="export-floor-color-warning">
+              <p className="font-medium">Floor color may show on the underside.</p>
+              <p className="mt-1">Review the pocket warnings in Materials before exporting multiple colors. A shallower pocket or thinner color layer can keep the color inside the bin.</p>
+            </div>
+          )}
+          <ProjectBackupOption checked={includeThreeMfProject} onChange={setIncludeThreeMfProject} />
+          <div className="grid min-w-0 grid-cols-1 gap-2">
             <Button
               variant="outline"
               className="h-auto w-full min-w-0 items-start justify-start whitespace-normal px-3 py-2.5 text-left"
               disabled={exporting || hasErrors}
               onClick={() => {
                 setThreeMfDialogOpen(false);
-                onExport("3mf");
+                onExport("3mf", includeThreeMfProject);
               }}
               data-testid="button-export-single-color-3mf"
             >
@@ -2138,7 +2189,7 @@ export function BinControlsPanel({
               disabled={exporting || hasErrors || !hasSelectedMulticolor}
               onClick={() => {
                 setThreeMfDialogOpen(false);
-                onExport("3mf-multicolor");
+                onExport("3mf-multicolor", includeThreeMfProject);
               }}
               data-testid="button-export-multicolor-3mf"
             >
@@ -2170,33 +2221,16 @@ export function BinControlsPanel({
         </DialogContent>
       </Dialog>
 
-      <AlertDialog open={stlWarningOpen} onOpenChange={setStlWarningOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>STL will not include your colors</AlertDialogTitle>
-            <AlertDialogDescription>
-              STL stores geometry only. The selected color assignments for
-              {" "}
-              {[
-                hasSelectedFloorColor ? "pocket-floor" : null,
-                hasSelectedRimColor ? "rim-top" : null,
-              ]
-                .filter(Boolean)
-                .join(" and ")} regions will be omitted. Use 3MF and choose
-              Multi-color 3MF to preserve the separate printable materials.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => onExport("stl")}
-              data-testid="button-confirm-stl-without-colors"
-            >
-              Export STL without colors
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {pendingExport && (
+        <ExportConfirmationDialog
+          {...pendingExport}
+          onCancel={() => setPendingExport(null)}
+          onConfirm={(includeProject) => {
+            setPendingExport(null);
+            pendingExport.onConfirm(includeProject);
+          }}
+        />
+      )}
 
     </div>
   );
@@ -2472,11 +2506,11 @@ function ProjectControls({
 
       <div className="space-y-1.5 border-t pt-3">
         <Label className="text-xs">Portable backup</Label>
-        <div className="flex flex-col gap-2">
+        <div className="grid grid-cols-2 gap-2">
           <Button
-            variant="ghost"
+            variant="outline"
             size="sm"
-            className="flex-1"
+            className="h-auto min-h-9 min-w-0 whitespace-normal px-2 py-2 text-xs"
             disabled={!ready || busy}
             onClick={onExportProject}
             data-testid="button-export-project"
@@ -2484,9 +2518,9 @@ function ProjectControls({
             Download editable project
           </Button>
           <Button
-            variant="ghost"
+            variant="outline"
             size="sm"
-            className="flex-1"
+            className="h-auto min-h-9 min-w-0 whitespace-normal px-2 py-2 text-xs"
             disabled={!ready || busy}
             onClick={() => importInputRef.current?.click()}
             data-testid="button-import-project"

--- a/client/src/components/gridfinity/export-confirmation-dialog.tsx
+++ b/client/src/components/gridfinity/export-confirmation-dialog.tsx
@@ -1,0 +1,53 @@
+import { useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+
+/** Shared opt-in for downloading the editable design beside an exported file. */
+export function ProjectBackupOption({ checked, onChange, description = "Keep a copy to reopen tools and settings later.", disabledReason }: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  description?: string;
+  disabledReason?: string;
+}): JSX.Element {
+  const id = useId();
+  return (
+    <div className="flex items-start gap-2 rounded-md border bg-muted/30 p-3">
+      <Checkbox id={id} checked={checked} disabled={Boolean(disabledReason)} onCheckedChange={(value) => onChange(value === true)} className="mt-0.5" data-testid="checkbox-export-project" />
+      <div className="min-w-0 space-y-1">
+        <Label htmlFor={id} className="cursor-pointer text-sm leading-snug">Also download editable project (.pocketry.json)</Label>
+        <p className="text-xs text-muted-foreground">{disabledReason ?? description}</p>
+      </div>
+    </div>
+  );
+}
+
+/** Mount for each export request so including a project is always an explicit choice. */
+export function ExportConfirmationDialog({ title, description, confirmLabel = "Download", backupDescription, backupDisabledReason, onConfirm, onCancel }: {
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  backupDescription?: string;
+  backupDisabledReason?: string;
+  onConfirm: (includeProject: boolean) => void;
+  onCancel: () => void;
+}): JSX.Element {
+  const [includeProject, setIncludeProject] = useState(false);
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onCancel(); }}>
+      <DialogContent className="max-h-[calc(100dvh_-_2rem)] w-[calc(100%_-_2rem)] grid-cols-1 overflow-y-auto sm:max-w-md">
+        <DialogHeader className="min-w-0 pr-6 text-left">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <ProjectBackupOption checked={includeProject} onChange={setIncludeProject} description={backupDescription} disabledReason={backupDisabledReason} />
+        <DialogFooter className="gap-2">
+          <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+          <Button onClick={() => onConfirm(includeProject && !backupDisabledReason)} data-testid="button-confirm-export">{confirmLabel}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/gridfinity/layout-canvas.tsx
+++ b/client/src/components/gridfinity/layout-canvas.tsx
@@ -1,5 +1,6 @@
 import {
   Ruler,
+  Spline,
   X,
 } from "lucide-react";
 import {
@@ -1607,6 +1608,23 @@ function LayoutStage(): JSX.Element {
           </div>
         </div>
       ) : null}
+
+      {selected && (editorMode === "placement" || editorMode === "contour") && (
+        <Button
+          className="absolute left-3 top-12 z-30 h-8 shadow-sm"
+          variant={editorMode === "contour" ? "default" : "outline"}
+          size="sm"
+          data-testid="button-layout-edit-contour"
+          onClick={() => {
+            setRulerActive(false);
+            setMeasurementPoints([]);
+            dispatch({ type: "SET_EDITOR_MODE", editorMode: editorMode === "contour" ? "placement" : "contour" });
+          }}
+        >
+          <Spline className="h-4 w-4" />
+          {editorMode === "contour" ? "Finish contour editing" : "Edit Contour"}
+        </Button>
+      )}
 
       <div
         className="absolute right-3 top-12 z-30 flex flex-col overflow-hidden rounded-md border bg-background/90 shadow-sm backdrop-blur"

--- a/client/src/components/gridfinity/pocket-measurements.test.tsx
+++ b/client/src/components/gridfinity/pocket-measurements.test.tsx
@@ -22,7 +22,7 @@ const scale = vi.fn();
 function Probe() {
   store = useBin();
   const cutout = store.cutouts[0];
-  return cutout ? <PocketMeasurements cutout={cutout} shape={shape} inspect={inspect} setScale={scale} /> : null;
+  return cutout ? <PocketMeasurements cutout={cutout} shape={shape} section={null} inspect={inspect} setScale={scale} /> : null;
 }
 
 beforeEach(() => {
@@ -34,6 +34,7 @@ beforeEach(() => {
   React.act(() => root.render(<ShapeLibraryProvider><BinProvider><Probe /></BinProvider></ShapeLibraryProvider>));
   React.act(() => store.dispatch({ type: "HYDRATE", spec: parseBinSpec({ gridX: 4, gridY: 4, heightUnits: 6 }),
     cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 }, scaleX: 0.9, scaleY: 0.9, clearanceMm: 0.5, depth: { mode: "mm", value: 12 } })] }));
+  React.act(() => host.querySelector("summary")!.click());
 });
 afterEach(() => { React.act(() => root.unmount()); host.remove(); vi.unstubAllGlobals(); });
 

--- a/client/src/components/gridfinity/pocket-measurements.tsx
+++ b/client/src/components/gridfinity/pocket-measurements.tsx
@@ -1,5 +1,6 @@
 import { outlineBounds } from "@/lib/geometry/outline";
 import { useState } from "react";
+import { ChevronDown } from "lucide-react";
 import { placementFootprint, resolvePocketDepth, type CutoutPlacement, type TracedShape } from "@shared/gridfinity/cutout";
 import { binTotalHeightMm } from "@shared/gridfinity/standard";
 import { Button } from "@/components/ui/button";
@@ -16,7 +17,7 @@ export function PositionInputs({ position, onChange }: {
 }): JSX.Element {
   return <div className="space-y-1.5">
     <p className="text-xs font-medium">Position from bin centre (mm)</p>
-    <div className="flex gap-2">{(["x", "y"] as const).map((axis) => <Label key={axis} className="flex flex-1 items-center gap-2 text-xs">
+    <div className="grid grid-cols-2 gap-2">{(["x", "y"] as const).map((axis) => <Label key={axis} className="flex min-w-0 items-center gap-2 text-xs">
       {axis.toUpperCase()}
       <DraftNumberInput aria-label={`${axis.toUpperCase()} position in millimetres`} className="h-8 min-w-0" value={position[axis]} displayPrecision={2} step={0.5}
         onValueChange={(value) => onChange({ ...position, [axis]: value }, true)}
@@ -26,10 +27,11 @@ export function PositionInputs({ position, onChange }: {
   </div>;
 }
 
-export function PocketMeasurements({ cutout, shape, setScale, inspect }: {
+export function PocketMeasurements({ cutout, shape, setScale, section, inspect }: {
   cutout: CutoutPlacement; shape: TracedShape;
   setScale: (axis: "x" | "y", percent: number) => void;
-  inspect: (section: BuildBinSection) => void;
+  section: BuildBinSection | null;
+  inspect: (section: BuildBinSection | null) => void;
 }): JSX.Element {
   const { spec, cutouts, dispatch } = useBin();
   const { shapes } = useShapeLibrary();
@@ -51,50 +53,66 @@ export function PocketMeasurements({ cutout, shape, setScale, inspect }: {
     const dy = side === "above" ? target.maxY + allowance - bounds.minY : side === "below" ? target.minY - allowance - bounds.maxY : 0;
     updatePosition({ x: cutout.position.x + dx, y: cutout.position.y + dy });
   };
-  return <div className="space-y-3">
-    <PositionInputs position={cutout.position} onChange={updatePosition} />
-    <div className="flex gap-2">
-      <Button variant="outline" size="sm" onClick={() => updatePosition({ ...cutout.position, x: cutout.position.x - (bounds.minX + bounds.maxX) / 2 })}>Centre X</Button>
-      <Button variant="outline" size="sm" onClick={() => updatePosition({ ...cutout.position, y: cutout.position.y - (bounds.minY + bounds.maxY) / 2 })}>Centre Y</Button>
-    </div>
-    {cutouts.length > 1 && <details className="space-y-2 text-xs">
-      <summary className="cursor-pointer">Space beside another pocket</summary>
-      <select className="h-8 w-full rounded border bg-background px-2" aria-label="Reference pocket" value={neighborId} onChange={(event) => setNeighborId(event.target.value)}>
-        <option value="">Choose a pocket</option>
-        {cutouts.filter((item) => item.id !== cutout.id).map((item) => <option key={item.id} value={item.id}>{shapes.find((shape) => shape.id === item.shapeId)?.name ?? "Pocket"}</option>)}
-      </select>
-      <div className="flex gap-2">
-        <select aria-label="Side of reference pocket" className="rounded border bg-background" value={side} onChange={(event) => setSide(event.target.value as typeof side)}>
-          <option value="right">Right</option><option value="left">Left</option><option value="above">Above</option><option value="below">Below</option>
-        </select>
-        <DraftNumberInput aria-label="Gap between pocket openings in millimetres" className="h-8" min={0} max={100} step={0.5} value={gap} onValueChange={setGap} />
-        <span>mm</span>
+  return <div className="space-y-2">
+    <details className="group/precision text-xs">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded py-1.5 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+        Fine-tune position &amp; size
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/precision:rotate-180" />
+      </summary>
+      <div className="space-y-3 pb-2 pt-2">
+        <PositionInputs position={cutout.position} onChange={updatePosition} />
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => updatePosition({ ...cutout.position, x: cutout.position.x - (bounds.minX + bounds.maxX) / 2 })}>Centre X</Button>
+          <Button variant="outline" size="sm" onClick={() => updatePosition({ ...cutout.position, y: cutout.position.y - (bounds.minY + bounds.maxY) / 2 })}>Centre Y</Button>
+        </div>
+        {cutouts.length > 1 && <details className="space-y-2 text-xs">
+          <summary className="cursor-pointer">Space beside another pocket</summary>
+          <select className="h-8 w-full rounded border bg-background px-2" aria-label="Reference pocket" value={neighborId} onChange={(event) => setNeighborId(event.target.value)}>
+            <option value="">Choose a pocket</option>
+            {cutouts.filter((item) => item.id !== cutout.id).map((item) => <option key={item.id} value={item.id}>{shapes.find((shape) => shape.id === item.shapeId)?.name ?? "Pocket"}</option>)}
+          </select>
+          <div className="flex gap-2">
+            <select aria-label="Side of reference pocket" className="rounded border bg-background" value={side} onChange={(event) => setSide(event.target.value as typeof side)}>
+              <option value="right">Right</option><option value="left">Left</option><option value="above">Above</option><option value="below">Below</option>
+            </select>
+            <DraftNumberInput aria-label="Gap between pocket openings in millimetres" className="h-8" min={0} max={100} step={0.5} value={gap} onValueChange={setGap} />
+            <span>mm</span>
+          </div>
+          <Button size="sm" variant="outline" disabled={!neighbor} onClick={spaceFromNeighbor}>Apply gap</Button>
+          <p className="text-muted-foreground">Gap between opening bounds, including top rounding.</p>
+        </details>}
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium">Pocket size before rotation (mm)</p>
+          <div className="grid grid-cols-2 gap-2">{(["x", "y"] as const).map((axis) => {
+            const extent = axis === "x" ? shape.bboxMm.maxX - shape.bboxMm.minX : shape.bboxMm.maxY - shape.bboxMm.minY;
+            const scale = axis === "x" ? cutout.scaleX : cutout.scaleY;
+            return <Label key={axis} className="flex min-w-0 items-center gap-1 text-xs">{axis === "x" ? "W" : "L"}<DraftNumberInput className="h-8 min-w-0" aria-label={`Pocket ${axis === "x" ? "width" : "length"} in millimetres`} value={extent * scale + 2 * cutout.clearanceMm} displayPrecision={2} min={extent * 0.05 + 2 * cutout.clearanceMm} max={extent * 20 + 2 * cutout.clearanceMm} step={0.1} onValueChange={(value) => setScale(axis, (value - 2 * cutout.clearanceMm) / extent * 100)} /></Label>;
+          })}</div>
+          <p className="text-[11px] text-muted-foreground">Includes extra clearance. Top rounding widens the opening further.</p>
+          <p className="text-[11px] text-muted-foreground" data-testid="pocket-margin-summary">{shape.traceMarginMm === undefined
+            ? `Original trace margin unknown (older project). Extra allowance: ${cutout.clearanceMm.toFixed(2)} mm per edge.`
+            : `Trace margin: ${shape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(shape.traceMarginMm * cutout.scaleX + cutout.clearanceMm).toFixed(2)} / ${(shape.traceMarginMm * cutout.scaleY + cutout.clearanceMm).toFixed(2)} mm per edge.`}</p>
+        </div>
       </div>
-      <Button size="sm" variant="outline" disabled={!neighbor} onClick={spaceFromNeighbor}>Apply gap</Button>
-      <p className="text-muted-foreground">Gap between opening bounds, including top rounding.</p>
-    </details>}
-    <div className="space-y-1.5">
-      <p className="text-xs font-medium">Pocket size before rotation (mm)</p>
-      <div className="flex gap-2">{(["x", "y"] as const).map((axis) => {
-        const extent = axis === "x" ? shape.bboxMm.maxX - shape.bboxMm.minX : shape.bboxMm.maxY - shape.bboxMm.minY;
-        const scale = axis === "x" ? cutout.scaleX : cutout.scaleY;
-        return <Label key={axis} className="flex flex-1 items-center gap-1 text-xs">{axis === "x" ? "W" : "L"}<DraftNumberInput className="h-8 min-w-0" aria-label={`Pocket ${axis === "x" ? "width" : "length"} in millimetres`} value={extent * scale + 2 * cutout.clearanceMm} displayPrecision={2} min={extent * 0.05 + 2 * cutout.clearanceMm} max={extent * 20 + 2 * cutout.clearanceMm} step={0.1} onValueChange={(value) => setScale(axis, (value - 2 * cutout.clearanceMm) / extent * 100)} /></Label>;
-      })}</div>
-      <p className="text-[11px] text-muted-foreground">Includes extra clearance. Top rounding widens the opening further.</p>
-      <p className="text-[11px] text-muted-foreground" data-testid="pocket-margin-summary">{shape.traceMarginMm === undefined
-        ? `Original trace margin unknown (older project). Extra allowance: ${cutout.clearanceMm.toFixed(2)} mm per edge.`
-        : `Trace margin: ${shape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(shape.traceMarginMm * cutout.scaleX + cutout.clearanceMm).toFixed(2)} / ${(shape.traceMarginMm * cutout.scaleY + cutout.clearanceMm).toFixed(2)} mm per edge.`}</p>
-    </div>
-    <div className="rounded border bg-muted/30 p-2 text-xs" data-testid="pocket-depth-summary">
-      <p>Cut depth: {pocket.depthMm === null ? "through" : `${pocket.depthMm.toFixed(1)} mm`} · Floor: {(pocket.floorZ ?? 0).toFixed(1)} mm</p>
-      <p className="text-muted-foreground">Infill top: {pocket.infillTopZ.toFixed(1)} mm · Total bin: {total.toFixed(1)} mm</p>
-      <svg viewBox="0 0 240 65" className="mt-2 h-16 w-full" role="img" aria-label="Cross-section: pocket depth above remaining floor, with stacking rim above infill">
-        <path d="M20 5 H40 V15 H200 V5 H220 V60 H20 Z" fill="currentColor" opacity="0.2" />
-        <rect x="70" y="15" width="100" height={45 * Math.min(1, Math.max(0, (pocket.depthMm ?? pocket.infillTopZ) / pocket.infillTopZ))} fill="hsl(var(--background))" stroke="currentColor" />
-        <text x="120" y="28" textAnchor="middle" fontSize="9" fill="currentColor">Pocket</text>
-        <text x="230" y="57" textAnchor="end" fontSize="9" fill="currentColor">Floor</text>
-      </svg>
-      <Button className="mt-1 w-full" size="sm" variant="outline" onClick={() => { dispatch({ type: "SET_VIEW_MODE", viewMode: "3d" }); inspect({ axis: "x", offsetMm: (bounds.minX + bounds.maxX) / 2 }); }}>Inspect this pocket in 3D</Button>
-    </div>
+    </details>
+    <details className="group/depth text-xs" data-testid="pocket-depth-summary">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded py-1.5 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+        <span>Cut depth: {pocket.depthMm === null ? "through" : `${pocket.depthMm.toFixed(1)} mm`} · Floor: {(pocket.floorZ ?? 0).toFixed(1)} mm</span>
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/depth:rotate-180" />
+      </summary>
+      <div className="rounded border bg-muted/30 p-2">
+        <p className="text-muted-foreground">Infill top: {pocket.infillTopZ.toFixed(1)} mm · Total bin: {total.toFixed(1)} mm</p>
+        <svg viewBox="0 0 240 65" className="mt-2 h-16 w-full" role="img" aria-label="Cross-section: pocket depth above remaining floor, with stacking rim above infill">
+          <path d="M20 5 H40 V15 H200 V5 H220 V60 H20 Z" fill="currentColor" opacity="0.2" />
+          <rect x="70" y="15" width="100" height={45 * Math.min(1, Math.max(0, (pocket.depthMm ?? pocket.infillTopZ) / pocket.infillTopZ))} fill="hsl(var(--background))" stroke="currentColor" />
+          <text x="120" y="28" textAnchor="middle" fontSize="9" fill="currentColor">Pocket</text>
+          <text x="230" y="57" textAnchor="end" fontSize="9" fill="currentColor">Floor</text>
+        </svg>
+      </div>
+    </details>
+    <Button className="h-8 w-full text-xs" size="sm" variant="outline" data-testid="button-inspect-pocket" onClick={() => {
+      dispatch({ type: "SET_VIEW_MODE", viewMode: "3d" });
+      inspect(section ? null : { axis: "x", offsetMm: (bounds.minX + bounds.maxX) / 2 });
+    }}>{section ? "Show full bin" : "Inspect this pocket in 3D"}</Button>
   </div>;
 }

--- a/client/src/components/help/help-dialog.tsx
+++ b/client/src/components/help/help-dialog.tsx
@@ -220,12 +220,17 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
                 STL for an inexpensive physical fit check.
               </li>
               <li>
-                Every bin STL or 3MF export, including fit tests, also downloads
-                a portable <strong>.pocketry.json</strong> backup of the full
-                editable project. The files share a name with the project name
+                Bin model, fit-test, and layout exports ask whether to also download
+                an editable <strong>.pocketry.json</strong> project. This checkbox
+                starts unchecked. When selected, the files share the project name
                 (when saved), bin size, and local date/time. Allow multiple
                 downloads if your browser asks, and keep the JSON to restore
                 the design later with Open Pocketry project.
+              </li>
+              <li>
+                Trace exports offer the same optional JSON download once the outline
+                is calibrated. Open that project in Bin to edit the exported outline
+                as a pocket at its original physical size.
               </li>
               <li>
                 Under <strong>Check fit</strong>, Complete surface fit test exports every pocket

--- a/client/src/lib/gridfinity/cutouts.test.ts
+++ b/client/src/lib/gridfinity/cutouts.test.ts
@@ -7,6 +7,7 @@ import {
 import { parseBinSpec } from "@shared/gridfinity/types";
 import {
   binTotalHeightMm,
+  BASE_PROFILE_HEIGHT,
   STACKING_LIP_HEIGHT_ACTUAL,
   STACKING_LIP_SUPPORT_HEIGHT_MM,
 } from "@shared/gridfinity/standard";
@@ -178,6 +179,31 @@ describe("buildBinWithCutouts", () => {
     const reunited = arena.track(body.add(pocketFloors!));
     expect(reunited.volume()).toBeCloseTo(built.solid.volume(), 5);
     expect(reunited.boundingBox()).toEqual(built.solid.boundingBox());
+  });
+
+  it.each([39, 38.8])("checks underside exposure in the actual floor-color mesh at %s mm fixed depth", (depthMm) => {
+    const built = buildBinWithCutouts(
+      kernel,
+      parseBinSpec({ gridX: 2, gridY: 2, heightUnits: 6.5, fill: "solid" }),
+      layoutFor([rectShape("tool", 30, 20)], [cutout("pocket", "tool", { depth: { mode: "mm", value: depthMm } })]),
+      QUALITY,
+      { floorInsertThicknessMm: 0.6 },
+    );
+    const mesh = built.materialParts!.pocketFloors!.getMesh();
+    let exposedArea = 0;
+    for (let i = 0; i < mesh.triVerts.length; i += 3) {
+      const vertices = [0, 1, 2].map((offset) => {
+        const index = mesh.triVerts[i + offset] * mesh.numProp;
+        return [mesh.vertProperties[index], mesh.vertProperties[index + 1], mesh.vertProperties[index + 2]];
+      });
+      if (!vertices.every((vertex) => Math.abs(vertex[2] - BASE_PROFILE_HEIGHT) < 1e-5)) continue;
+      const [a, b, c] = vertices;
+      const normalZ = (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]);
+      // Downward faces on the bridge are exposed between the base feet.
+      if (normalZ < 0) exposedArea += -normalZ / 2;
+    }
+    if (depthMm === 39) expect(exposedArea).toBeGreaterThan(1);
+    else expect(exposedArea).toBe(0);
   });
 
   it("splits the stacking-rim crest into a printable 0.6 mm material volume", () => {

--- a/client/src/lib/project/export.ts
+++ b/client/src/lib/project/export.ts
@@ -46,12 +46,13 @@ export function prepareProjectExport(
   };
 }
 
-/** Download the recovery copy first, even if the browser blocks a second download. */
+/** Include the recovery copy only when requested, using the same design snapshot. */
 export function downloadModelWithProject(
   model: Blob,
-  format: "stl" | "3mf",
+  format: "stl" | "3mf" | "svg" | "dxf",
   project: ProjectExport,
+  includeProject: boolean,
 ): void {
-  downloadBlob(project.backup, `${project.baseName}.pocketry.json`);
+  if (includeProject) downloadBlob(project.backup, `${project.baseName}.pocketry.json`);
   downloadBlob(model, `${project.baseName}.${format}`);
 }

--- a/client/src/lib/project/trace-export.test.ts
+++ b/client/src/lib/project/trace-export.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import type { Outline } from "@shared/geometry/types";
+import { parseProjectDoc } from "@shared/gridfinity/project";
+import { projectFromTrace } from "./trace-export";
+
+const outline: Outline = [{
+  outer: [{ x: 10, y: 10 }, { x: 70, y: 10 }, { x: 70, y: 50 }, { x: 10, y: 50 }],
+  holes: [[{ x: 20, y: 20 }, { x: 20, y: 30 }, { x: 30, y: 30 }, { x: 30, y: 20 }]],
+}];
+
+describe("editable project from a Trace export", () => {
+  it("round trips the calibrated contour and its holes without changing the trace", () => {
+    const original = structuredClone(outline);
+    const project = projectFromTrace(outline, { mmPerPx: 0.5, imageHeight: 100 }, "Tool", 0.75);
+    const restored = parseProjectDoc(JSON.parse(JSON.stringify(project)))!;
+    const shape = restored.shapes[0];
+    expect(shape.bboxMm).toEqual({ minX: -15, minY: -10, maxX: 15, maxY: 10 });
+    expect(shape.outlineMm[0].holes).toHaveLength(1);
+    expect(shape.outlineMm[0].holes[0]).toContainEqual({ x: -10, y: 5 });
+    expect(shape.sourceMmPerPx).toBe(0.5);
+    expect(shape.traceMarginMm).toBe(0.75);
+    expect(restored.cutouts[0].shapeId).toBe(shape.id);
+    expect(restored.cutouts[0].scaleX).toBe(1);
+    expect(restored.cutouts[0].scaleY).toBe(1);
+    expect(outline).toEqual(original);
+  });
+
+  it("rejects an uncalibrated outline instead of inventing a physical scale", () => {
+    expect(() => projectFromTrace(outline, { mmPerPx: null, imageHeight: 100 }, "Tool", 0))
+      .toThrow("Set the scale");
+  });
+});

--- a/client/src/lib/project/trace-export.ts
+++ b/client/src/lib/project/trace-export.ts
@@ -1,0 +1,23 @@
+import type { Outline } from "@shared/geometry/types";
+import { PROJECT_SCHEMA_VERSION, type ProjectDoc } from "@shared/gridfinity/project";
+import { parseBinSpec } from "@shared/gridfinity/types";
+
+import type { ExportScale } from "@/lib/export/scale";
+import { autoPlaceFresh } from "@/lib/gridfinity/autoplace";
+import { normalizeTracedShape } from "@/lib/gridfinity/traced-shape";
+
+/** Reopens the exported contour at its calibrated size using the existing Bin editor. */
+export function projectFromTrace(outline: Outline, scale: ExportScale, name: string, marginMm: number): ProjectDoc {
+  const traced = normalizeTracedShape(outline, scale, name);
+  if (!traced) throw new Error("Set the scale before exporting an editable Pocketry project.");
+  const shape = { ...traced, traceMarginMm: marginMm };
+  const placement = autoPlaceFresh([shape], "standard");
+  return {
+    schemaVersion: PROJECT_SCHEMA_VERSION,
+    name: name.trim().slice(0, 80) || "Traced outline",
+    shapes: [shape],
+    spec: parseBinSpec({ gridX: placement.gridX, gridY: placement.gridY, heightUnits: 6, fill: "solid" }),
+    cutouts: placement.cutouts,
+    fingerHoles: [],
+  };
+}

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -11,6 +11,7 @@ import { PROJECT_SCHEMA_VERSION, parseProjectDoc, type ProjectDoc } from "@share
 import { fingerHoleSchema, parseCutoutPlacement, type TracedShape } from "@shared/gridfinity/cutout";
 import { parseBinSpec } from "@shared/gridfinity/types";
 import { downloadBlob } from "@/lib/download";
+import { useBinGeometry } from "@/lib/gridfinity/use-bin-geometry";
 
 /**
  * Structure smoke tests for the bin designer page, following the pattern of
@@ -80,7 +81,7 @@ const binGeometryMock = vi.hoisted(() => ({
 vi.mock("@/lib/download", () => ({ downloadBlob: vi.fn() }));
 
 vi.mock("@/lib/gridfinity/use-bin-geometry", () => ({
-  useBinGeometry: () => ({
+  useBinGeometry: vi.fn(() => ({
     geometry: null,
     hasPocketFloor: binGeometryMock.hasPocketFloor,
     hasStackingRim: binGeometryMock.hasStackingRim,
@@ -93,7 +94,7 @@ vi.mock("@/lib/gridfinity/use-bin-geometry", () => ({
     buildOnce: binGeometryMock.buildOnce,
     buildFitCheck: binGeometryMock.buildFitCheck,
     buildSurfaceFitCheck: binGeometryMock.buildSurfaceFitCheck,
-  }),
+  })),
 }));
 
 // Deterministic persistence: no stored project, writes are no-ops. Hydration
@@ -251,13 +252,136 @@ function openSettingsSection(
 }
 
 describe("BinDesignerPage", () => {
+  it("opens the requested pocket's properties from its row and keeps selection separate from renaming", async () => {
+    const first = rectangularShape("first-shape", "Wrench");
+    const second = rectangularShape("second-shape", "Pliers");
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT,
+      shapes: [first, second],
+      cutouts: [
+        parseCutoutPlacement({ id: "first-pocket", shapeId: first.id, position: { x: -20, y: 0 }, depth: { mode: "mm", value: 10 } }),
+        parseCutoutPlacement({ id: "second-pocket", shapeId: second.id, position: { x: 20, y: 0 }, depth: { mode: "mm", value: 20 } }),
+      ],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "tool-cutouts");
+    const firstButton = container.querySelector<HTMLButtonElement>('[data-testid="button-select-first-pocket"]')!;
+    const secondButton = container.querySelector<HTMLButtonElement>('[data-testid="button-select-second-pocket"]')!;
+    expect(firstButton.getAttribute("aria-pressed")).toBe("false");
+    expect(secondButton.textContent).toContain("Edit properties");
+    React.act(() => secondButton.querySelector("span")!.click());
+    expect(secondButton.getAttribute("aria-pressed")).toBe("true");
+    expect(secondButton.textContent).toContain("Properties shown below");
+    expect(container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).toContain("Pliers");
+    expect(container.querySelector<HTMLInputElement>('[aria-label="Pocket cut depth in millimetres"]')!.value).toBe("20");
+    React.act(() => firstButton.click());
+    expect(firstButton.getAttribute("aria-pressed")).toBe("true");
+    expect(secondButton.getAttribute("aria-pressed")).toBe("false");
+    expect(container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).toContain("Wrench");
+    expect(container.querySelector<HTMLInputElement>('[aria-label="Pocket cut depth in millimetres"]')!.value).toBe("10");
+    React.act(() => firstButton.click());
+    expect(container.querySelector('[data-testid="input-shape-name"]')).toBeNull();
+    expect(container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.disabled).toBe(true);
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-edit-shape-name"]')!.click());
+    expect(container.querySelector<HTMLInputElement>('[data-testid="input-shape-name"]')!.value).toBe("Wrench");
+    unmount();
+  });
+
+  it("edits and finishes a selected contour directly in Layout, including after using the ruler", async () => {
+    const shape = rectangularShape("tool", "Wrench");
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT, shapes: [shape],
+      cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 } })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="view-toggle-2d"]')!.click());
+    expect(container.querySelector('[data-testid="button-layout-edit-contour"]')).toBeNull();
+    openSettingsSection(container, "tool-cutouts");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click());
+    const edit = container.querySelector<HTMLButtonElement>('[data-testid="button-layout-edit-contour"]')!;
+    expect(edit.textContent).toBe("Edit Contour");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-layout-ruler"]')!.click());
+    expect(container.querySelector('[data-testid="layout-ruler-status"]')).not.toBeNull();
+    React.act(() => edit.click());
+    expect(edit.textContent).toBe("Finish contour editing");
+    expect(container.querySelector('[data-testid="layout-ruler-status"]')).toBeNull();
+    expect(container.querySelectorAll('[data-testid="contour-vertex-handle"]')).toHaveLength(4);
+    expect(container.querySelector('[data-testid="button-edit-contour"]')!.textContent).toContain("Finish contour editing");
+    React.act(() => edit.click());
+    expect(edit.textContent).toBe("Edit Contour");
+    expect(container.querySelector('[data-testid="contour-vertex-handle"]')).toBeNull();
+    expect(container.querySelector('[data-testid="pocket-resize-handle-ne"]')).not.toBeNull();
+    unmount();
+  });
+
+  it.each(["stl", "3mf"])("cancels %s without downloads and resets the JSON checkbox for the next request", async (format) => {
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "export");
+    const trigger = container.querySelector<HTMLButtonElement>(`[data-testid="button-export-${format}"]`)!;
+    React.act(() => trigger.click());
+    const checkbox = () => document.querySelector<HTMLButtonElement>('[data-testid="checkbox-export-project"]')!;
+    expect(checkbox().getAttribute("aria-checked")).toBe("false");
+    React.act(() => checkbox().click());
+    expect(checkbox().getAttribute("aria-checked")).toBe("true");
+    React.act(() => [...document.querySelectorAll<HTMLButtonElement>('[role="dialog"] button')].find((button) => button.textContent === "Cancel")!.click());
+    expect(document.querySelector('[data-testid="checkbox-export-project"]')).toBeNull();
+    expect(downloadBlob).not.toHaveBeenCalled();
+    expect(binGeometryMock.buildOnce).not.toHaveBeenCalled();
+    React.act(() => trigger.click());
+    expect(checkbox().getAttribute("aria-checked")).toBe("false");
+    unmount();
+  });
+
+  it.each(["button-show-full-bin", "button-inspect-pocket"])(
+    "exits pocket inspection from %s and restores the full preview without editing the model",
+    async (exitButton) => {
+      const shape = rectangularShape("tool", "Wrench");
+      vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+        ...EMPTY_PROJECT,
+        shapes: [shape],
+        cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 12, y: 0 } })],
+      });
+      const { container, unmount } = renderPage();
+      await flushHydration();
+      openSettingsSection(container, "tool-cutouts");
+      React.act(() => {
+        container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click();
+        container.querySelector<HTMLButtonElement>('[data-testid="view-toggle-2d"]')!.click();
+      });
+      const precision = container.querySelector<HTMLDetailsElement>('[aria-label="X position in millimetres"]')!.closest("details")!;
+      expect(precision.open).toBe(false);
+      expect(container.querySelector('[data-testid="button-show-full-bin"]')).toBeNull();
+      const before = vi.mocked(useBinGeometry).mock.lastCall!;
+      React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-inspect-pocket"]')!.click());
+      expect(container.querySelector('[data-testid="bin-viewport-stub"]')).not.toBeNull();
+      expect(vi.mocked(useBinGeometry).mock.lastCall![3]).toEqual({ axis: "x", offsetMm: 12 });
+      expect(container.querySelector('[data-testid="button-inspect-pocket"]')!.textContent).toBe("Show full bin");
+      React.act(() => container.querySelector<HTMLButtonElement>(`[data-testid="${exitButton}"]`)!.click());
+      const after = vi.mocked(useBinGeometry).mock.lastCall!;
+      expect(after[3]).toBeNull();
+      expect(after[0]).toBe(before[0]);
+      expect(after[2]).toBe(before[2]);
+      expect(container.querySelector('[data-testid="button-show-full-bin"]')).toBeNull();
+      expect(container.querySelector('[data-testid="button-inspect-pocket"]')!.textContent).toBe("Inspect this pocket in 3D");
+      expect(container.querySelector('[data-testid="bin-viewport-stub"]')).not.toBeNull();
+      unmount();
+    },
+  );
+
   it.each([
     ["stl", "", "stl"],
     ["single-color-3mf", "", "3mf"],
     ["multicolor-3mf", "-multicolor", "3mf"],
     ["surface-fit-test", "-surface-fit-test-1.2mm", "stl"],
     ["fit-check", "-Wrench-fit-template-2mm", "stl"],
-  ])("saves the full portable project beside the %s export", async (kind, suffix, extension) => {
+    ["layout-svg", "-layout", "svg"],
+    ["layout-dxf", "-layout", "dxf"],
+  ].flatMap(([kind, suffix, extension]) => [false, true].map((includeProject) => ({ kind, suffix, extension, includeProject }))))(
+    "exports $kind with project JSON only when requested ($includeProject)",
+    async ({ kind, suffix, extension, includeProject }) => {
     const shape = rectangularShape("tool", "Wrench");
     const project: ProjectDoc = {
       ...EMPTY_PROJECT,
@@ -289,22 +413,26 @@ describe("BinDesignerPage", () => {
           container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click();
         });
       }
-      openSettingsSection(container, kind === "surface-fit-test" || kind === "fit-check" ? "check-fit" : "export");
+      openSettingsSection(container, kind === "surface-fit-test" || kind === "fit-check" || kind.startsWith("layout-") ? "check-fit" : "export");
       await React.act(async () => {
-        const button = kind.endsWith("3mf") ? "3mf" : kind;
-        container.querySelector<HTMLButtonElement>(`[data-testid="button-export-${button}"]`)!.click();
+        const button = kind.startsWith("layout-") ? `button-${kind}` : `button-export-${kind.endsWith("3mf") ? "3mf" : kind}`;
+        container.querySelector<HTMLButtonElement>(`[data-testid="${button}"]`)!.click();
       });
-      if (kind.endsWith("3mf") || kind === "stl") {
-        await React.act(async () => {
-          const button = kind === "stl" ? "button-confirm-stl-without-colors" : `button-export-${kind}`;
-          document.querySelector<HTMLButtonElement>(`[data-testid="${button}"]`)!.click();
-        });
-      }
-      expect(downloadBlob).toHaveBeenCalledTimes(2);
-      const [[backup, backupName], [model, modelName]] = vi.mocked(downloadBlob).mock.calls;
+      expect(downloadBlob).not.toHaveBeenCalled();
+      const checkbox = document.querySelector<HTMLButtonElement>('[data-testid="checkbox-export-project"]')!;
+      expect(checkbox.getAttribute("aria-checked")).toBe("false");
+      if (includeProject) React.act(() => checkbox.click());
+      await React.act(async () => {
+        const button = kind.endsWith("3mf") ? `button-export-${kind}` : "button-confirm-export";
+        document.querySelector<HTMLButtonElement>(`[data-testid="${button}"]`)!.click();
+      });
+      expect(downloadBlob).toHaveBeenCalledTimes(includeProject ? 2 : 1);
+      const [model, modelName] = vi.mocked(downloadBlob).mock.calls.at(-1)!;
       expect(modelName).toMatch(new RegExp(`^Layout-2-bin-4x4x6\\.5${suffix.replaceAll(".", "\\.")}-\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}\\.${extension}$`));
-      expect(backupName).toBe(modelName.replace(/\.(stl|3mf)$/, ".pocketry.json"));
       expect(model.size).toBeGreaterThan(84);
+      if (!includeProject) return;
+      const [backup, backupName] = vi.mocked(downloadBlob).mock.calls[0];
+      expect(backupName).toBe(modelName.replace(/\.(stl|3mf|svg|dxf)$/, ".pocketry.json"));
       const json = await new Promise<string>((resolve, reject) => {
         const reader = new FileReader();
         reader.onload = () => resolve(String(reader.result));
@@ -324,8 +452,9 @@ describe("BinDesignerPage", () => {
     openSettingsSection(container, "export");
     React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-export-stl"]')!.click());
     await React.act(async () => {
-      document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-stl-without-colors"]')!.click();
+      document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-export"]')!.click();
     });
+    expect(binGeometryMock.buildOnce).toHaveBeenCalledTimes(1);
     expect(downloadBlob).not.toHaveBeenCalled();
     unmount();
   });
@@ -715,6 +844,58 @@ describe("BinDesignerPage", () => {
     unmount();
   });
 
+  it("warns about floor color on the underside in pocket controls, Materials, and 3MF export without blocking", async () => {
+    const shape = rectangularShape("tool", "Air Duster");
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT,
+      spec: parseBinSpec({ gridX: 2, gridY: 2, heightUnits: 6.5, fill: "solid" }),
+      shapes: [shape],
+      cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 }, depth: { mode: "mm", value: 39 } })],
+    });
+    binGeometryMock.hasPocketFloor = true;
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "export");
+    const issueSelector = '[data-issue-code="floor-color-on-underside"]';
+    const issue = container.querySelector<HTMLButtonElement>(issueSelector)!;
+    expect(issue.textContent).toContain("Air Duster");
+    expect(issue.textContent).toContain("Floor color may show on the underside");
+    React.act(() => issue.click());
+    expect(container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).toContain("Air Duster");
+    expect(container.querySelector('[data-testid="selected-object-issues"]')!.textContent).toContain("Floor color may show on the underside");
+
+    const setNumber = (input: HTMLInputElement, value: string) => React.act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const depthInput = container.querySelector<HTMLInputElement>('[aria-label="Pocket cut depth in millimetres"]')!;
+    setNumber(depthInput, "38.8");
+    expect(container.querySelector(issueSelector)).toBeNull();
+    setNumber(depthInput, "39");
+    expect(container.querySelector(issueSelector)).not.toBeNull();
+
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="bin-settings-jump-materials"]')!.click());
+    expect(container.querySelector('[aria-label="Pocket floor color warnings"]')!.textContent).toContain("Air Duster");
+    const thicknessInput = container.querySelector<HTMLInputElement>('[data-testid="input-pocket-floor-thickness"]')!;
+    setNumber(thicknessInput, "0.4");
+    expect(container.querySelector(issueSelector)).toBeNull();
+    setNumber(thicknessInput, "0.6");
+    expect(container.querySelector(issueSelector)).not.toBeNull();
+    const toggle = container.querySelector<HTMLButtonElement>('[role="switch"][aria-label="Color pocket floors"]')!;
+    React.act(() => toggle.click());
+    expect(container.querySelector(issueSelector)).toBeNull();
+    React.act(() => toggle.click());
+    expect(container.querySelector(issueSelector)).not.toBeNull();
+
+    openSettingsSection(container, "export");
+    const exportButton = container.querySelector<HTMLButtonElement>('[data-testid="button-export-3mf"]')!;
+    expect(exportButton.disabled).toBe(false);
+    React.act(() => exportButton.click());
+    expect(document.querySelector('[data-testid="export-floor-color-warning"]')!.textContent).toContain("Floor color may show on the underside");
+    expect(document.querySelector<HTMLButtonElement>('[data-testid="button-export-multicolor-3mf"]')!.disabled).toBe(false);
+    unmount();
+  });
+
   it("shows compact color swatches and configurable downward material depths", () => {
     binGeometryMock.hasPocketFloor = true;
     const { container, unmount } = renderPage();
@@ -1075,8 +1256,8 @@ describe("BinDesignerPage", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("test wrench");
     expect(text).toContain("Fit bin to contents");
-    expect(text).toContain("Select a pocket in the list or Layout view.");
-    expect(text).toContain("Click its name to rename it");
+    expect(text).toContain("Choose a pocket below to edit its size, depth, and shape.");
+    expect(text).toContain("Pocket properties");
     // Selected-pocket controls appear for the auto-selected cutout.
     expect(text).not.toContain("Editing selected tool");
     expect(text).toContain("Rotation");
@@ -1136,9 +1317,8 @@ describe("BinDesignerPage", () => {
     const renameButton = container.querySelector(
       '[data-testid="button-edit-shape-name"]',
     ) as HTMLButtonElement;
-    const selectedRow = renameButton.closest('[data-testid^="cutout-row-"]');
-    expect(selectedRow).not.toBeNull();
-    expect(selectedRow!.textContent).toContain("Selected");
+    expect(renameButton.closest('[data-testid="pocket-properties-heading"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid^="button-select-"][aria-pressed="true"]')?.textContent).toContain("Properties shown below");
     React.act(() => renameButton.click());
     const shapeName = container.querySelector(
       '[data-testid="input-shape-name"]',
@@ -1391,7 +1571,9 @@ describe("BinDesignerPage", () => {
     const text = container.textContent ?? "";
 
     expect(text).toContain("8,400 triangles");
-    expect(text).toContain("82.4 cm³");
+    expect(text).toContain("82.4 cm³ model volume");
+    expect(text).not.toContain("g solid PLA");
+    expect(text).toContain("Estimate filament weight in your slicer");
     expect(
       container.querySelector("#bin-settings-export [data-panel-section-trigger]")
         ?.textContent,
@@ -1463,6 +1645,9 @@ describe("BinDesignerPage", () => {
     ).toBe(false);
 
     React.act(() => {
+      [...document.querySelectorAll<HTMLButtonElement>('[role="dialog"] button')].find((button) => button.textContent === "Cancel")!.click();
+    });
+    React.act(() => {
       (
         container.querySelector(
           '[data-testid="button-export-stl"]',
@@ -1471,9 +1656,9 @@ describe("BinDesignerPage", () => {
     });
     expect(document.body.textContent).toContain("STL will not include your colors");
     expect(
-      document.querySelector('[data-testid="button-confirm-stl-without-colors"]'),
+      document.querySelector('[data-testid="button-confirm-export"]'),
     ).not.toBeNull();
-    expect(document.body.textContent).toContain("Use 3MF");
+    expect(document.body.textContent).toContain("Use multi-color 3MF");
     unmount();
   });
 });

--- a/client/src/pages/bin-designer.tsx
+++ b/client/src/pages/bin-designer.tsx
@@ -1,4 +1,4 @@
-import { History, Redo2, Undo2 } from "lucide-react";
+import { Box, History, Redo2, Undo2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { BinControlsPanel } from "@/components/gridfinity/bin-controls-panel";
@@ -366,28 +366,16 @@ function BinDesignerWorkspace(): JSX.Element {
   }, [cutouts, fingerHoles, library.shapes, spec.lip, spec.gridPitch, dispatch, toast, keepBinSize, spec]);
 
   const handleExportLayout = useCallback(
-    (format: "dxf" | "svg") => {
-      const shapesById = new Map(library.shapes.map((shape) => [shape.id, shape]));
-      const label = `${spec.gridX}x${spec.gridY}${
-        spec.gridPitch === "full" ? "" : `-${spec.gridPitch}`
-      }${spec.footprint.kind === "custom" ? `-custom-${spec.footprint.cells.length}cell` : ""}`;
-      if (format === "dxf") {
-        downloadBlob(
-          new Blob([generateLayoutDXF(spec, cutouts, shapesById, fingerHoles)], {
-            type: "application/dxf",
-          }),
-          `bin-layout-${label}.dxf`,
-        );
-      } else {
-        downloadBlob(
-          new Blob([generateLayoutSVG(spec, cutouts, shapesById, fingerHoles)], {
-            type: "image/svg+xml",
-          }),
-          `bin-layout-${label}.svg`,
-        );
-      }
+    (format: "dxf" | "svg", includeProject: boolean) => {
+      const { spec, cutouts, fingerHoles, shapes } = exportProjectDoc;
+      const shapesById = new Map(shapes.map((shape) => [shape.id, shape]));
+      const project = prepareProjectExport(exportProjectDoc, currentProjectName, "layout");
+      const model = format === "dxf"
+        ? new Blob([generateLayoutDXF(spec, cutouts, shapesById, fingerHoles)], { type: "application/dxf" })
+        : new Blob([generateLayoutSVG(spec, cutouts, shapesById, fingerHoles)], { type: "image/svg+xml" });
+      downloadModelWithProject(model, format, project, includeProject);
     },
-    [spec, cutouts, fingerHoles, library.shapes],
+    [exportProjectDoc, currentProjectName],
   );
 
   const handleExportProject = useCallback(() => {
@@ -602,7 +590,7 @@ function BinDesignerWorkspace(): JSX.Element {
   }, [dispatch]);
 
   const handleExport = useCallback(
-    async (format: "3mf" | "3mf-multicolor" | "stl") => {
+    async (format: "3mf" | "3mf-multicolor" | "stl", includeProject: boolean) => {
       setExporting(true);
       try {
         const label = binSizeLabel(exportProjectDoc.spec);
@@ -678,6 +666,7 @@ function BinDesignerWorkspace(): JSX.Element {
             new Blob([bytes], { type: "model/3mf" }),
             "3mf",
             project,
+            includeProject,
           );
         } else if (format === "3mf") {
           const bytes = writeThreeMf(
@@ -693,7 +682,7 @@ function BinDesignerWorkspace(): JSX.Element {
             ],
             { title: `Pocketry Gridfinity bin ${label}` },
           );
-          downloadModelWithProject(new Blob([bytes], { type: "model/3mf" }), "3mf", project);
+          downloadModelWithProject(new Blob([bytes], { type: "model/3mf" }), "3mf", project, includeProject);
         } else {
           const stl = writeBinarySTL(
             { positions: result.mesh.positions, indices: result.mesh.indices },
@@ -703,13 +692,12 @@ function BinDesignerWorkspace(): JSX.Element {
             new Blob([stl], { type: "application/octet-stream" }),
             "stl",
             project,
+            includeProject,
           );
         }
         toast({
           title: "Saved",
-          description: multicolor
-            ? `Exported bin ${label} as a multi-color 3MF with a matching portable JSON backup.`
-            : `Exported bin ${label} as ${format.toUpperCase()} with a matching portable JSON backup.`,
+          description: `Exported bin ${label} as ${multicolor ? "a multi-color 3MF" : format.toUpperCase()}${includeProject ? " with an editable project JSON" : ""}.`,
         });
       } catch (cause) {
         if (!(cause instanceof WorkerCancelledError)) {
@@ -739,7 +727,7 @@ function BinDesignerWorkspace(): JSX.Element {
   );
 
   const handleExportFitCheck = useCallback(
-    async (cutoutId: string, depthMm: number) => {
+    async (cutoutId: string, depthMm: number, includeProject: boolean) => {
       const cutout = exportProjectDoc.cutouts.find((candidate) => candidate.id === cutoutId);
       const shape = cutout
         ? library.shapes.find((candidate) => candidate.id === cutout.shapeId)
@@ -770,10 +758,11 @@ function BinDesignerWorkspace(): JSX.Element {
           new Blob([stl], { type: "application/octet-stream" }),
           "stl",
           project,
+          includeProject,
         );
         toast({
           title: "Fit template saved",
-          description: `Exported “${shape.name}” as a ${depthLabel} mm filled outline with a portable JSON backup of the full project.`,
+          description: `Exported “${shape.name}” as a ${depthLabel} mm filled outline${includeProject ? " with an editable project JSON" : ""}.`,
         });
       } catch (cause) {
         if (!(cause instanceof WorkerCancelledError)) {
@@ -791,7 +780,7 @@ function BinDesignerWorkspace(): JSX.Element {
   );
 
   const handleExportSurfaceFitCheck = useCallback(
-    async (thicknessMm: number) => {
+    async (thicknessMm: number, includeProject: boolean) => {
       setExporting(true);
       try {
         const label = binSizeLabel(exportProjectDoc.spec);
@@ -810,10 +799,11 @@ function BinDesignerWorkspace(): JSX.Element {
           new Blob([stl], { type: "application/octet-stream" }),
           "stl",
           project,
+          includeProject,
         );
         toast({
           title: "Surface fit test saved",
-          description: `Exported the complete pocket-layout surface at ${thicknessLabel} mm thick with a portable JSON backup of the full project.`,
+          description: `Exported the complete pocket-layout surface at ${thicknessLabel} mm thick${includeProject ? " with an editable project JSON" : ""}.`,
         });
       } catch (cause) {
         if (!(cause instanceof WorkerCancelledError)) {
@@ -844,12 +834,12 @@ function BinDesignerWorkspace(): JSX.Element {
           stats={stats}
           building={building}
           exporting={exporting}
-          onExport={(format) => void handleExport(format)}
-          onExportFitCheck={(cutoutId, depthMm) =>
-            void handleExportFitCheck(cutoutId, depthMm)
+          onExport={(format, includeProject) => void handleExport(format, includeProject)}
+          onExportFitCheck={(cutoutId, depthMm, includeProject) =>
+            void handleExportFitCheck(cutoutId, depthMm, includeProject)
           }
-          onExportSurfaceFitCheck={(thicknessMm) =>
-            void handleExportSurfaceFitCheck(thicknessMm)
+          onExportSurfaceFitCheck={(thicknessMm, includeProject) =>
+            void handleExportSurfaceFitCheck(thicknessMm, includeProject)
           }
           onExportLayout={handleExportLayout}
           onAutoArrange={handleAutoArrange}
@@ -911,6 +901,21 @@ function BinDesignerWorkspace(): JSX.Element {
             viewMode={viewMode}
             onChange={(mode) => dispatch({ type: "SET_VIEW_MODE", viewMode: mode })}
           />
+          {viewMode === "3d" && section && (
+            <div className="absolute left-3 top-12 z-30 flex max-w-[calc(100%_-_4.5rem)] flex-wrap items-center gap-x-3 gap-y-1 rounded-md border bg-background/95 p-2 shadow-sm backdrop-blur">
+              <span className="text-xs text-muted-foreground">Section view</span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={() => setSection(null)}
+                data-testid="button-show-full-bin"
+              >
+                <Box className="h-3.5 w-3.5" />
+                Show full bin
+              </Button>
+            </div>
+          )}
           <div className="absolute right-3 top-3 z-30 flex overflow-hidden rounded-md border bg-background/90 shadow-sm backdrop-blur">
             <Button
               variant="ghost"

--- a/client/src/pages/trace.test.tsx
+++ b/client/src/pages/trace.test.tsx
@@ -5,6 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PanelProvider } from "@/components/layout/panel-context";
 import { TraceProvider, useTrace } from "@/state/trace-store";
+import { downloadBlob } from "@/lib/download";
+import { generateSTL } from "@/lib/export/stl";
+import { parseProjectDoc } from "@shared/gridfinity/project";
+import type { Outline } from "@shared/geometry/types";
 
 import TracePage from "./trace";
 
@@ -36,8 +40,25 @@ vi.mock("@/components/layout/workspace-layout", () => ({
 }));
 
 vi.mock("@/components/trace/trace-controls-panel", () => ({
-  TraceControlsPanel: () => <div>Trace controls</div>,
+  TraceControlsPanel: ({ onExport }: { onExport: () => void }) => <button onClick={onExport} data-testid="export-trace">Export trace</button>,
 }));
+
+vi.mock("@/lib/download", () => ({ downloadBlob: vi.fn() }));
+vi.mock("@/lib/export/stl", () => ({ generateSTL: vi.fn() }));
+
+const exportOutline: Outline = [{ outer: [{ x: 10, y: 20 }, { x: 70, y: 20 }, { x: 70, y: 60 }, { x: 10, y: 60 }], holes: [] }];
+
+function SeedExportOutline({ format, calibrated = true }: { format: "svg" | "dxf" | "dwg" | "stl"; calibrated?: boolean }): null {
+  const { dispatch } = useTrace();
+  React.useEffect(() => {
+    dispatch({ type: "SOURCE_LOADED", imageUrl: "data:image/png;base64,source", fileName: "Test tool" });
+    dispatch({ type: "SOURCE_READY", imageSize: { width: 800, height: 600 } });
+    dispatch({ type: "OUTLINE_COMMITTED", outline: exportOutline });
+    if (calibrated) dispatch({ type: "SET_CALIBRATION", calibration: { startX: 0, startY: 0, endX: 100, endY: 0, lengthMm: 50 } });
+    dispatch({ type: "SET_EXPORT_FORMAT", exportFormat: format });
+  }, [dispatch, format, calibrated]);
+  return null;
+}
 
 vi.mock("@/components/trace/trace-canvas", () => ({
   TraceCanvas: ({
@@ -146,6 +167,7 @@ describe("Trace detection workflow", () => {
 
   beforeEach(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.mocked(generateSTL).mockResolvedValue(new ArrayBuffer(100));
     getImageDataMock.mockReturnValue({
       width: 300,
       height: 200,
@@ -168,6 +190,62 @@ describe("Trace detection workflow", () => {
     host.remove();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  it.each((["svg", "dxf", "dwg", "stl"] as const).flatMap((format) => [false, true].map((includeProject) => ({ format, includeProject }))))(
+    "exports Trace $format with JSON only when requested ($includeProject)",
+    async ({ format, includeProject }) => {
+      await React.act(async () => root.render(<PanelProvider><TraceProvider><SeedExportOutline format={format} /><TracePage /></TraceProvider></PanelProvider>));
+      // The existing DWG explanation is separate from the export request.
+      if (format === "dwg") React.act(() => [...document.querySelectorAll<HTMLButtonElement>('[role="dialog"] button')].find((button) => button.textContent === "Close")!.click());
+      React.act(() => host.querySelector<HTMLButtonElement>('[data-testid="export-trace"]')!.click());
+      const checkbox = document.querySelector<HTMLButtonElement>('[data-testid="checkbox-export-project"]')!;
+      expect(checkbox.getAttribute("aria-checked")).toBe("false");
+      expect(downloadBlob).not.toHaveBeenCalled();
+      if (includeProject) React.act(() => checkbox.click());
+      await React.act(async () => document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-export"]')!.click());
+      expect(downloadBlob).toHaveBeenCalledTimes(includeProject ? 2 : 1);
+      const [model, filename] = vi.mocked(downloadBlob).mock.calls.at(-1)!;
+      expect(model.size).toBeGreaterThan(0);
+      expect(filename).toBe(`${format === "stl" ? "model" : "outline"}_Test-tool.${format}`);
+      if (includeProject) {
+        const [backup, backupName] = vi.mocked(downloadBlob).mock.calls[0];
+        expect(backupName).toBe(filename.replace(/\.[^.]+$/, ".pocketry.json"));
+        const json = await new Promise<string>((resolve) => { const reader = new FileReader(); reader.onload = () => resolve(String(reader.result)); reader.readAsText(backup); });
+        const project = parseProjectDoc(JSON.parse(json));
+        expect(project?.shapes[0].bboxMm).toEqual({ minX: -15, maxX: 15, minY: -10, maxY: 10 });
+        expect(project?.shapes[0].sourceMmPerPx).toBe(0.5);
+        expect(project?.cutouts[0].shapeId).toBe(project?.shapes[0].id);
+      }
+    },
+  );
+
+  it("keeps uncalibrated outlines exportable but requires a scale for a Pocketry project", async () => {
+    await React.act(async () => root.render(<PanelProvider><TraceProvider><SeedExportOutline format="svg" calibrated={false} /><TracePage /></TraceProvider></PanelProvider>));
+    React.act(() => host.querySelector<HTMLButtonElement>('[data-testid="export-trace"]')!.click());
+    expect(document.querySelector<HTMLButtonElement>('[data-testid="checkbox-export-project"]')!.disabled).toBe(true);
+    expect(document.body.textContent).toContain("Set the scale to include an editable Pocketry project.");
+    await React.act(async () => document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-export"]')!.click());
+    expect(downloadBlob).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(downloadBlob).mock.calls[0][1]).toMatch(/\.svg$/);
+  });
+
+  it("cancels Trace export without building or downloading", async () => {
+    await React.act(async () => root.render(<PanelProvider><TraceProvider><SeedExportOutline format="stl" /><TracePage /></TraceProvider></PanelProvider>));
+    React.act(() => host.querySelector<HTMLButtonElement>('[data-testid="export-trace"]')!.click());
+    React.act(() => [...document.querySelectorAll<HTMLButtonElement>('[role="dialog"] button')].find((button) => button.textContent === "Cancel")!.click());
+    expect(generateSTL).not.toHaveBeenCalled();
+    expect(downloadBlob).not.toHaveBeenCalled();
+  });
+
+  it("downloads neither file when Trace STL generation fails", async () => {
+    vi.mocked(generateSTL).mockRejectedValueOnce(new Error("Mesh failed"));
+    await React.act(async () => root.render(<PanelProvider><TraceProvider><SeedExportOutline format="stl" /><TracePage /></TraceProvider></PanelProvider>));
+    React.act(() => host.querySelector<HTMLButtonElement>('[data-testid="export-trace"]')!.click());
+    React.act(() => document.querySelector<HTMLButtonElement>('[data-testid="checkbox-export-project"]')!.click());
+    await React.act(async () => document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-export"]')!.click());
+    expect(generateSTL).toHaveBeenCalledTimes(1);
+    expect(downloadBlob).not.toHaveBeenCalled();
   });
 
   it("links both calibration-sheet downloads above the empty drop zone", async () => {

--- a/client/src/pages/trace.tsx
+++ b/client/src/pages/trace.tsx
@@ -7,6 +7,7 @@ import { usePanelState } from "@/components/layout/panel-context";
 import { WorkspaceLayout } from "@/components/layout/workspace-layout";
 import { TraceCanvas } from "@/components/trace/trace-canvas";
 import { TraceControlsPanel } from "@/components/trace/trace-controls-panel";
+import { ExportConfirmationDialog } from "@/components/gridfinity/export-confirmation-dialog";
 import {
   decodeImageFile,
   fitWithin,
@@ -40,6 +41,8 @@ import {
   type TemplateVariant,
 } from "@/lib/calibrate/template";
 import { downloadBlob } from "@/lib/download";
+import { exportFilePart } from "@/lib/project/export";
+import { projectFromTrace } from "@/lib/project/trace-export";
 import { generateDXF } from "@/lib/export/dxf";
 import { exportScale } from "@/lib/export/scale";
 import { generateSTL } from "@/lib/export/stl";
@@ -78,6 +81,7 @@ function TraceWorkspace(): JSX.Element {
   const detectionRequest = useRef(0);
   const [uploadOpen, setUploadOpen] = useState(false);
   const [dwgDialogOpen, setDwgDialogOpen] = useState(false);
+  const [exportDialogOpen, setExportDialogOpen] = useState(false);
 
   const workingImageMax = store.perspectiveCorrection
     ? RECTIFIED_IMAGE_MAX
@@ -436,61 +440,45 @@ function TraceWorkspace(): JSX.Element {
     }, [source, store.processing, dispatch, workingImageMax],
   );
 
-  const handleExport = async () => {
-    const { outline, imageSize, exportFormat, extrusionHeight, fileName } = store;
+  const handleExport = async (includeProject: boolean) => {
+    const { outline, imageSize, exportFormat, extrusionHeight, fileName, calibration, margin } = store;
     if (outline.length === 0) {
-      toast({
-        title: "Nothing to export",
-        description: "Trace an image first.",
-        variant: "destructive",
-      });
+      toast({ title: "Nothing to export", description: "Trace an image first.", variant: "destructive" });
       return;
     }
-
-    const scale = exportScale(store.calibration, imageSize.height);
-    const base = fileName || "outline";
+    const scale = exportScale(calibration, imageSize.height);
+    const base = exportFilePart(fileName) || "outline";
+    const stem = `${exportFormat === "stl" ? "model" : "outline"}_${base}`;
 
     try {
+      // Capture the optional editable outline before asynchronous STL generation.
+      const backup = includeProject
+        ? new Blob([JSON.stringify(projectFromTrace(outline, scale, fileName || "Traced outline", margin ?? 0), null, 2)], { type: "application/json" })
+        : null;
+      let model: Blob;
       if (exportFormat === "svg") {
-        downloadBlob(
-          new Blob(
-            [
-              generateOutlineSVG(outline, {
-                width: imageSize.width,
-                height: imageSize.height,
-                mmPerPx: scale.mmPerPx,
-                calibration: store.calibration,
-              }),
-            ],
-            { type: "image/svg+xml" },
-          ),
-          `outline_${base}.svg`,
-        );
+        model = new Blob([generateOutlineSVG(outline, {
+          width: imageSize.width,
+          height: imageSize.height,
+          mmPerPx: scale.mmPerPx,
+          calibration,
+        })], { type: "image/svg+xml" });
       } else if (exportFormat === "dxf" || exportFormat === "dwg") {
-        downloadBlob(
-          new Blob([generateDXF(outline, scale)], { type: "application/dxf" }),
-          `outline_${base}.${exportFormat}`,
-        );
-        if (exportFormat === "dwg") {
-          toast({
-            title: "DWG compatibility file",
-            description:
-              "A DXF file was saved with a .dwg name; CAD software will open it.",
-            duration: 5000,
-          });
-        }
+        model = new Blob([generateDXF(outline, scale)], { type: "application/dxf" });
       } else {
-        const stl = await generateSTL(outline, {
-          heightMm: extrusionHeight,
-          scale,
-        });
-        downloadBlob(
-          new Blob([stl], { type: "application/octet-stream" }),
-          `model_${base}.stl`,
-        );
+        const stl = await generateSTL(outline, { heightMm: extrusionHeight, scale });
+        model = new Blob([stl], { type: "application/octet-stream" });
       }
-
-      toast({ title: "Saved", description: `Exported as ${exportFormat.toUpperCase()}.` });
+      if (backup) downloadBlob(backup, `${stem}.pocketry.json`);
+      downloadBlob(model, `${stem}.${exportFormat}`);
+      if (exportFormat === "dwg") {
+        toast({
+          title: "DWG compatibility file",
+          description: "A DXF file was saved with a .dwg name; CAD software will open it.",
+          duration: 5000,
+        });
+      }
+      toast({ title: "Saved", description: `Exported as ${exportFormat.toUpperCase()}${includeProject ? " with an editable outline project" : ""}.` });
     } catch (error) {
       toast({
         title: "Export failed",
@@ -515,6 +503,17 @@ function TraceWorkspace(): JSX.Element {
 
   return (
     <>
+      {exportDialogOpen && (
+        <ExportConfirmationDialog
+          title={`Save outline ${store.exportFormat.toUpperCase()}?`}
+          description="Download the current traced outline in the selected format."
+          confirmLabel={`Download ${store.exportFormat.toUpperCase()}`}
+          backupDescription="Reopen this calibrated outline as an editable pocket in Bin."
+          backupDisabledReason={mmPerPixel(store.calibration) === null ? "Set the scale to include an editable Pocketry project." : undefined}
+          onCancel={() => setExportDialogOpen(false)}
+          onConfirm={(includeProject) => { setExportDialogOpen(false); void handleExport(includeProject); }}
+        />
+      )}
       <input ref={photoInputRef} type="file" accept="image/png,image/jpeg,image/webp" className="hidden" aria-label="Choose another photo"
         onChange={(event) => { const file = event.target.files?.[0]; if (file) void handleFileSelected(file); event.target.value = ""; }} />
       <WorkspaceLayout
@@ -526,7 +525,7 @@ function TraceWorkspace(): JSX.Element {
           <TraceControlsPanel
             onReplaceImage={() => photoInputRef.current?.click()}
             onRotateImage={handleRotateImage}
-            onExport={() => void handleExport()}
+            onExport={() => setExportDialogOpen(true)}
             onReprocess={(settings) => void runDetection(settings)}
             onDetectMarkers={() => void detectMarkers(true)}
             onApplyPerspective={(proposal, paper) =>

--- a/docs/gridfinity-plan.md
+++ b/docs/gridfinity-plan.md
@@ -25,6 +25,27 @@ spacing, effective depth/floor measurements, trace-margin provenance, and a dire
 and can select the affected objects. **Materials**, **View**, and **Check fit** are
 separate sections, with thin fit checks available before full model export.
 
+Precision positioning, dimensions, and spacing are collapsed under **Fine-tune
+position & size**. Depth and floor measurements stay in a compact row with an
+expandable diagram. Pocket inspection exposes **Show full bin** both beside the
+3D model and in the pocket controls. The 3MF color dialog wraps its choices within
+the available width and scrolls on short screens. Export statistics show model
+volume; filament weight is left to the slicer's infill and wall settings.
+
+Selecting a pocket in Layout also exposes **Edit Contour** beside the canvas,
+with **Finish contour editing** to return to placement. The portable project
+download and open actions appear side by side. Bin model, fit-template, and
+DXF/SVG layout exports offer an unchecked **Also download editable project**
+checkbox; canceling does not build or download files. When requested, the JSON
+and exported geometry come from the same snapshot and share a filename stem.
+Trace SVG, DXF, DWG-compatibility, and STL exports offer the same choice. Their
+optional JSON reopens the current calibrated outline as an editable pocket in a
+new Bin project, preserving its contour, physical scale, and trace margin. This
+option requires calibration; exporting an outline alone remains available without it.
+Pocket rows are full selection buttons with an explicit **Edit properties** label,
+persistent borders, and a highlighted selected state. Selecting a row brings the
+named **Pocket properties** header into view; renaming is a separate action there.
+
 Project schema 10 adds optional names, the fixed-size preference, and trace-margin
 metadata. Versions 1–9 remain supported through explicit migration; the supplied
 version-9 Airduster fixture verifies all seven shapes, four placements, and two
@@ -32,7 +53,7 @@ finger-access features survive a library save and portable JSON round trip. New
 outside-only defaults never alter imported contours. Legacy IndexedDB keys are
 retained, unreadable library records are preserved, and autosave refuses to
 overwrite an unreadable working copy. The project header reports save success or
-failure, and STL/3MF exports continue to download the editable project backup first.
+failure. When an export includes an editable project, its JSON is downloaded first.
 
 Nonrectangular bin footprints landed on 2026-08-27. A bin can now use a
 connected, hole-free mask at the selected full/half/quarter pitch, so a 2×2
@@ -182,7 +203,13 @@ depths are independently selectable from 0.2–3.0 mm for pocket floors and
 defaults). The rim limit is the full
 modeled lip depth and does not extend into the bin wall. Both accents are cut
 downward from the original surfaces, never added above them; STL warns before
-dropping those color assignments. Hole regression worth
+dropping those color assignments. Pocket controls, Materials, and export show a
+nonblocking warning when a pocket's colored floor layer reaches the underside
+recesses. This uses the resolved depth and selected color thickness: ordinary
+base recesses rise to 4.75 mm, while lite cavities and full-pitch screw bores can
+reach 7 mm. The check is conservative because actual exposure also depends on
+the pocket's position. Reducing depth or color thickness, increasing the remaining
+floor, or disabling floor coloring updates the warning immediately. Hole regression worth
 remembering: abutting union pieces whose faces share no vertices don't weld —
 the genus invariant caught the resulting sealed voids; pieces now overlap.
 

--- a/shared/gridfinity/validate-pocket-floor-materials.test.ts
+++ b/shared/gridfinity/validate-pocket-floor-materials.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCutoutPlacement, type DepthSpec, type TracedShape } from "./cutout";
+import { parseBinSpec, type BinSpecInput } from "./types";
+import { validatePocketFloorMaterials } from "./validate";
+
+const shape: TracedShape = {
+  id: "tool", name: "Air Duster", sourceMmPerPx: 0.5, pointCount: 4,
+  bboxMm: { minX: -15, minY: -10, maxX: 15, maxY: 10 },
+  outlineMm: [{ outer: [{ x: -15, y: -10 }, { x: 15, y: -10 }, { x: 15, y: 10 }, { x: -15, y: 10 }], holes: [] }],
+};
+const shapes = new Map([[shape.id, shape]]);
+const fixedDepth: DepthSpec = { mode: "mm", value: 39 };
+function warnings(depth: DepthSpec = fixedDepth, thickness = 0.6, overrides: Partial<BinSpecInput> = {}) {
+  return validatePocketFloorMaterials(
+    parseBinSpec({ gridX: 4, gridY: 4, heightUnits: 6.5, fill: "solid", ...overrides }),
+    [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 }, depth })],
+    shapes,
+    thickness,
+  );
+}
+
+describe("pocket floor material warnings", () => {
+  it("warns for a 5.3 mm floor whose color reaches the raised underside, even without magnet holes", () => {
+    expect(warnings()).toEqual([expect.objectContaining({
+      code: "floor-color-on-underside", severity: "warning", cutoutIds: ["pocket"],
+    })]);
+    expect(warnings()[0].message).toContain("Air Duster");
+    expect(warnings()[0].message).toContain("0.60 mm");
+    expect(warnings()[0].message).toContain("recesses between the base feet");
+  });
+
+  it("also checks remaining-floor mode and contact with the underside boundary", () => {
+    expect(warnings({ mode: "remaining", floorThicknessMm: 5.35 })).toHaveLength(1);
+    expect(warnings({ mode: "remaining", floorThicknessMm: 5.36 })).toEqual([]);
+    expect(warnings({ mode: "remaining", floorThicknessMm: 7 })).toEqual([]);
+  });
+
+  it("clears after reducing fixed depth, increasing bin height, or removing the lip allowance", () => {
+    expect(warnings({ mode: "mm", value: 38.8 })).toEqual([]);
+    expect(warnings(fixedDepth, 0.6, { heightUnits: 7 })).toEqual([]);
+    expect(warnings(fixedDepth, 0.6, { lip: "none" })).toEqual([]);
+  });
+
+  it("responds to color thickness without needing a geometry rebuild", () => {
+    expect(warnings(fixedDepth, 0.4)).toEqual([]);
+    expect(warnings(fixedDepth, 0.6)).toHaveLength(1);
+    expect(warnings({ mode: "remaining", floorThicknessMm: 5.8 }, 0.6)).toEqual([]);
+    expect(warnings({ mode: "remaining", floorThicknessMm: 5.8 }, 1.2)).toHaveLength(1);
+  });
+
+  it.each(["half", "quarter"] as const)("checks the shaped underside for %s pitch", (gridPitch) => {
+    expect(warnings(fixedDepth, 0.6, { gridPitch })).toHaveLength(1);
+  });
+
+  it.each([{ screwHoles: true }, { liteBase: true }])("accounts for taller recesses with %o", (options) => {
+    expect(warnings({ mode: "remaining", floorThicknessMm: 7.4 }, 0.6, options)).toHaveLength(1);
+    expect(warnings({ mode: "remaining", floorThicknessMm: 7.7 }, 0.6, options)).toEqual([]);
+  });
+
+  it("ignores screw holes on a pitch where the builder omits them", () => {
+    expect(warnings({ mode: "remaining", floorThicknessMm: 7 }, 0.6, { screwHoles: true, gridPitch: "half" })).toEqual([]);
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])("ignores a disabled or invalid color thickness %s", (thickness) => {
+    expect(warnings(fixedDepth, thickness)).toEqual([]);
+  });
+
+  it.each<DepthSpec>([
+    { mode: "through" }, { mode: "remaining", floorThicknessMm: 0 },
+    { mode: "mm", value: 100 }, { mode: "remaining", floorThicknessMm: 50 },
+  ])("does not add material warnings for a pocket without a printable floor: %o", (depth) => {
+    expect(warnings(depth)).toEqual([]);
+  });
+
+  it("leaves missing shapes and absent infill to layout validation", () => {
+    expect(warnings(fixedDepth, 0.6, { fill: "none" })).toEqual([]);
+    expect(validatePocketFloorMaterials(
+      parseBinSpec({ gridX: 2, gridY: 2, heightUnits: 6, fill: "solid" }),
+      [parseCutoutPlacement({ id: "missing", shapeId: "missing", position: { x: 0, y: 0 }, depth: { mode: "remaining", floorThicknessMm: 5 } })],
+      shapes, 0.6,
+    )).toEqual([]);
+  });
+});

--- a/shared/gridfinity/validate.ts
+++ b/shared/gridfinity/validate.ts
@@ -25,6 +25,7 @@ import {
 } from "./cutout";
 import {
   BASE_HEIGHT,
+  BASE_PROFILE_HEIGHT,
   binHeightMm,
   binWallHeightMm,
   D_DIV,
@@ -68,6 +69,47 @@ export interface ValidationResult {
   issues: ValidationIssue[];
   /** True when nothing blocks building/exporting this spec. */
   ok: boolean;
+}
+
+/**
+ * Conservative depth check for floor colors reaching an underside recess.
+ * The ordinary underside rises to the bridge at BASE_PROFILE_HEIGHT; lite
+ * cavities and full-pitch screw bores can reach BASE_HEIGHT. Actual exposure
+ * also depends on where the pocket overlaps those features, so this is a
+ * warning, not a claim that every affected pocket has an exposed color face.
+ * Pass zero when floor coloring is disabled. Like the builder, the colored
+ * volume extends down from the resolved floor and stops at z = 0.
+ */
+export function validatePocketFloorMaterials(
+  spec: BinSpec,
+  cutouts: readonly CutoutPlacement[],
+  shapesById: ReadonlyMap<string, TracedShape>,
+  floorColorThicknessMm: number,
+): ValidationIssue[] {
+  if (spec.fill !== "solid" || !Number.isFinite(floorColorThicknessMm) || floorColorThicknessMm <= 0) return [];
+
+  const hasScrewBores = spec.screwHoles && spec.gridPitch === "full";
+  const undersideHeightMm = spec.liteBase || hasScrewBores ? BASE_HEIGHT : BASE_PROFILE_HEIGHT;
+  const recess = spec.liteBase ? "the hollow base" : hasScrewBores ? "the screw holes" : "the recesses between the base feet";
+  const issues: ValidationIssue[] = [];
+  for (const cutout of cutouts) {
+    const shape = shapesById.get(cutout.shapeId);
+    const { floorZ, depthMm } = resolvePocketDepth(spec, cutout.depth);
+    // Invalid and through pockets have no printable floor-color volume.
+    if (!shape || floorZ === null || floorZ <= 0 || depthMm === null || depthMm <= 0) continue;
+    const thicknessMm = Math.min(floorColorThicknessMm, floorZ);
+    if (floorZ - thicknessMm > undersideHeightMm + 1e-6) continue;
+    issues.push({
+      code: "floor-color-on-underside",
+      severity: "warning",
+      cutoutIds: [cutout.id],
+      message:
+        `“${shape.name}”: Floor color may show on the underside. ` +
+        `The ${thicknessMm.toFixed(2)} mm color layer reaches ${recess}. ` +
+        `Reduce pocket depth, increase the remaining floor, or use a thinner color layer.`,
+    });
+  }
+  return issues;
 }
 
 /** Print beds this side of a Voron 350 top out around here. */


### PR DESCRIPTION
Miscellaneous UI improvements.

Pocket selection and precision controls interrupted the normal editing flow, 3MF choices could overflow their dialog, and inspecting a pocket left the model in a section view without a nearby way back. This change makes pocket selection explicit, collapses fine tuning, adds Edit Contour in Layout, and provides Show full bin beside both the model and pocket controls.

- Keep export dialogs within narrow and short screens; place Download editable project and Open Pocketry project side by side.
- Make the editable project JSON an unchecked option in export confirmations for Bin models, fit templates, layout outlines, and Trace exports. Requested backups and exported geometry use the same snapshot and filename stem. Trace backups reopen the calibrated outline as an editable pocket in a new Bin project.
- Replace the solid-PLA weight estimate with model volume; filament estimates belong to the slicer settings.
- Warn when a colored pocket floor may reach underside recesses. For example, a 39 mm pocket in a 6.5u bin leaves a 5.3 mm floor, and a 0.6 mm color layer reaches below the 4.75 mm recess ceiling. Warnings identify the pocket in its controls and Materials and appear again in the 3MF dialog. They update with depth and material changes and do not block export. The depth check is conservative because exposure also depends on pocket placement.
