### PR TITLE
Add optional flat bottoms under Construction

### DIFF
--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -373,8 +373,9 @@ export function BinControlsPanel({
   const enabledFeatureCount = [
     spec.lip === "standard",
     spec.fill === "solid",
-    spec.magnetHoles,
-    spec.screwHoles,
+    spec.flatBottom,
+    !spec.flatBottom && spec.magnetHoles,
+    !spec.flatBottom && spec.screwHoles,
     spec.labelTab !== null,
   ].filter(Boolean).length;
   const [fitCheckDepthMm, setFitCheckDepthMm] = useState(2);
@@ -685,13 +686,19 @@ export function BinControlsPanel({
           title="Construction"
           icon={Magnet}
           tone="rose"
-          summary={`${enabledFeatureCount} on`}
+          summary={spec.flatBottom ? "Flat bottom" : `${enabledFeatureCount} on`}
           defaultOpen={false}
           className="scroll-mt-16"
         >
           <FeatureSwitch
+            label="Flat bottom"
+            description="Smooth underside; no Gridfinity base."
+            checked={spec.flatBottom}
+            onChange={(flatBottom) => patchSpec({ flatBottom })}
+          />
+          <FeatureSwitch
             label="Stacking lip"
-            description="Lets another bin stack on top"
+            description={spec.flatBottom ? "Receives a Gridfinity bin on top" : "Lets another bin stack on top"}
             checked={spec.lip === "standard"}
             onChange={(on) => patchSpec({ lip: on ? "standard" : "none" })}
           />
@@ -701,36 +708,40 @@ export function BinControlsPanel({
             checked={spec.fill === "solid"}
             onChange={(on) => patchSpec({ fill: on ? "solid" : "none" })}
           />
-          <FeatureSwitch
-            label="Magnet holes"
-            description={
-              spec.gridPitch === "full"
-                ? "⌀6.5 × 2.4 mm, four per cell"
-                : "Available on the full 42 mm pitch"
-            }
-            checked={spec.magnetHoles}
-            disabled={spec.gridPitch !== "full"}
-            onChange={(magnetHoles) => patchSpec({ magnetHoles })}
-          />
-          {spec.magnetHoles && (
-            <FeatureSwitch
-              label="Crush ribs"
-              description="Press-fit magnets, no glue"
-              checked={spec.magnetCrushRibs}
-              onChange={(magnetCrushRibs) => patchSpec({ magnetCrushRibs })}
-            />
+          {!spec.flatBottom && (
+            <>
+              <FeatureSwitch
+                label="Magnet holes"
+                description={
+                  spec.gridPitch === "full"
+                    ? "⌀6.5 × 2.4 mm, four per cell"
+                    : "Available on the full 42 mm pitch"
+                }
+                checked={spec.magnetHoles}
+                disabled={spec.gridPitch !== "full"}
+                onChange={(magnetHoles) => patchSpec({ magnetHoles })}
+              />
+              {spec.magnetHoles && (
+                <FeatureSwitch
+                  label="Crush ribs"
+                  description="Press-fit magnets, no glue"
+                  checked={spec.magnetCrushRibs}
+                  onChange={(magnetCrushRibs) => patchSpec({ magnetCrushRibs })}
+                />
+              )}
+              <FeatureSwitch
+                label="Screw holes"
+                description={
+                  spec.gridPitch === "full"
+                    ? "⌀3 mm M3, through the base"
+                    : "Available on the full 42 mm pitch"
+                }
+                checked={spec.screwHoles}
+                disabled={spec.gridPitch !== "full"}
+                onChange={(screwHoles) => patchSpec({ screwHoles })}
+              />
+            </>
           )}
-          <FeatureSwitch
-            label="Screw holes"
-            description={
-              spec.gridPitch === "full"
-                ? "⌀3 mm M3, through the base"
-                : "Available on the full 42 mm pitch"
-            }
-            checked={spec.screwHoles}
-            disabled={spec.gridPitch !== "full"}
-            onChange={(screwHoles) => patchSpec({ screwHoles })}
-          />
 
           <div className="space-y-2 border-t pt-3">
             <div className="flex items-center gap-2">

--- a/client/src/lib/gridfinity/bin.test.ts
+++ b/client/src/lib/gridfinity/bin.test.ts
@@ -323,3 +323,34 @@ describe("stacking fit (software mating test)", () => {
     expect(overlap.volume()).toBeGreaterThan(1e-3);
   });
 });
+
+describe("flat bottoms", () => {
+  it.each(["full", "half", "quarter"] as const)("fills the underside for %s pitch at preview and export quality", (gridPitch) => {
+    for (const quality of [PREVIEW_QUALITY, EXPORT_QUALITY]) {
+      const ordinarySpec = spec({ gridPitch });
+      const flatSpec = { ...ordinarySpec, flatBottom: true };
+      const ordinary = buildBinParts(kernel, ordinarySpec, quality);
+      const flat = buildBinParts(kernel, flatSpec, quality);
+      expect(flat.base.status()).toBe("NoError");
+      expect(flat.base.genus()).toBe(0);
+      expect(flat.base.boundingBox()).toEqual(ordinary.base.boundingBox());
+      expect(arena.track(flat.base.slice(0.1)).area()).toBeCloseTo(arena.track(flat.base.slice(6.9)).area(), 5);
+      expect(flat.base.volume()).toBeGreaterThan(ordinary.base.volume());
+      expect(binDimensionsMm(flatSpec)).toEqual(binDimensionsMm(ordinarySpec));
+      expect(flat.wall!.volume()).toBeCloseTo(ordinary.wall!.volume(), 6);
+      expect(buildBin(kernel, flatSpec, quality).solid.status()).toBe("NoError");
+    }
+  });
+
+  it("keeps a custom footprint and ignores dormant base holes", () => {
+    const flatSpec = spec({ gridX: 2, gridY: 2, flatBottom: true,
+      footprint: { kind: "custom", cells: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 0, y: 1 }] } });
+    const plain = buildBinParts(kernel, flatSpec, QUALITY).base;
+    const holes = buildBinParts(kernel, { ...flatSpec, magnetHoles: true, screwHoles: true, magnetCrushRibs: true }, QUALITY).base;
+    expect(plain.volume()).toBeCloseTo(holes.volume(), 6);
+    expect(arena.track(plain.slice(0.1)).area()).toBeCloseTo(arena.track(plain.slice(6.9)).area(), 5);
+    const rectangle = buildBinParts(kernel, { ...flatSpec, footprint: { kind: "rectangle" } }, QUALITY).base;
+    expect(plain.volume()).toBeLessThan(rectangle.volume());
+    expect(buildBin(kernel, flatSpec, QUALITY).solid.status()).toBe("NoError");
+  });
+});

--- a/client/src/lib/gridfinity/bin.ts
+++ b/client/src/lib/gridfinity/bin.ts
@@ -91,7 +91,7 @@ export const MULTICOLOR_RIM_MAX_THICKNESS_MM = Math.floor(
 ) / 100;
 
 export interface BinParts {
-  /** Sockets plus bridge, z ∈ [0, 7]. */
+  /** Sockets plus bridge, or a flat slab, z ∈ [0, 7]. */
   base: Manifold;
   /** Plain wall ring, z ∈ [7, units·7]. `null` for 1u bins (zero height). */
   wall: Manifold | null;
@@ -131,12 +131,14 @@ export function buildBinParts(
   const { CrossSection, arena } = kernel;
   const segments = quality.circularSegments;
 
-  const base = buildBase(
-    kernel,
-    spec,
-    segments,
-    spec.gridPitch === "full" ? holeOptionsFromSpec(spec) : undefined,
-  );
+  const base = spec.flatBottom
+    ? arena.track(footprintOuterSection(kernel, spec, segments).extrude(BASE_HEIGHT))
+    : buildBase(
+        kernel,
+        spec,
+        segments,
+        spec.gridPitch === "full" ? holeOptionsFromSpec(spec) : undefined,
+      );
   let wall = buildWallRing(kernel, spec, segments);
   const lip = spec.lip === "standard"
     ? buildStackingLip(kernel, spec, segments, quality.filletProfileStepMm)

--- a/client/src/lib/project/persist.test.ts
+++ b/client/src/lib/project/persist.test.ts
@@ -51,11 +51,11 @@ describe("current project persistence", () => {
     memory.set("tooltrace:project:v1", structuredClone(airdusterV9));
     const migrated = (await loadProjectDoc())!;
     const { liteBase: _removed, ...spec } = airdusterV9.spec;
-    expect(migrated).toEqual({ ...airdusterV9, spec, schemaVersion: PROJECT_SCHEMA_VERSION });
+    expect(migrated).toEqual({ ...airdusterV9, spec: { ...spec, flatBottom: false }, schemaVersion: PROJECT_SCHEMA_VERSION });
     await saveProjectToLibrary(migrated, "New Airduster Layout", null);
     const reloaded = (await loadProjectDoc())!;
     const exported = JSON.parse(await prepareProjectExport(reloaded, reloaded.name!).backup.text());
-    expect(exported).toEqual({ ...airdusterV9, spec, schemaVersion: PROJECT_SCHEMA_VERSION, name: "New Airduster Layout" });
+    expect(exported).toEqual({ ...airdusterV9, spec: { ...spec, flatBottom: false }, schemaVersion: PROJECT_SCHEMA_VERSION, name: "New Airduster Layout" });
   });
   it("never overwrites an unsupported working copy during autosave", async () => {
     const future = { schemaVersion: 999, valuable: { outlines: [1, 2, 3] } };

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -489,6 +489,24 @@ describe("BinDesignerPage", () => {
     unmount();
   });
 
+  it("toggles flat bottoms without resizing and restores base hole preferences", async () => {
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "construction");
+    const control = (label: string) => container.querySelector<HTMLButtonElement>(`[role="switch"][aria-label="${label}"]`)!;
+    const dimensions = container.querySelector("#bin-settings-size")!.textContent;
+    React.act(() => control("Magnet holes").click());
+    expect(control("Magnet holes").getAttribute("aria-checked")).toBe("true");
+    React.act(() => control("Flat bottom").click());
+    expect(control("Flat bottom").getAttribute("aria-checked")).toBe("true");
+    expect(control("Magnet holes")).toBeNull();
+    expect(control("Screw holes")).toBeNull();
+    expect(container.querySelector("#bin-settings-size")!.textContent).toBe(dimensions);
+    React.act(() => control("Flat bottom").click());
+    expect(control("Magnet holes").getAttribute("aria-checked")).toBe("true");
+    unmount();
+  });
+
   it("sets width, length, and height in half-unit increments", async () => {
     const { container, unmount } = renderPage();
     await flushHydration();

--- a/docs/gridfinity-plan.md
+++ b/docs/gridfinity-plan.md
@@ -150,7 +150,11 @@ and ⌀6.5 for glue-free press-fit magnets, a per-spec toggle under Magnet
 holes. The earlier modeled Lite Base option was removed: ordinary slicer
 infill already provides the intended material savings without permanently
 adding hollow chambers and special pocket-floor support to the exported
-model. **Half/quarter grid**
+model. **Flat bottom** is an optional Construction setting that replaces the
+Gridfinity sockets with a smooth 7 mm base, preserving outer size and pocket
+heights. Base magnet/screw holes are inactive in this mode; their settings
+return when switched off. Existing projects retain the Gridfinity base.
+**Half/quarter grid**
 landed as explicit 21/10.5 mm pitch modes while retaining the upstream 0.5 mm
 gap; fractional magnet/screw patterns are disabled until the corner-only hole
 layout is ported. Baseplate generation was intentionally removed from

--- a/shared/gridfinity/project.test.ts
+++ b/shared/gridfinity/project.test.ts
@@ -48,7 +48,7 @@ describe("parseProjectDoc", () => {
     const original = JSON.stringify(airdusterV9);
     const doc = parseProjectDoc(airdusterV9);
     const { liteBase: _removed, ...spec } = airdusterV9.spec;
-    expect(doc).toEqual({ ...airdusterV9, spec, schemaVersion: PROJECT_SCHEMA_VERSION });
+    expect(doc).toEqual({ ...airdusterV9, spec: { ...spec, flatBottom: false }, schemaVersion: PROJECT_SCHEMA_VERSION });
     expect(doc!.shapes).toHaveLength(7);
     expect(doc!.cutouts).toHaveLength(4);
     expect(doc!.fingerHoles).toHaveLength(2);
@@ -350,5 +350,18 @@ describe("removed Lite Base migration", () => {
     const current = parseProjectDoc(VALID)!;
     expect(parseProjectDoc({ ...current, schemaVersion: 10, spec: { ...current.spec, liteBase: "yes" } })).toBeNull();
     expect(parseProjectDoc({ ...current, spec: { ...current.spec, liteBase: true } })).toBeNull();
+  });
+});
+
+
+describe("flat bottom projects", () => {
+  it("defaults existing v11 documents to Gridfinity and preserves flat projects on reload", () => {
+    const legacy = JSON.parse(JSON.stringify(VALID));
+    legacy.schemaVersion = 11;
+    delete legacy.spec.flatBottom;
+    expect(parseProjectDoc(legacy)?.spec.flatBottom).toBe(false);
+    const flat = parseProjectDoc({ ...VALID, spec: { ...VALID.spec, flatBottom: true } });
+    expect(flat?.spec.flatBottom).toBe(true);
+    expect(parseProjectDoc(JSON.parse(JSON.stringify(flat)))).toEqual(flat);
   });
 });

--- a/shared/gridfinity/project.ts
+++ b/shared/gridfinity/project.ts
@@ -26,9 +26,10 @@ import { binSpecSchema } from "./types";
  * version 9 adds per-finger-hole top and bottom edge fillets; version 10 adds
  * optional project names, fixed-size preference, and trace margin provenance.
  * Version 11 removes Lite Base; older projects use the ordinary Gridfinity base.
+ * Version 12 adds an optional flat bottom, defaulting off for existing projects.
  */
 
-export const PROJECT_SCHEMA_VERSION = 11 as const;
+export const PROJECT_SCHEMA_VERSION = 12 as const;
 
 const projectFields = {
   shapes: z.array(tracedShapeSchema),
@@ -67,6 +68,8 @@ export const projectDocSchema = z
     keepBinSize: z.boolean().optional(),
   })
   .strict();
+
+const version11ProjectSchema = projectDocSchema.extend({ schemaVersion: z.literal(11) });
 
 const version10ProjectSchema = projectDocSchema.extend({ schemaVersion: z.literal(10) });
 
@@ -150,6 +153,8 @@ export function parseProjectDoc(input: unknown): ProjectDoc | null {
       input = { ...doc, spec };
     }
   }
+  const version11 = version11ProjectSchema.safeParse(input);
+  if (version11.success) return projectDocSchema.parse({ ...version11.data, schemaVersion: PROJECT_SCHEMA_VERSION });
   const version10 = version10ProjectSchema.safeParse(input);
   if (version10.success) return projectDocSchema.parse({ ...version10.data, schemaVersion: PROJECT_SCHEMA_VERSION });
   const version9 = version9ProjectSchema.safeParse(input);

--- a/shared/gridfinity/types.ts
+++ b/shared/gridfinity/types.ts
@@ -58,6 +58,8 @@ export const binSpecSchema = z
      * default. `none` is the classic hollow storage bin.
      */
     fill: z.enum(["none", "solid"]).default("solid"),
+    /** Smooth underside without Gridfinity sockets; preserves outer size and pocket heights. */
+    flatBottom: z.boolean().default(false),
     /** ⌀6.5 × 2.4 mm magnet pockets, four per cell, opening downward. */
     magnetHoles: z.boolean().default(false),
     /**

--- a/shared/gridfinity/validate-pocket-floor-materials.test.ts
+++ b/shared/gridfinity/validate-pocket-floor-materials.test.ts
@@ -21,6 +21,10 @@ function warnings(depth: DepthSpec = fixedDepth, thickness = 0.6, overrides: Par
 }
 
 describe("pocket floor material warnings", () => {
+  it("does not warn about underside recesses for a flat bottom, including dormant holes", () => {
+    expect(warnings(fixedDepth, 0.6, { flatBottom: true, screwHoles: true, magnetHoles: true })).toEqual([]);
+  });
+
   it("warns for a 5.3 mm floor whose color reaches the raised underside, even without magnet holes", () => {
     expect(warnings()).toEqual([expect.objectContaining({
       code: "floor-color-on-underside", severity: "warning", cutoutIds: ["pocket"],

--- a/shared/gridfinity/validate.ts
+++ b/shared/gridfinity/validate.ts
@@ -86,7 +86,7 @@ export function validatePocketFloorMaterials(
   shapesById: ReadonlyMap<string, TracedShape>,
   floorColorThicknessMm: number,
 ): ValidationIssue[] {
-  if (spec.fill !== "solid" || !Number.isFinite(floorColorThicknessMm) || floorColorThicknessMm <= 0) return [];
+  if (spec.flatBottom || spec.fill !== "solid" || !Number.isFinite(floorColorThicknessMm) || floorColorThicknessMm <= 0) return [];
 
   const hasScrewBores = spec.screwHoles && spec.gridPitch === "full";
   const undersideHeightMm = hasScrewBores ? BASE_HEIGHT : BASE_PROFILE_HEIGHT;
@@ -161,7 +161,7 @@ export function validateBinSpec(spec: BinSpec): ValidationResult {
     }
   }
 
-  if (spec.gridPitch !== "full" && (spec.magnetHoles || spec.screwHoles)) {
+  if (!spec.flatBottom && spec.gridPitch !== "full" && (spec.magnetHoles || spec.screwHoles)) {
     issues.push({
       code: "fractional-grid-holes",
       severity: "warning",
@@ -473,7 +473,7 @@ function validateAgainstBin(spec: BinSpec, p: PlacedCutout): ValidationIssue[] {
       message: `“${label}” leaves a ${pocket.floorZ.toFixed(1)} mm floor — likely to flex or delaminate.`,
         });
       }
-      if (spec.magnetHoles && pocket.floorZ < BASE_HEIGHT) {
+      if (!spec.flatBottom && spec.magnetHoles && pocket.floorZ < BASE_HEIGHT) {
         issues.push({
           code: "floor-in-base",
           severity: "warning",


### PR DESCRIPTION
Add a default-off Flat bottom toggle under Construction. It replaces Gridfinity feet with a smooth base while preserving outer dimensions, pocket heights, and the existing editing flow. Base magnet/screw controls are hidden while enabled and their preferences return when switched off.

Project schema v12 saves the choice; older projects default to Gridfinity. Preview and exports share the geometry path, including fractional pitches and custom footprints. Flat bottoms omit warnings about absent base recesses and magnet holes.

Validation: type-check, all 1,030 tests, production build, and browser interaction check passed. The local preview is updated for human review.

Closes #30.
