### PR TITLE
Use thinner default pocket floors for flat-bottom bins

### DIFF
--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -35,6 +35,7 @@ import {
   DEFAULT_TOP_EDGE_FILLET_MM,
   MAX_OBLONG_DEEP_SCOOP_LENGTH_MM,
   MIN_OBLONG_DEEP_SCOOP_SPAN_MM,
+  defaultPocketFloorThicknessMm,
   resolvePocketDepth,
   type FingerHole,
   type TracedShape,
@@ -1105,8 +1106,8 @@ export function BinControlsPanel({
                       mode === "through"
                         ? ({ mode: "through" } as const)
                         : mode === "mm"
-                          ? ({ mode: "mm", value: Math.max(0.1, resolved.depthMm ?? resolved.infillTopZ - 7) } as const)
-                          : ({ mode: "remaining", floorThicknessMm: Math.max(0, resolved.floorZ ?? 7) } as const);
+                          ? ({ mode: "mm", value: Math.max(0.1, resolved.depthMm ?? resolved.infillTopZ - defaultPocketFloorThicknessMm(spec)) } as const)
+                          : ({ mode: "remaining", floorThicknessMm: Math.max(0, resolved.floorZ ?? defaultPocketFloorThicknessMm(spec)) } as const);
                     dispatch({
                       type: "UPDATE_CUTOUT",
                       id: selectedCutout.id,
@@ -1143,6 +1144,9 @@ export function BinControlsPanel({
                 )}
               </div>
 
+              {spec.flatBottom && selectedCutout.depth.mode === "remaining" && (
+                <p className="text-[11px] text-muted-foreground">Measured from the flat underside. A 2 mm floor lets pockets extend into the former base area.</p>
+              )}
               {selectedCutout.depth.mode === "remaining" && <MmSlider label="Remaining floor thickness" value={selectedCutout.depth.floorThicknessMm} min={0} max={Math.max(7, spec.heightUnits * 7)} step={0.5}
                 onChange={(floorThicknessMm, transient) => dispatch({ type: "UPDATE_CUTOUT", id: selectedCutout.id, patch: { depth: { mode: "remaining", floorThicknessMm } }, transient, historyLabel: "Change remaining floor" })} />}
 

--- a/client/src/lib/gridfinity/cutouts.test.ts
+++ b/client/src/lib/gridfinity/cutouts.test.ts
@@ -964,3 +964,20 @@ describe("budgetOutline", () => {
     expect(budgetedPointCount(outline, 150)).toBe(budgeted[0].outer.length);
   });
 });
+
+it("cuts flat-bottom pockets below the former feet while retaining a solid 2 mm floor", () => {
+  const shape = rectShape("deep-flat", 10, 10);
+  const spec = parseBinSpec({ gridX: 2, gridY: 2, heightUnits: 6, flatBottom: true });
+  const cutout = parseCutoutPlacement({ id: "deep", shapeId: shape.id, position: { x: 0, y: 0 },
+    depth: { mode: "remaining", floorThicknessMm: 2 }, topFilletMm: 0, bottomFilletMm: 0, cornerRoundMm: 0 });
+  const layout = { shapesById: new Map([[shape.id, shape]]), cutouts: [cutout], fingerHoles: [] };
+  for (const circularSegments of [24, 64]) {
+    const quality = { circularSegments };
+    const blank = buildBin(kernel, spec, quality).solid;
+    const pocketed = buildBinWithCutouts(kernel, spec, layout, quality).solid;
+    expect(pocketed.status()).toBe("NoError");
+    expect(arena.track(pocketed.slice(1)).area()).toBeCloseTo(arena.track(blank.slice(1)).area(), 5);
+    expect(arena.track(blank.slice(3)).area() - arena.track(pocketed.slice(3)).area()).toBeCloseTo(100, 5);
+    expect(arena.track(blank.slice(6)).area() - arena.track(pocketed.slice(6)).area()).toBeCloseTo(100, 5);
+  }
+});

--- a/client/src/state/bin-store.test.tsx
+++ b/client/src/state/bin-store.test.tsx
@@ -432,3 +432,25 @@ describe("bin store history (G4 undo/redo)", () => {
     expect(store().cutouts[0].position).toEqual({ x: 0, y: 0 });
   });
 });
+
+it("uses a deeper default floor for flat bins and restores it with undo and base changes", () => {
+  const { store, act } = mountBin();
+  const custom = { ...CUTOUT, id: "custom", depth: { mode: "remaining" as const, floorThicknessMm: 4 } };
+  const fixed = { ...CUTOUT, id: "fixed", depth: { mode: "mm" as const, value: 12 } };
+  act(() => store().dispatch({ type: "ADD_PLACED", gridX: 2, gridY: 2, cutouts: [CUTOUT, custom, fixed] }));
+  const original = store().cutouts;
+  act(() => store().dispatch({ type: "PATCH_SPEC", patch: { flatBottom: true } }));
+  expect(store().cutouts[0].depth).toEqual({ mode: "remaining", floorThicknessMm: 2 });
+  expect(store().cutouts.slice(1)).toEqual([custom, fixed]);
+  act(() => store().dispatch({ type: "UNDO" }));
+  expect(store().spec.flatBottom).toBe(false);
+  expect(store().cutouts).toEqual(original);
+  act(() => store().dispatch({ type: "REDO" }));
+  expect(store().cutouts[0].depth).toEqual({ mode: "remaining", floorThicknessMm: 2 });
+  act(() => store().dispatch({ type: "ADD_PLACED", gridX: 2, gridY: 2, cutouts: [{ ...CUTOUT, id: "new" }] }));
+  expect(store().cutouts.at(-1)!.depth).toEqual({ mode: "remaining", floorThicknessMm: 2 });
+  act(() => store().dispatch({ type: "PATCH_SPEC", patch: { flatBottom: false } }));
+  expect(store().cutouts[0].depth).toEqual(CUTOUT.depth);
+  expect(store().cutouts.at(-1)!.depth).toEqual(CUTOUT.depth);
+  expect(store().cutouts.slice(1, 3)).toEqual([custom, fixed]);
+});

--- a/client/src/state/bin-store.tsx
+++ b/client/src/state/bin-store.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 
-import type { CutoutPlacement, FingerHole } from "@shared/gridfinity/cutout";
+import { defaultPocketFloorThicknessMm, type CutoutPlacement, type FingerHole } from "@shared/gridfinity/cutout";
 import { parseBinSpec, type BinSpec, type BinSpecInput } from "@shared/gridfinity/types";
 
 /**
@@ -268,6 +268,15 @@ function reducer(state: BinState, action: BinAction): BinState {
         cutouts: state.cutouts,
         fingerHoles: state.fingerHoles,
       };
+      if (doc.spec.flatBottom !== state.spec.flatBottom) {
+        const previousFloor = defaultPocketFloorThicknessMm(state.spec);
+        const nextFloor = defaultPocketFloorThicknessMm(doc.spec);
+        doc.cutouts = state.cutouts.map((cutout) =>
+          cutout.depth.mode === "remaining" && cutout.depth.floorThicknessMm === previousFloor
+            ? { ...cutout, depth: { mode: "remaining", floorThicknessMm: nextFloor } }
+            : cutout,
+        );
+      }
       return action.transient
         ? preview(state, doc)
         : commit(state, doc, action.historyLabel ?? specPatchLabel(action.patch));
@@ -282,7 +291,12 @@ function reducer(state: BinState, action: BinAction): BinState {
             gridY: action.gridY,
             ...(action.footprint ? { footprint: action.footprint } : {}),
           }),
-          cutouts: [...state.cutouts, ...action.cutouts],
+          cutouts: [...state.cutouts, ...action.cutouts.map((cutout): CutoutPlacement =>
+            state.spec.flatBottom && cutout.depth.mode === "remaining" &&
+              cutout.depth.floorThicknessMm === defaultPocketFloorThicknessMm({ flatBottom: false })
+              ? { ...cutout, depth: { mode: "remaining", floorThicknessMm: defaultPocketFloorThicknessMm(state.spec) } }
+              : cutout,
+          )],
           fingerHoles: state.fingerHoles,
         },
         action.historyLabel ??

--- a/docs/gridfinity-plan.md
+++ b/docs/gridfinity-plan.md
@@ -151,8 +151,11 @@ holes. The earlier modeled Lite Base option was removed: ordinary slicer
 infill already provides the intended material savings without permanently
 adding hollow chambers and special pocket-floor support to the exported
 model. **Flat bottom** is an optional Construction setting that replaces the
-Gridfinity sockets with a smooth 7 mm base, preserving outer size and pocket
-heights. Base magnet/screw holes are inactive in this mode; their settings
+Gridfinity sockets with a smooth base, preserving outer size. New pockets
+default to a 2 mm remaining floor in flat-bottom mode (7 mm for Gridfinity).
+Switching base styles updates pockets using the previous default floor; custom
+floors and fixed depths are retained. Remaining floor is measured from the
+actual underside, so flat pockets can cut into the former feet area. Base magnet/screw holes are inactive in this mode; their settings
 return when switched off. Existing projects retain the Gridfinity base.
 **Half/quarter grid**
 landed as explicit 21/10.5 mm pitch modes while retaining the upstream 0.5 mm

--- a/shared/gridfinity/cutout.ts
+++ b/shared/gridfinity/cutout.ts
@@ -707,6 +707,11 @@ export function placementFootprint(
 // Depth resolution
 // ---------------------------------------------------------------------------
 
+/** Default material left under a new pocket, measured from the actual underside. */
+export function defaultPocketFloorThicknessMm(spec: Pick<BinSpec, "flatBottom">): number {
+  return spec.flatBottom ? 2 : BASE_HEIGHT;
+}
+
 export interface ResolvedPocket {
   /** Absolute z of the pocket floor, or null for a through cut. */
   floorZ: number | null;


### PR DESCRIPTION
Flat-bottom bins still used the 7 mm Gridfinity pocket-floor default, leaving the former feet area unused. Use a 2 mm remaining floor for newly added flat-bottom pockets and when selecting Keep floor thickness from fixed or through depth. Enabling Flat bottom changes remaining-floor pockets matching the 7 mm default to 2 mm; disabling it restores matching 2 mm floors to 7 mm. Other floor values and fixed depths are retained, and the change is included in undo/redo.

Clarify in the pocket controls that remaining floor is measured from the flat underside. No geometry offset or reinterpretation of saved depths is introduced.

Validation: type-check, all 1,034 tests, and production build passed. New geometry tests verify a continuous 2 mm floor and pocket openings below the old feet region at preview and export resolutions; state tests cover existing/new pockets, custom depths, undo/redo, and switching back. Browser regression verified selecting Keep floor thickness changes a 7.0 mm floor to 2.0 mm and increases cut depth by 5 mm. Local preview rebuilt and refreshed.
