### PR TITLE
Fix floor-mode selection for flat-bottom pockets

### DIFF
--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -1107,7 +1107,7 @@ export function BinControlsPanel({
                         ? ({ mode: "through" } as const)
                         : mode === "mm"
                           ? ({ mode: "mm", value: Math.max(0.1, resolved.depthMm ?? resolved.infillTopZ - defaultPocketFloorThicknessMm(spec)) } as const)
-                          : ({ mode: "remaining", floorThicknessMm: Math.max(0, resolved.floorZ ?? defaultPocketFloorThicknessMm(spec)) } as const);
+                          : ({ mode: "remaining", floorThicknessMm: spec.flatBottom ? defaultPocketFloorThicknessMm(spec) : Math.max(0, resolved.floorZ ?? defaultPocketFloorThicknessMm(spec)) } as const);
                     dispatch({
                       type: "UPDATE_CUTOUT",
                       id: selectedCutout.id,
@@ -1116,7 +1116,7 @@ export function BinControlsPanel({
                     });
                   }}
                 >
-                  <SelectTrigger className="h-8 flex-1">
+                  <SelectTrigger className="h-8 flex-1" aria-label="Pocket depth mode">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -8,7 +8,7 @@ import { WORKSPACES } from "@/components/layout/workspaces";
 import * as ShapeLibraryModule from "@/state/shape-library";
 import { ShapeLibraryProvider } from "@/state/shape-library";
 import { PROJECT_SCHEMA_VERSION, parseProjectDoc, type ProjectDoc } from "@shared/gridfinity/project";
-import { fingerHoleSchema, parseCutoutPlacement, type TracedShape } from "@shared/gridfinity/cutout";
+import { fingerHoleSchema, resolvePocketDepth, parseCutoutPlacement, type TracedShape } from "@shared/gridfinity/cutout";
 import { parseBinSpec } from "@shared/gridfinity/types";
 import { downloadBlob } from "@/lib/download";
 import { useBinGeometry } from "@/lib/gridfinity/use-bin-geometry";
@@ -860,6 +860,27 @@ describe("BinDesignerPage", () => {
     React.act(() => toggle.click());
     expect(viewport?.getAttribute("data-pocket-floor-color")).toBe("off");
     expect(toggle.getAttribute("data-state")).toBe("unchecked");
+    unmount();
+  });
+
+  it.each([true, false])("sets the correct floor when selecting floor mode with flatBottom=%s", async (flatBottom) => {
+    const shape = rectangularShape("tool", "Depth test");
+    const spec = parseBinSpec({ gridX: 2, gridY: 2, heightUnits: 6, flatBottom });
+    const depthMm = resolvePocketDepth(spec, { mode: "remaining", floorThicknessMm: 7 }).depthMm!;
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT, spec, shapes: [shape],
+      cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 }, depth: { mode: "mm", value: depthMm } })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "tool-cutouts");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click());
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-label="Pocket depth mode"]')!;
+    React.act(() => trigger.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true })));
+    const option = Array.from(document.querySelectorAll<HTMLElement>('[role="option"]')).find((node) => node.textContent?.includes("Keep floor thickness"))!;
+    React.act(() => option.click());
+    const floor = container.querySelector<HTMLInputElement>('input[aria-label="Remaining floor thickness in millimetres"]')!;
+    expect(floor.value).toBe(flatBottom ? "2" : "7");
     unmount();
   });
 


### PR DESCRIPTION
Selecting Keep floor thickness from a fixed depth preserved the previous floor height, so a flat-bottom pocket could remain at the old 7 mm Gridfinity base level. Set the floor to 2 mm when selecting this mode with Flat bottom enabled. Ordinary Gridfinity behavior remains unchanged.

This completes the correction missing from merged PR #33. Add UI regression coverage for both base styles and an accessible label for the depth-mode selector.

Validation: all 1,034 tests, type-check, and production build passed on the identical source tree. Browser verification confirmed the floor changed from 7.0 to 2.0 mm and cut depth increased by 5 mm. Local preview is refreshed.
