### PR TITLE
Make pocket editing easier to find and keep Bin settings compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ processing, project storage, and model generation kept on the user's device.
   keeps the layout available.
 - Model warnings and errors appear in a collapsible panel at the bottom right of
   the Layout and 3D canvas. Click a message to edit the affected pocket or settings.
-  On phones it starts as a compact count. Errors still block export.
+  It starts as a compact count with a gentle pulse every four seconds until expanded
+  (unless reduced motion is enabled). Errors still block export.
 - Configure full-, half-, and quarter-pitch bins and export STL or 3MF models.
 - Model, fit-test, and outline export dialogs include an optional, unchecked
   `.pocketry.json` download. Bin exports preserve the full design; Trace exports

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ processing, project storage, and model generation kept on the user's device.
 - Refine exterior contours and interior holes.
 - Export traced geometry as SVG, DXF, DWG-compatible DXF, or STL.
 - Arrange traced tools as pockets in Gridfinity bins.
-- Click a pocket in Layout or choose it under Pockets to reveal its named editor
-  at the top of the controls. Size, depth, and clearance are immediately available;
-  position, scale, and rounding details stay compact. Use Edit pocket to return
-  from other settings. On phones, tapping opens the controls drawer; dragging
-  keeps the layout available.
+- Pocket properties stay in the Pockets section. Click a pocket on the canvas
+  or choose its row in the compact list to open its settings there. On phones, tapping opens
+  the controls drawer; dragging keeps the layout available.
+  Depth leads; size and scale, extra clearance, edges and corners, and position
+  settings start collapsed. Expand the depth profile to inspect the pocket in 3D.
+  Help icons reveal optional guidance on hover, focus, or tap. Use a pocket row’s
+  pencil to rename it.
 - Model warnings and errors appear in a collapsible panel at the bottom right of
   the Layout and 3D canvas. Click a message to edit the affected pocket or settings.
   It starts as a compact count with a gentle pulse every four seconds until expanded

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ processing, project storage, and model generation kept on the user's device.
   position, scale, and rounding details stay compact. Use Edit pocket to return
   from other settings. On phones, tapping opens the controls drawer; dragging
   keeps the layout available.
+- Model warnings and errors appear in a collapsible panel at the bottom right of
+  the Layout and 3D canvas. Click a message to edit the affected pocket or settings.
+  On phones it starts as a compact count. Errors still block export.
 - Configure full-, half-, and quarter-pitch bins and export STL or 3MF models.
 - Model, fit-test, and outline export dialogs include an optional, unchecked
   `.pocketry.json` download. Bin exports preserve the full design; Trace exports

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ processing, project storage, and model generation kept on the user's device.
   It starts as a compact count with a gentle pulse every four seconds until expanded
   (unless reduced motion is enabled). Errors still block export.
 - Configure full-, half-, and quarter-pitch bins and export STL or 3MF models.
+  Bin size places numeric inputs alongside each slider, with optional sizing guidance in hover hints.
   All pitches support the same maximum outer size of 671.5 mm per axis
   (16 full, 32 half, or 64 quarter cells), so finer pitch does not shrink the size allowance.
 - Model, fit-test, and outline export dialogs include an optional, unchecked

--- a/README.md
+++ b/README.md
@@ -22,8 +22,14 @@ processing, project storage, and model generation kept on the user's device.
   the controls drawer; dragging keeps the layout available.
   Depth leads; size and scale, extra clearance, edges and corners, and position
   settings start collapsed. Expand the depth profile to inspect the pocket in 3D.
-  Help icons reveal optional guidance on hover, focus, or tap. Use a pocket row’s
-  pencil to rename it.
+  Throughout Bin settings, help icons reveal optional guidance on hover, focus,
+  or tap. Dimensions, warnings, save status, and active editing guidance stay visible. Use a pocket row’s
+  pencil to rename it. Edit contour is in the properties header and beside the
+  canvas ruler. Pocket clearance has a zero-centered slider: negative values shrink
+  each edge to undo excess trace padding; positive values add room. Shrinking
+  changes the 3D cutter and fit templates without altering the saved trace.
+  Layout warnings and automatic packing conservatively retain the original outline
+  when clearance is negative; inspect the 3D model for the resulting pocket.
 - Model warnings and errors appear in a collapsible panel at the bottom right of
   the Layout and 3D canvas. Click a message to edit the affected pocket or settings.
   It starts as a compact count with a gentle pulse every four seconds until expanded

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ processing, project storage, and model generation kept on the user's device.
   It starts as a compact count with a gentle pulse every four seconds until expanded
   (unless reduced motion is enabled). Errors still block export.
 - Configure full-, half-, and quarter-pitch bins and export STL or 3MF models.
+  All pitches support the same maximum outer size of 671.5 mm per axis
+  (16 full, 32 half, or 64 quarter cells), so finer pitch does not shrink the size allowance.
 - Model, fit-test, and outline export dialogs include an optional, unchecked
   `.pocketry.json` download. Bin exports preserve the full design; Trace exports
   preserve the calibrated outline as an editable pocket in a new Bin project.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ processing, project storage, and model generation kept on the user's device.
 - Refine exterior contours and interior holes.
 - Export traced geometry as SVG, DXF, DWG-compatible DXF, or STL.
 - Arrange traced tools as pockets in Gridfinity bins.
+- Click a pocket in Layout or choose it under Pockets to reveal its named editor
+  at the top of the controls. Size, depth, and clearance are immediately available;
+  position, scale, and rounding details stay compact. Use Edit pocket to return
+  from other settings. On phones, tapping opens the controls drawer; dragging
+  keeps the layout available.
 - Configure full-, half-, and quarter-pitch bins and export STL or 3MF models.
 - Model, fit-test, and outline export dialogs include an optional, unchecked
   `.pocketry.json` download. Bin exports preserve the full design; Trace exports

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -932,39 +932,6 @@ export function BinControlsPanel({
                 <div className="pb-2" key={selectedCutout.id}><PocketSizeInputs cutout={selectedCutout} shape={selectedShape} setScale={setPocketScale} /></div>
               </details>
 
-              <details className="group/clearance border-t pt-1 text-xs" data-testid="pocket-clearance-settings">
-                <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2 font-medium [&::-webkit-details-marker]:hidden">
-                  Extra pocket clearance
-                  <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/clearance:rotate-180" />
-                </summary>
-                <div className="space-y-2 pb-2" key={selectedCutout.id}>
-                  <MmSlider
-                    label="Extra pocket clearance"
-                    value={selectedCutout.clearanceMm}
-                    centered
-                    min={-2}
-                    max={2}
-                    step={0.1}
-                    onChange={(clearanceMm, transient) =>
-                      dispatch({
-                        type: "UPDATE_CUTOUT",
-                        id: selectedCutout.id,
-                        patch: { clearanceMm },
-                        historyLabel: "Change pocket clearance",
-                        transient,
-                      })
-                    }
-                    hintAsTooltip
-                    hint={<>
-                      Adjusts each edge after the Trace margin and scaling. Negative values shrink the pocket to reduce excess padding; positive values enlarge it. Zero keeps the traced size. Narrow features can disappear when shrunk.
-                      <span className="mt-1 block">{selectedShape.traceMarginMm === undefined
-                        ? `Original trace margin unknown (older project). Extra allowance: ${selectedCutout.clearanceMm.toFixed(2)} mm per edge.`
-                        : `Trace margin: ${selectedShape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(selectedShape.traceMarginMm * selectedCutout.scaleX + selectedCutout.clearanceMm).toFixed(2)} / ${(selectedShape.traceMarginMm * selectedCutout.scaleY + selectedCutout.clearanceMm).toFixed(2)} mm per edge.`}</span>
-                    </>}
-                  />
-                </div>
-              </details>
-
               <details className="group/more border-t pt-1 text-xs" data-testid="pocket-edge-settings">
                 <summary className="flex cursor-pointer list-none items-center justify-between py-1.5 font-medium [&::-webkit-details-marker]:hidden">
                   <span className="flex items-center gap-1">Edges &amp; corners <HelpHint label="edges and corners">Soften sharp corners and edges. Values are rounding radii in millimetres; 0 keeps an edge sharp.</HelpHint></span>
@@ -1062,6 +1029,39 @@ export function BinControlsPanel({
                 </div>
 
               </PocketMeasurements>
+              <details className="group/clearance border-t pt-1 text-xs" data-testid="pocket-clearance-settings">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2 font-medium [&::-webkit-details-marker]:hidden">
+                  Extra pocket clearance
+                  <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/clearance:rotate-180" />
+                </summary>
+                <div className="space-y-2 pb-2" key={selectedCutout.id}>
+                  <MmSlider
+                    label="Extra pocket clearance"
+                    value={selectedCutout.clearanceMm}
+                    centered
+                    min={-2}
+                    max={2}
+                    step={0.1}
+                    onChange={(clearanceMm, transient) =>
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { clearanceMm },
+                        historyLabel: "Change pocket clearance",
+                        transient,
+                      })
+                    }
+                    hintAsTooltip
+                    hint={<>
+                      Adjusts each edge after the Trace margin and scaling. Negative values shrink the pocket to reduce excess padding; positive values enlarge it. Zero keeps the traced size. Narrow features can disappear when shrunk.
+                      <span className="mt-1 block">{selectedShape.traceMarginMm === undefined
+                        ? `Original trace margin unknown (older project). Extra allowance: ${selectedCutout.clearanceMm.toFixed(2)} mm per edge.`
+                        : `Trace margin: ${selectedShape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(selectedShape.traceMarginMm * selectedCutout.scaleX + selectedCutout.clearanceMm).toFixed(2)} / ${(selectedShape.traceMarginMm * selectedCutout.scaleY + selectedCutout.clearanceMm).toFixed(2)} mm per edge.`}</span>
+                    </>}
+                  />
+                </div>
+              </details>
+
               {editorMode === "contour" && (
                 <p className="rounded-md bg-violet-500/10 px-2.5 py-2 text-[11px] text-violet-800 dark:text-violet-200">
                   Drag points to reshape. Click an edge to add a point; right-click a

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -10,7 +10,6 @@ import {
   FilePlus2,
   FolderOpen,
   LayoutGrid,
-  Lock,
   LoaderCircle,
   Magnet,
   MousePointerClick,
@@ -25,7 +24,6 @@ import {
   SlidersHorizontal,
   Spline,
   Trash2,
-  Unlock,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { useLocation } from "wouter";
@@ -108,7 +106,7 @@ import {
 } from "@/lib/gridfinity/worker-api";
 import type { ProjectLibraryItem } from "@/lib/project/persist";
 import { cn } from "@/lib/utils";
-import { PocketMeasurements, PositionInputs } from "./pocket-measurements";
+import { PocketMeasurements, PocketSizeInputs, PositionInputs } from "./pocket-measurements";
 import { ExportConfirmationDialog, ProjectBackupOption } from "./export-confirmation-dialog";
 import { useBin } from "@/state/bin-store";
 import { useShapeLibrary } from "@/state/shape-library";
@@ -218,7 +216,7 @@ const BIN_SETTINGS_SECTIONS = [
   { id: "bin-settings-project", label: "Project", tone: "slate" },
   { id: "bin-settings-size", label: "Size", tone: "blue" },
   { id: "bin-settings-construction", label: "Construction", tone: "rose" },
-  { id: "bin-settings-pockets", label: "Arrange", tone: "violet" },
+  { id: "bin-settings-pockets", label: "Pockets", tone: "violet" },
   { id: "bin-settings-finger-holes", label: "Finger access", tone: "cyan" },
   { id: "bin-settings-materials", label: "Materials", tone: "amber" },
   { id: "bin-settings-view", label: "View", tone: "amber" },
@@ -227,6 +225,8 @@ const BIN_SETTINGS_SECTIONS = [
 ] as const;
 
 export interface BinControlsPanelProps {
+  /** Changes when the canvas explicitly requests the selected pocket editor. */
+  pocketEditorRequest?: number;
   keepBinSize?: boolean;
   onKeepBinSizeChange?: (fixed: boolean) => void;
   saveStatus?: "saving" | "saved" | "error";
@@ -311,6 +311,7 @@ export function BinControlsPanel({
   onStackingRimColorChange,
   stackingRimThicknessMm,
   onStackingRimThicknessChange,
+  pocketEditorRequest = 0,
   keepBinSize = false,
   onKeepBinSizeChange,
   saveStatus = "saved",
@@ -329,10 +330,19 @@ export function BinControlsPanel({
   const [, navigate] = useLocation();
   const { shapes, storeShape } = useShapeLibrary();
   const pocketPropertiesHeadingRef = useRef<HTMLDivElement>(null);
+  const revealPocketProperties = () => {
+    // Scroll only this panel, preserving the canvas and mobile drawer position.
+    const scroller = pocketPropertiesHeadingRef.current?.parentElement?.parentElement;
+    if (scroller) scroller.scrollTop = 0;
+  };
+  useEffect(() => {
+    if (!selectedCutoutId) return;
+    const frame = requestAnimationFrame(revealPocketProperties);
+    return () => cancelAnimationFrame(frame);
+  }, [selectedCutoutId, pocketEditorRequest]);
   const selectPocketProperties = (id: string) => {
     dispatch({ type: "SELECT_CUTOUT", id });
-    // Reveal the heading after the selected pocket's controls have rendered.
-    requestAnimationFrame(() => pocketPropertiesHeadingRef.current?.scrollIntoView?.({ block: "nearest" }));
+    requestAnimationFrame(revealPocketProperties);
   };
   const shapesById = useMemo(
     () => new Map(shapes.map((shape) => [shape.id, shape])),
@@ -359,7 +369,7 @@ export function BinControlsPanel({
     if (issue.cutoutIds?.length) {
       const next = issue.cutoutIds.find((id) => id !== selectedCutoutId) ?? issue.cutoutIds[0];
       dispatch({ type: "SELECT_CUTOUT", id: next });
-      revealPanelSection("bin-settings-pockets", BIN_SETTINGS_SECTIONS);
+      requestAnimationFrame(revealPocketProperties);
     } else if (issue.fingerHoleIds?.length) {
       dispatch({ type: "SELECT_FINGER_HOLE", id: issue.fingerHoleIds[0] });
       revealPanelSection("bin-settings-finger-holes", BIN_SETTINGS_SECTIONS);
@@ -442,6 +452,9 @@ export function BinControlsPanel({
   const setPocketScale = (axis: "x" | "y", percent: number) => {
     if (!selectedCutout) return;
     const requested = Math.min(20, Math.max(0.05, percent / 100));
+    const changedScale = axis === "x" ? selectedCutout.scaleX : selectedCutout.scaleY;
+    // The number field also commits on blur; do not record that value twice.
+    if (requested === changedScale) return;
     if (!selectedCutout.aspectRatioLocked) {
       dispatch({
         type: "UPDATE_CUTOUT",
@@ -451,8 +464,6 @@ export function BinControlsPanel({
       });
       return;
     }
-    const changedScale =
-      axis === "x" ? selectedCutout.scaleX : selectedCutout.scaleY;
     let factor = requested / changedScale;
     factor = Math.min(
       20 / selectedCutout.scaleX,
@@ -502,13 +513,287 @@ export function BinControlsPanel({
         <p className="truncate text-sm font-medium" title={currentProjectName ?? "Untitled project"}>{currentProjectName ?? "Untitled project"}</p>
         <p className="text-[11px] text-muted-foreground" role="status">{!hydrated ? "Opening project…" : projectBusy || saveStatus === "saving" ? "Saving in this browser…" : saveStatus === "error" ? "Could not save. Download an editable project to keep your work." : "Saved in this browser"}</p>
       </div>
-      <PanelSettingsIndex
-        ariaLabel="Find bin settings"
-        testIdPrefix="bin"
-        items={BIN_SETTINGS_SECTIONS}
-      />
+      {/* On short screens the section headers remain reachable by scrolling;
+          reserve the limited height for editable fields instead of shortcuts. */}
+      <div className="shrink-0 [@media(max-height:500px)]:hidden">
+        <PanelSettingsIndex
+          ariaLabel="Find bin settings"
+          testIdPrefix="bin"
+          items={BIN_SETTINGS_SECTIONS}
+        />
+      </div>
       {selectedIssues.length > 0 && <div className="max-h-32 shrink-0 space-y-1 overflow-y-auto border-b p-2" data-testid="selected-object-issues" aria-label="Issues for selected object">{selectedIssues.map(issueButton)}</div>}
       <PanelBody className="flex-1">
+        {selectedCutout && selectedShape && (
+          <div className="space-y-3 border-b bg-violet-500/[0.025] px-3 pb-4" id="pocket-properties" role="region" aria-label="Selected pocket properties" key={selectedCutout.id}>
+            <div ref={pocketPropertiesHeadingRef} className="sticky top-0 z-10 -mx-3 border-b border-violet-500/30 bg-background px-3 py-2" data-testid="pocket-properties-heading">
+              <div className="flex items-center justify-between gap-2">
+                <h3 className="text-[11px] font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">Pocket properties</h3>
+                <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={() => revealPanelSection("bin-settings-pockets", BIN_SETTINGS_SECTIONS)}>All pockets</Button>
+              </div>
+              <EditableShapeName key={selectedCutout.id} shape={selectedShape} onRename={(name) => storeShape({ ...selectedShape, name })} />
+            </div>
+            <PocketSizeInputs cutout={selectedCutout} shape={selectedShape} setScale={setPocketScale} />
+            <div className="flex items-center gap-2">
+              <Label className="w-16 shrink-0 text-xs">Depth</Label>
+              <Select
+                value={selectedCutout.depth.mode}
+                onValueChange={(mode) => {
+                  const resolved = resolvePocketDepth(spec, selectedCutout.depth);
+                  const depth =
+                    mode === "through"
+                      ? ({ mode: "through" } as const)
+                      : mode === "mm"
+                        ? ({ mode: "mm", value: Math.max(0.1, resolved.depthMm ?? resolved.infillTopZ - defaultPocketFloorThicknessMm(spec)) } as const)
+                        : ({ mode: "remaining", floorThicknessMm: spec.flatBottom ? defaultPocketFloorThicknessMm(spec) : Math.max(0, resolved.floorZ ?? defaultPocketFloorThicknessMm(spec)) } as const);
+                  dispatch({
+                    type: "UPDATE_CUTOUT",
+                    id: selectedCutout.id,
+                    patch: { depth },
+                    historyLabel: "Change pocket depth",
+                  });
+                }}
+              >
+                <SelectTrigger className="h-8 flex-1" aria-label="Pocket depth mode">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="remaining">Keep floor thickness</SelectItem>
+                  <SelectItem value="mm">Fixed depth</SelectItem>
+                  <SelectItem value="through">Through</SelectItem>
+                </SelectContent>
+              </Select>
+              {selectedCutout.depth.mode === "mm" && (
+                <DraftNumberInput
+                  className="h-8 w-20"
+                  aria-label="Pocket cut depth in millimetres"
+                  value={selectedCutout.depth.value}
+                  min={1}
+                  step={1}
+                  onValueChange={(value) =>
+                    dispatch({
+                      type: "UPDATE_CUTOUT",
+                      id: selectedCutout.id,
+                      patch: { depth: { mode: "mm", value } },
+                      historyLabel: "Change pocket depth",
+                    })
+                  }
+                />
+              )}
+            </div>
+
+            {spec.flatBottom && selectedCutout.depth.mode === "remaining" && (
+              <p className="text-[11px] text-muted-foreground">Measured from the flat underside. A 2 mm floor lets pockets extend into the former base area.</p>
+            )}
+            {selectedCutout.depth.mode === "remaining" && <MmSlider label="Remaining floor thickness" value={selectedCutout.depth.floorThicknessMm} min={0} max={Math.max(7, spec.heightUnits * 7)} step={0.5}
+              onChange={(floorThicknessMm, transient) => dispatch({ type: "UPDATE_CUTOUT", id: selectedCutout.id, patch: { depth: { mode: "remaining", floorThicknessMm } }, transient, historyLabel: "Change remaining floor" })} />}
+
+            <MmSlider
+              label="Extra pocket clearance"
+              value={selectedCutout.clearanceMm}
+              min={0}
+              max={2}
+              step={0.1}
+              onChange={(clearanceMm, transient) =>
+                dispatch({
+                  type: "UPDATE_CUTOUT",
+                  id: selectedCutout.id,
+                  patch: { clearanceMm },
+                  historyLabel: "Change pocket clearance",
+                  transient,
+                })
+              }
+              hint="Added after the Trace margin; new pockets start at 0 mm."
+            />
+
+            <Button
+              variant={editorMode === "contour" ? "default" : "outline"}
+              size="sm"
+              className="w-full"
+              data-testid="button-edit-contour"
+              onClick={() => {
+                const editing = editorMode === "contour";
+                dispatch({
+                  type: "SET_EDITOR_MODE",
+                  editorMode: editing ? "placement" : "contour",
+                });
+                if (!editing) {
+                  dispatch({ type: "SET_VIEW_MODE", viewMode: "2d" });
+                }
+              }}
+            >
+              <Spline className="mr-1.5 h-3.5 w-3.5" />
+              {editorMode === "contour" ? "Finish contour editing" : "Edit contour"}
+            </Button>
+            {editorMode === "contour" && (
+              <p className="rounded-md bg-violet-500/10 px-2.5 py-2 text-[11px] text-violet-800 dark:text-violet-200">
+                Drag points to reshape. Click an edge to add a point; right-click a
+                point to remove it.
+              </p>
+            )}
+
+            <PocketMeasurements cutout={selectedCutout} shape={selectedShape} section={section} inspect={onSectionChange} />
+            <details className="group/more text-xs" data-testid="pocket-more-settings">
+              <summary className="flex cursor-pointer list-none items-center justify-between py-1.5 font-medium [&::-webkit-details-marker]:hidden">
+                Rotation, scale &amp; rounding
+                <ChevronDown className="h-3.5 w-3.5 transition-transform group-open/more:rotate-180" />
+              </summary>
+              <div className="space-y-3 pt-2">
+                <div className="flex items-center gap-2">
+                  <Label className="w-16 shrink-0 text-xs">Rotation</Label>
+                  <DraftNumberInput
+                    className="h-8"
+                    value={Math.round(selectedCutout.rotationDeg * 10) / 10}
+                    step={15}
+                    normalize={(value) => ((value % 360) + 360) % 360}
+                    onValueChange={(rotationDeg) =>
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { rotationDeg },
+                        historyLabel: "Rotate tool pocket",
+                      })
+                    }
+                  />
+                  <FeatureSwitch
+                    label="Mirror"
+                    description=""
+                    checked={selectedCutout.mirrored}
+                    onChange={(mirrored) =>
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { mirrored },
+                        historyLabel: "Mirror tool pocket",
+                      })
+                    }
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-2">
+                    <Label className="w-16 shrink-0 text-xs">Scale</Label>
+                    <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                      <Label
+                        className="text-[11px] text-muted-foreground"
+                        htmlFor="pocket-scale-width"
+                      >
+                        W
+                      </Label>
+                      <DraftNumberInput
+                        id="pocket-scale-width"
+                        className="h-8 min-w-0"
+                        aria-label="Pocket width scale percent"
+                        data-testid="input-pocket-scale-x"
+                        value={Math.round(selectedCutout.scaleX * 1000) / 10}
+                        min={5}
+                        max={2000}
+                        step={1}
+                        onValueChange={(percent) => setPocketScale("x", percent)}
+                      />
+                      <span className="text-xs text-muted-foreground">%</span>
+                      <Label
+                        className="text-[11px] text-muted-foreground"
+                        htmlFor="pocket-scale-height"
+                      >
+                        H
+                      </Label>
+                      <DraftNumberInput
+                        id="pocket-scale-height"
+                        className="h-8 min-w-0"
+                        aria-label="Pocket height scale percent"
+                        data-testid="input-pocket-scale-y"
+                        value={Math.round(selectedCutout.scaleY * 1000) / 10}
+                        min={5}
+                        max={2000}
+                        step={1}
+                        onValueChange={(percent) => setPocketScale("y", percent)}
+                      />
+                      <span className="text-xs text-muted-foreground">%</span>
+
+                    </div>
+                  </div>
+                  <div className="ml-[4.5rem] flex items-start justify-between gap-2">
+                    <p className="text-[11px] leading-4 text-muted-foreground">
+                      Drag layout edges or corners. Keep proportions links width and length.
+                    </p>
+                    {(selectedCutout.scaleX !== 1 || selectedCutout.scaleY !== 1) && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 shrink-0 px-2 text-[11px]"
+                        onClick={() =>
+                          dispatch({
+                            type: "UPDATE_CUTOUT",
+                            id: selectedCutout.id,
+                            patch: { scaleX: 1, scaleY: 1 },
+                            historyLabel: "Reset tool pocket scale",
+                          })
+                        }
+                      >
+                        Reset 100%
+                      </Button>
+                    )}
+                  </div>
+                </div>
+
+                <MmSlider
+                  label="Outline corner round"
+                  value={selectedCutout.cornerRoundMm}
+                  min={0}
+                  max={3}
+                  step={0.5}
+                  onChange={(cornerRoundMm, transient) =>
+                    dispatch({
+                      type: "UPDATE_CUTOUT",
+                      id: selectedCutout.id,
+                      patch: { cornerRoundMm },
+                      historyLabel: "Change outline corner round",
+                      transient,
+                    })
+                  }
+                  hint="Rounds sharp corners in the pocket outline from top to bottom."
+                />
+                <MmSlider
+                  label="Top edge round"
+                  value={selectedCutout.topFilletMm}
+                  min={0}
+                  max={5}
+                  step={0.2}
+                  onChange={(topFilletMm, transient) =>
+                    dispatch({
+                      type: "UPDATE_CUTOUT",
+                      id: selectedCutout.id,
+                      patch: { topFilletMm },
+                      historyLabel: "Change top edge round",
+                      transient,
+                    })
+                  }
+                  hint="Rounds the pocket wall into the top surface of the bin."
+                />
+                <MmSlider
+                  label="Bottom fillet"
+                  value={selectedCutout.bottomFilletMm}
+                  min={0}
+                  max={4}
+                  step={0.2}
+                  onChange={(bottomFilletMm, transient) =>
+                    dispatch({
+                      type: "UPDATE_CUTOUT",
+                      id: selectedCutout.id,
+                      patch: { bottomFilletMm },
+                      historyLabel: "Change bottom fillet",
+                      transient,
+                    })
+                  }
+                  hint="Rounds the wall into the floor; the transition ends one radius above the floor."
+                />
+
+              </div>
+            </details>
+          </div>
+        )}
         <PanelSection
           id="bin-settings-project"
           title="Project"
@@ -827,7 +1112,7 @@ export function BinControlsPanel({
         <PanelSection
           key={cutouts.length > 0 ? "pockets" : "pockets-empty"}
           id="bin-settings-pockets"
-          title="Arrange pockets"
+          title="Pockets"
           icon={Scissors}
           tone="violet"
           summary={`${cutouts.length} pocket${cutouts.length === 1 ? "" : "s"}`}
@@ -847,7 +1132,7 @@ export function BinControlsPanel({
               >
                 <MousePointerClick className="mt-0.5 h-4 w-4 shrink-0" />
                 <p>
-                  Choose a pocket below to edit its size, depth, and shape.
+                  Click a pocket in Layout or choose one below to edit its properties.
                 </p>
               </div>
               <Button
@@ -888,7 +1173,7 @@ export function BinControlsPanel({
                         <span className="min-w-0 flex-1">
                           <span className="block truncate font-medium">{shape?.name ?? "Missing shape"}</span>
                           <span className={cn("mt-0.5 block text-[11px]", isSelected ? "font-medium text-violet-700 dark:text-violet-300" : "text-muted-foreground")}>
-                            {isSelected ? "Properties shown below" : "Edit properties"}
+                            {isSelected ? "Editing this pocket" : "Edit properties"}
                           </span>
                         </span>
                         {isSelected ? <ChevronDown className="h-4 w-4 shrink-0 text-violet-600 dark:text-violet-300" /> : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
@@ -928,299 +1213,6 @@ export function BinControlsPanel({
             </>
           )}
 
-          {selectedCutout && selectedShape && (
-            <div className="space-y-3 border-t pt-3" id="pocket-properties">
-              <div ref={pocketPropertiesHeadingRef} className="scroll-mt-3 rounded-md border border-violet-500/30 bg-violet-500/5 px-2.5 py-2" data-testid="pocket-properties-heading">
-                <h3 className="text-[11px] font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">Pocket properties</h3>
-                <EditableShapeName key={selectedCutout.id} shape={selectedShape} onRename={(name) => storeShape({ ...selectedShape, name })} />
-              </div>
-              <PocketMeasurements cutout={selectedCutout} shape={selectedShape} setScale={setPocketScale} section={section} inspect={onSectionChange} />
-              <Button
-                variant={editorMode === "contour" ? "default" : "outline"}
-                size="sm"
-                className="w-full"
-                data-testid="button-edit-contour"
-                onClick={() => {
-                  const editing = editorMode === "contour";
-                  dispatch({
-                    type: "SET_EDITOR_MODE",
-                    editorMode: editing ? "placement" : "contour",
-                  });
-                  if (!editing) {
-                    dispatch({ type: "SET_VIEW_MODE", viewMode: "2d" });
-                  }
-                }}
-              >
-                <Spline className="mr-1.5 h-3.5 w-3.5" />
-                {editorMode === "contour" ? "Finish contour editing" : "Edit contour"}
-              </Button>
-              {editorMode === "contour" && (
-                <p className="rounded-md bg-violet-500/10 px-2.5 py-2 text-[11px] text-violet-800 dark:text-violet-200">
-                  Drag points to reshape. Click an edge to add a point; right-click a
-                  point to remove it.
-                </p>
-              )}
-
-              <div className="flex items-center gap-2">
-                <Label className="w-16 shrink-0 text-xs">Rotation</Label>
-                <DraftNumberInput
-                  className="h-8"
-                  value={Math.round(selectedCutout.rotationDeg * 10) / 10}
-                  step={15}
-                  normalize={(value) => ((value % 360) + 360) % 360}
-                  onValueChange={(rotationDeg) =>
-                    dispatch({
-                      type: "UPDATE_CUTOUT",
-                      id: selectedCutout.id,
-                      patch: { rotationDeg },
-                      historyLabel: "Rotate tool pocket",
-                    })
-                  }
-                />
-                <FeatureSwitch
-                  label="Mirror"
-                  description=""
-                  checked={selectedCutout.mirrored}
-                  onChange={(mirrored) =>
-                    dispatch({
-                      type: "UPDATE_CUTOUT",
-                      id: selectedCutout.id,
-                      patch: { mirrored },
-                      historyLabel: "Mirror tool pocket",
-                    })
-                  }
-                />
-              </div>
-
-              <div className="space-y-1.5">
-                <div className="flex items-center gap-2">
-                  <Label className="w-16 shrink-0 text-xs">Scale</Label>
-                  <div className="flex min-w-0 flex-1 items-center gap-1.5">
-                    <Label
-                      className="text-[11px] text-muted-foreground"
-                      htmlFor="pocket-scale-width"
-                    >
-                      W
-                    </Label>
-                    <DraftNumberInput
-                      id="pocket-scale-width"
-                      className="h-8 min-w-0"
-                      aria-label="Pocket width scale percent"
-                      data-testid="input-pocket-scale-x"
-                      value={Math.round(selectedCutout.scaleX * 1000) / 10}
-                      min={5}
-                      max={2000}
-                      step={1}
-                      onValueChange={(percent) => setPocketScale("x", percent)}
-                    />
-                    <span className="text-xs text-muted-foreground">%</span>
-                    <Label
-                      className="text-[11px] text-muted-foreground"
-                      htmlFor="pocket-scale-height"
-                    >
-                      H
-                    </Label>
-                    <DraftNumberInput
-                      id="pocket-scale-height"
-                      className="h-8 min-w-0"
-                      aria-label="Pocket height scale percent"
-                      data-testid="input-pocket-scale-y"
-                      value={Math.round(selectedCutout.scaleY * 1000) / 10}
-                      min={5}
-                      max={2000}
-                      step={1}
-                      onValueChange={(percent) => setPocketScale("y", percent)}
-                    />
-                    <span className="text-xs text-muted-foreground">%</span>
-                    <Button
-                      type="button"
-                      variant={
-                        selectedCutout.aspectRatioLocked ? "secondary" : "outline"
-                      }
-                      size="icon"
-                      className="h-8 w-8 shrink-0"
-                      aria-label={
-                        selectedCutout.aspectRatioLocked
-                          ? "Unlock pocket aspect ratio"
-                          : "Lock pocket aspect ratio"
-                      }
-                      aria-pressed={selectedCutout.aspectRatioLocked}
-                      title={
-                        selectedCutout.aspectRatioLocked
-                          ? "Aspect ratio locked"
-                          : "Aspect ratio unlocked"
-                      }
-                      onClick={() =>
-                        dispatch({
-                          type: "UPDATE_CUTOUT",
-                          id: selectedCutout.id,
-                          patch: {
-                            aspectRatioLocked: !selectedCutout.aspectRatioLocked,
-                          },
-                          historyLabel: selectedCutout.aspectRatioLocked
-                            ? "Unlock pocket proportions"
-                            : "Lock pocket proportions",
-                        })
-                      }
-                    >
-                      {selectedCutout.aspectRatioLocked ? (
-                        <Lock className="h-3.5 w-3.5" />
-                      ) : (
-                        <Unlock className="h-3.5 w-3.5" />
-                      )}
-                    </Button>
-                  </div>
-                </div>
-                <div className="ml-[4.5rem] flex items-start justify-between gap-2">
-                  <p className="text-[11px] leading-4 text-muted-foreground">
-                    Drag layout edges or corners. Lock preserves proportions.
-                  </p>
-                  {(selectedCutout.scaleX !== 1 || selectedCutout.scaleY !== 1) && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 shrink-0 px-2 text-[11px]"
-                      onClick={() =>
-                        dispatch({
-                          type: "UPDATE_CUTOUT",
-                          id: selectedCutout.id,
-                          patch: { scaleX: 1, scaleY: 1 },
-                          historyLabel: "Reset tool pocket scale",
-                        })
-                      }
-                    >
-                      Reset 100%
-                    </Button>
-                  )}
-                </div>
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Label className="w-16 shrink-0 text-xs">Depth</Label>
-                <Select
-                  value={selectedCutout.depth.mode}
-                  onValueChange={(mode) => {
-                    const resolved = resolvePocketDepth(spec, selectedCutout.depth);
-                    const depth =
-                      mode === "through"
-                        ? ({ mode: "through" } as const)
-                        : mode === "mm"
-                          ? ({ mode: "mm", value: Math.max(0.1, resolved.depthMm ?? resolved.infillTopZ - defaultPocketFloorThicknessMm(spec)) } as const)
-                          : ({ mode: "remaining", floorThicknessMm: spec.flatBottom ? defaultPocketFloorThicknessMm(spec) : Math.max(0, resolved.floorZ ?? defaultPocketFloorThicknessMm(spec)) } as const);
-                    dispatch({
-                      type: "UPDATE_CUTOUT",
-                      id: selectedCutout.id,
-                      patch: { depth },
-                      historyLabel: "Change pocket depth",
-                    });
-                  }}
-                >
-                  <SelectTrigger className="h-8 flex-1" aria-label="Pocket depth mode">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="remaining">Keep floor thickness</SelectItem>
-                    <SelectItem value="mm">Fixed depth</SelectItem>
-                    <SelectItem value="through">Through</SelectItem>
-                  </SelectContent>
-                </Select>
-                {selectedCutout.depth.mode === "mm" && (
-                  <DraftNumberInput
-                    className="h-8 w-20"
-                    aria-label="Pocket cut depth in millimetres"
-                    value={selectedCutout.depth.value}
-                    min={1}
-                    step={1}
-                    onValueChange={(value) =>
-                      dispatch({
-                        type: "UPDATE_CUTOUT",
-                        id: selectedCutout.id,
-                        patch: { depth: { mode: "mm", value } },
-                        historyLabel: "Change pocket depth",
-                      })
-                    }
-                  />
-                )}
-              </div>
-
-              {spec.flatBottom && selectedCutout.depth.mode === "remaining" && (
-                <p className="text-[11px] text-muted-foreground">Measured from the flat underside. A 2 mm floor lets pockets extend into the former base area.</p>
-              )}
-              {selectedCutout.depth.mode === "remaining" && <MmSlider label="Remaining floor thickness" value={selectedCutout.depth.floorThicknessMm} min={0} max={Math.max(7, spec.heightUnits * 7)} step={0.5}
-                onChange={(floorThicknessMm, transient) => dispatch({ type: "UPDATE_CUTOUT", id: selectedCutout.id, patch: { depth: { mode: "remaining", floorThicknessMm } }, transient, historyLabel: "Change remaining floor" })} />}
-
-              <MmSlider
-                label="Extra pocket clearance"
-                value={selectedCutout.clearanceMm}
-                min={0}
-                max={2}
-                step={0.1}
-                onChange={(clearanceMm, transient) =>
-                  dispatch({
-                    type: "UPDATE_CUTOUT",
-                    id: selectedCutout.id,
-                    patch: { clearanceMm },
-                    historyLabel: "Change pocket clearance",
-                    transient,
-                  })
-                }
-                hint="Added after the Trace margin; new pockets start at 0 mm."
-              />
-              <MmSlider
-                label="Outline corner round"
-                value={selectedCutout.cornerRoundMm}
-                min={0}
-                max={3}
-                step={0.5}
-                onChange={(cornerRoundMm, transient) =>
-                  dispatch({
-                    type: "UPDATE_CUTOUT",
-                    id: selectedCutout.id,
-                    patch: { cornerRoundMm },
-                    historyLabel: "Change outline corner round",
-                    transient,
-                  })
-                }
-                hint="Rounds sharp corners in the pocket outline from top to bottom."
-              />
-              <MmSlider
-                label="Top edge round"
-                value={selectedCutout.topFilletMm}
-                min={0}
-                max={5}
-                step={0.2}
-                onChange={(topFilletMm, transient) =>
-                  dispatch({
-                    type: "UPDATE_CUTOUT",
-                    id: selectedCutout.id,
-                    patch: { topFilletMm },
-                    historyLabel: "Change top edge round",
-                    transient,
-                  })
-                }
-                hint="Rounds the pocket wall into the top surface of the bin."
-              />
-              <MmSlider
-                label="Bottom fillet"
-                value={selectedCutout.bottomFilletMm}
-                min={0}
-                max={4}
-                step={0.2}
-                onChange={(bottomFilletMm, transient) =>
-                  dispatch({
-                    type: "UPDATE_CUTOUT",
-                    id: selectedCutout.id,
-                    patch: { bottomFilletMm },
-                    historyLabel: "Change bottom fillet",
-                    transient,
-                  })
-                }
-                hint="Rounds the wall into the floor; the transition ends one radius above the floor."
-              />
-
-            </div>
-          )}
         </PanelSection>
 
         <PanelSection
@@ -2105,7 +2097,6 @@ export function BinControlsPanel({
               </Button>
             </div>
           </div>
-
 
         </PanelSection>
       </PanelBody>

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -649,12 +649,6 @@ export function BinControlsPanel({
           className="scroll-mt-16"
         >
           <FeatureSwitch
-            label="Flat bottom"
-            description="Smooth underside; no Gridfinity base."
-            checked={spec.flatBottom}
-            onChange={(flatBottom) => patchSpec({ flatBottom })}
-          />
-          <FeatureSwitch
             label="Stacking lip"
             description={spec.flatBottom ? "Receives a Gridfinity bin on top" : "Lets another bin stack on top"}
             checked={spec.lip === "standard"}
@@ -774,6 +768,12 @@ export function BinControlsPanel({
               </div>
             )}
           </div>
+          <FeatureSwitch
+            label="Flat bottom"
+            description="Smooth underside; no Gridfinity base."
+            checked={spec.flatBottom}
+            onChange={(flatBottom) => patchSpec({ flatBottom })}
+          />
         </PanelSection>
 
         {/* Keyed on emptiness: defaultOpen is uncontrolled, and the section

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -503,7 +503,7 @@ export function BinControlsPanel({
           className="scroll-mt-16"
         >
           <div className="flex items-center gap-2">
-            <Label className="w-16 shrink-0 text-xs">Grid pitch</Label>
+            <SettingLabel label="Grid pitch" hint="Pitch changes preserve the outer size. A coarser pitch needs whole cells; custom footprints keep their current pitch." className="shrink-0" />
             <Select
               value={spec.gridPitch}
               onValueChange={(value) => {
@@ -534,7 +534,6 @@ export function BinControlsPanel({
               </SelectContent>
             </Select>
           </div>
-          <p className="text-[11px] text-muted-foreground">Pitch changes preserve the outer size. A coarser pitch needs whole cells; custom footprints keep their current pitch.</p>
           <FeatureSwitch label="Keep bin size fixed" description="Adding tools keeps these dimensions. Tools that do not fit stay visible for adjustment." checked={keepBinSize} onChange={(fixed) => onKeepBinSizeChange?.(fixed)} />
           {spec.footprint.kind === "rectangle" ? (
             <>
@@ -562,7 +561,7 @@ export function BinControlsPanel({
             </div>
           )}
           <div className="space-y-1.5">
-            <div className="flex items-baseline justify-between">
+            <div className="flex items-baseline justify-between gap-2">
               <Label className="text-xs">Height</Label>
               <span className="text-xs tabular-nums text-muted-foreground">
                 <DraftNumberInput className="inline-block h-8 w-20" aria-label="Bin height in units" value={spec.heightUnits} min={1} max={MAX_HEIGHT_UNITS_UI} step={0.5} normalize={(value) => Math.round(value * 2) / 2} onValueChange={(heightUnits) => patchSpec({ heightUnits }, true)} onValueCommit={(heightUnits) => patchSpec({ heightUnits })} /> u · {spec.heightUnits * 7} mm
@@ -704,7 +703,7 @@ export function BinControlsPanel({
 
           <div className="space-y-2 border-t pt-3">
             <div className="flex items-center gap-2">
-              <Label className="w-16 shrink-0 text-xs">Label tab</Label>
+              <SettingLabel label="Label tab" hint="A sloped shelf under the rim for labelling the bin." className="shrink-0" />
               <Select
                 value={spec.labelTab?.width ?? "none"}
                 onValueChange={(width) =>
@@ -774,9 +773,6 @@ export function BinControlsPanel({
                 </Button>
               </div>
             )}
-            <p className="text-[11px] text-muted-foreground">
-              A sloped shelf under the rim for labelling the bin.
-            </p>
           </div>
         </PanelSection>
 
@@ -849,6 +845,27 @@ export function BinControlsPanel({
               <div className="flex min-w-0 items-center gap-2 border-b border-violet-500/20 pb-2" data-testid="pocket-properties-heading">
                 <h3 className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">Pocket properties</h3>
                 <span className="min-w-0 truncate text-xs font-medium" title={selectedShape.name}>{selectedShape.name}</span>
+                <Button
+                  variant={editorMode === "contour" ? "default" : "outline"}
+                  size="sm"
+                  className="ml-auto h-7 shrink-0 gap-1 px-1.5 text-[10px]"
+                  aria-label={editorMode === "contour" ? "Finish contour editing" : "Edit contour"}
+                  aria-pressed={editorMode === "contour"}
+                  data-testid="button-edit-contour"
+                  onClick={() => {
+                    const editing = editorMode === "contour";
+                    dispatch({
+                      type: "SET_EDITOR_MODE",
+                      editorMode: editing ? "placement" : "contour",
+                    });
+                    if (!editing) {
+                      dispatch({ type: "SET_VIEW_MODE", viewMode: "2d" });
+                    }
+                  }}
+                >
+                  <Spline className="h-3 w-3" />
+                  {editorMode === "contour" ? "Done" : "Edit contour"}
+                </Button>
               </div>
               <section className="space-y-2" aria-label="Pocket depth" key={selectedCutout.id}>
                 <div className="flex items-center gap-1">
@@ -924,7 +941,8 @@ export function BinControlsPanel({
                   <MmSlider
                     label="Extra pocket clearance"
                     value={selectedCutout.clearanceMm}
-                    min={0}
+                    centered
+                    min={-2}
                     max={2}
                     step={0.1}
                     onChange={(clearanceMm, transient) =>
@@ -938,7 +956,7 @@ export function BinControlsPanel({
                     }
                     hintAsTooltip
                     hint={<>
-                      Added after the Trace margin; new pockets start at 0 mm.
+                      Adjusts each edge after the Trace margin and scaling. Negative values shrink the pocket to reduce excess padding; positive values enlarge it. Zero keeps the traced size. Narrow features can disappear when shrunk.
                       <span className="mt-1 block">{selectedShape.traceMarginMm === undefined
                         ? `Original trace margin unknown (older project). Extra allowance: ${selectedCutout.clearanceMm.toFixed(2)} mm per edge.`
                         : `Trace margin: ${selectedShape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(selectedShape.traceMarginMm * selectedCutout.scaleX + selectedCutout.clearanceMm).toFixed(2)} / ${(selectedShape.traceMarginMm * selectedCutout.scaleY + selectedCutout.clearanceMm).toFixed(2)} mm per edge.`}</span>
@@ -954,25 +972,7 @@ export function BinControlsPanel({
                 </summary>
                 <div className="space-y-3 pt-2" key={selectedCutout.id}>
                   <MmSlider
-                    label="Outline corners"
-                    value={selectedCutout.cornerRoundMm}
-                    min={0}
-                    max={3}
-                    step={0.5}
-                    onChange={(cornerRoundMm, transient) =>
-                      dispatch({
-                        type: "UPDATE_CUTOUT",
-                        id: selectedCutout.id,
-                        patch: { cornerRoundMm },
-                        historyLabel: "Change outline corner round",
-                        transient,
-                      })
-                    }
-                    hintAsTooltip
-                    hint="Rounds sharp corners in the pocket outline from top to bottom."
-                  />
-                  <MmSlider
-                    label="Top edge"
+                    label="Top edge rounding"
                     value={selectedCutout.topFilletMm}
                     min={0}
                     max={5}
@@ -990,7 +990,7 @@ export function BinControlsPanel({
                     hint="Rounds the pocket wall into the top surface of the bin."
                   />
                   <MmSlider
-                    label="Bottom edge"
+                    label="Bottom edge fillet"
                     value={selectedCutout.bottomFilletMm}
                     min={0}
                     max={4}
@@ -1006,6 +1006,24 @@ export function BinControlsPanel({
                     }
                     hintAsTooltip
                     hint="Rounds the wall into the floor; the transition ends one radius above the floor."
+                  />
+                  <MmSlider
+                    label="Outline corner rounding"
+                    value={selectedCutout.cornerRoundMm}
+                    min={0}
+                    max={3}
+                    step={0.5}
+                    onChange={(cornerRoundMm, transient) =>
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { cornerRoundMm },
+                        historyLabel: "Change outline corner round",
+                        transient,
+                      })
+                    }
+                    hintAsTooltip
+                    hint="Rounds sharp corners in the pocket outline from top to bottom."
                   />
 
                 </div>
@@ -1044,25 +1062,6 @@ export function BinControlsPanel({
                 </div>
 
               </PocketMeasurements>
-              <Button
-                variant={editorMode === "contour" ? "default" : "outline"}
-                size="sm"
-                className="w-full"
-                data-testid="button-edit-contour"
-                onClick={() => {
-                  const editing = editorMode === "contour";
-                  dispatch({
-                    type: "SET_EDITOR_MODE",
-                    editorMode: editing ? "placement" : "contour",
-                  });
-                  if (!editing) {
-                    dispatch({ type: "SET_VIEW_MODE", viewMode: "2d" });
-                  }
-                }}
-              >
-                <Spline className="mr-1.5 h-3.5 w-3.5" />
-                {editorMode === "contour" ? "Finish contour editing" : "Edit contour"}
-              </Button>
               {editorMode === "contour" && (
                 <p className="rounded-md bg-violet-500/10 px-2.5 py-2 text-[11px] text-violet-800 dark:text-violet-200">
                   Drag points to reshape. Click an edge to add a point; right-click a
@@ -1092,11 +1091,8 @@ export function BinControlsPanel({
           className="scroll-mt-16"
         >
           <div className="space-y-3">
-            <div className="flex items-start justify-between gap-3 rounded-md border border-violet-500/25 bg-violet-500/10 px-2.5 py-2">
-              <p className="text-[11px] text-violet-900 dark:text-violet-100">
-                Finger holes are independent layout objects. Select, move, resize,
-                or remove one without changing a tool pocket.
-              </p>
+            <div className="flex items-center justify-between gap-3">
+              <SettingLabel label="Finger holes" hint="Finger holes are independent layout objects. Select, move, resize, or remove one without changing a tool pocket. Drag a hole to move it and its white size handle to resize it; oblong holes also have two end handles for length and angle." />
               <Button
                 variant="outline"
                 size="sm"
@@ -1466,11 +1462,6 @@ export function BinControlsPanel({
                     hint="Rounds the straight wall into its flat floor."
                   />
                 )}
-                <p className="text-[11px] text-muted-foreground">
-                  Drag the shape to move it. Drag the white size handle to change
-                  diameter; oblong holes also have two end handles for length and
-                  angle.
-                </p>
               </div>
             )}
           </div>
@@ -1490,12 +1481,7 @@ export function BinControlsPanel({
             data-testid="view-color-row-bin"
           >
             <div className="min-w-0">
-              <Label htmlFor="input-bin-color" className="text-xs">
-                Bin body
-              </Label>
-              <p className="truncate text-[11px] text-muted-foreground">
-                Main preview and 3MF material
-              </p>
+              <SettingLabel label="Bin body" htmlFor="input-bin-color" hint="Main preview and 3MF material." />
             </div>
             <MaterialColorSwatch
               id="input-bin-color"
@@ -1510,10 +1496,7 @@ export function BinControlsPanel({
           >
             <div className="flex items-center justify-between gap-3">
               <div className="min-w-0">
-                <Label className="text-xs">Pocket floors</Label>
-                <p className="truncate text-[11px] text-muted-foreground">
-                  Separate material below blind-pocket surfaces
-                </p>
+                <SettingLabel label="Pocket floors" hint="Separate material below blind-pocket surfaces." />
               </div>
               <div className="flex shrink-0 items-center gap-2">
                 <MaterialColorSwatch
@@ -1531,9 +1514,7 @@ export function BinControlsPanel({
               </div>
             </div>
             <div className="flex items-center justify-between gap-3">
-              <Label htmlFor="input-pocket-floor-thickness" className="text-[11px]">
-                Color thickness
-              </Label>
+              <SettingLabel label="Color thickness" htmlFor="input-pocket-floor-thickness" hint="Accent thickness replaces existing material downward from the original surface; it never adds height to the bin." />
               <div className="flex items-center gap-1.5">
                 <DraftNumberInput
                   id="input-pocket-floor-thickness"
@@ -1566,12 +1547,8 @@ export function BinControlsPanel({
           >
             <div className="flex items-center justify-between gap-3">
               <div className="min-w-0">
-                <Label className="text-xs">Stacking rim top</Label>
-                <p className="truncate text-[11px] text-muted-foreground">
-                  {spec.lip === "standard"
-                    ? "Separate material below the original rim surface"
-                    : "Turn on the stacking lip to enable this material"}
-                </p>
+                <SettingLabel label="Stacking rim top" hint="Separate material below the original rim surface." />
+                {spec.lip !== "standard" && <p className="text-[11px] text-muted-foreground">Turn on the stacking lip to enable this material.</p>}
               </div>
               <div className="flex shrink-0 items-center gap-2">
                 <MaterialColorSwatch
@@ -1590,9 +1567,7 @@ export function BinControlsPanel({
               </div>
             </div>
             <div className="flex items-center justify-between gap-3">
-              <Label htmlFor="input-stacking-rim-thickness" className="text-[11px]">
-                Color thickness
-              </Label>
+              <SettingLabel label="Color thickness" htmlFor="input-stacking-rim-thickness" hint="Accent thickness replaces existing material downward from the original surface; it never adds height to the bin." />
               <div className="flex items-center gap-1.5">
                 <DraftNumberInput
                   id="input-stacking-rim-thickness"
@@ -1618,16 +1593,11 @@ export function BinControlsPanel({
               </div>
             </div>
           </div>
-          <p className="text-[11px] text-muted-foreground">
-            Accent thickness replaces existing material downward from each
-            original surface; it never adds height to the bin.
-          </p>
         </PanelSection>
         <PanelSection id="bin-settings-view" title="View" icon={Eye} tone="amber" defaultOpen={section !== null} summary={section ? "Cut open" : "Whole bin"}>
-          <p className="text-xs text-muted-foreground">These controls only change the preview. Exports always contain the complete bin.</p>
           <FeatureSwitch
             label="Cut the preview open"
-            description="Slice the 3D view to inspect pockets"
+            description="Slice the 3D view to inspect pockets. These controls only change the preview; exports always contain the complete bin."
             checked={section !== null}
             onChange={(on) =>
               onSectionChange(on ? { axis: "x", offsetMm: 0 } : null)
@@ -1675,17 +1645,12 @@ export function BinControlsPanel({
         </PanelSection>
 
         <PanelSection id="bin-settings-fit" title="Check fit" icon={ClipboardCheck} tone="emerald" defaultOpen={false} summary="Thin templates">
-          <p className="text-xs text-muted-foreground">Print a thin template and try the actual tools before printing the full bin.</p>
           <div
             className="space-y-3 rounded-md border border-violet-500/25 bg-violet-500/5 p-2.5"
             data-testid="export-preview-layout"
           >
             <div>
-              <Label className="text-xs">Fit templates and layout</Label>
-              <p className="text-[11px] text-muted-foreground">
-                Lightweight outputs for checking fit or planning a shadow board;
-                these are not the final bin model.
-              </p>
+              <SettingLabel label="Fit templates and layout" hint="Print a thin template and try the actual tools before printing the full bin. These lightweight outputs check fit or plan a shadow board; they are not the final bin model." />
             </div>
 
             {(cutouts.length > 0 || fingerHoles.length > 0) && (
@@ -1694,11 +1659,7 @@ export function BinControlsPanel({
                 data-testid="surface-fit-test-export"
               >
                 <div>
-                  <Label className="text-xs">Complete surface fit test</Label>
-                  <p className="text-[11px] text-muted-foreground">
-                    The bin's full pocket-layout surface as one thin plate,
-                    without its base, wall height, label tab, or stacking lip.
-                  </p>
+                  <SettingLabel label="Complete surface fit test" hint="The bin's full pocket-layout surface as one thin plate, without its base, wall height, label tab, or stacking lip. Checks every pocket opening and independent finger hole together. It does not test cut depth or baseplate fit." />
                 </div>
                 <div className="flex items-center gap-2">
                   <Label className="w-20 shrink-0 text-xs">Thickness</Label>
@@ -1738,21 +1699,14 @@ export function BinControlsPanel({
                   <Download className="mr-1.5 h-3.5 w-3.5" />
                   {exporting ? "Building…" : "Save surface fit test STL"}
                 </Button>
-                <p className="text-[11px] text-muted-foreground">
-                  Checks every pocket opening and independent finger hole together.
-                  It does not test cut depth or baseplate fit.
-                </p>
               </div>
             )}
 
             {selectedCutout && selectedShape ? (
               <div className="space-y-2 border-t pt-2.5">
                 <div>
-                  <Label className="text-xs">Tool fit template</Label>
-                  <p className="text-[11px] text-muted-foreground">
-                    A filled outline of “{selectedShape.name}” without the bin or
-                    finger holes.
-                  </p>
+                  <SettingLabel label="Tool fit template" hint="A filled tool outline without the bin or finger holes. Includes its Trace margin, signed pocket clearance, and outline corner rounding." />
+                  <p className="truncate text-xs font-medium" title={selectedShape.name}>{selectedShape.name}</p>
                 </div>
                 <div className="flex items-center gap-2">
                   <Label className="w-20 shrink-0 text-xs">Thickness</Label>
@@ -1785,10 +1739,6 @@ export function BinControlsPanel({
                   <Download className="mr-1.5 h-3.5 w-3.5" />
                   {exporting ? "Building…" : "Save fit template STL"}
                 </Button>
-                <p className="text-[11px] text-muted-foreground">
-                  Includes its Trace margin, extra clearance, and outline corner
-                  round.
-                </p>
               </div>
             ) : cutouts.length > 0 ? (
               <p className="border-t pt-2.5 text-[11px] text-muted-foreground">
@@ -1817,7 +1767,7 @@ export function BinControlsPanel({
 
             {cutouts.length > 0 && (
               <div className="space-y-1.5 border-t pt-2.5">
-                <Label className="text-xs">Shadow-board layout (top view)</Label>
+                <SettingLabel label="Shadow-board layout (top view)" hint="Bin footprint and pocket silhouettes in millimetres, for CNC or laser shadow boards." />
                 <div className="flex gap-2">
                   <Button
                     variant="outline"
@@ -1848,10 +1798,6 @@ export function BinControlsPanel({
                     Layout SVG
                   </Button>
                 </div>
-                <p className="text-[11px] text-muted-foreground">
-                  Bin footprint and pocket silhouettes in millimetres, for CNC
-                  or laser shadow boards.
-                </p>
               </div>
             )}
           </div>
@@ -1881,14 +1827,13 @@ export function BinControlsPanel({
           className="scroll-mt-16"
         >
           <div className="space-y-1">
-            <Label className="text-xs">Model validation</Label>
+            <SettingLabel label="Model validation" hint="Estimate filament weight in your slicer using your infill and wall settings." />
             {stats ? (
               <div className="space-y-1 text-xs text-muted-foreground">
                 <p className="tabular-nums">
                   {stats.triangles.toLocaleString()} triangles ·{" "}
                   {(stats.volumeMm3 / 1000).toFixed(1)} cm³ model volume
                 </p>
-                <p className="text-[11px]">Estimate filament weight in your slicer using your infill and wall settings.</p>
               </div>
             ) : (
               <p className="text-xs text-muted-foreground">
@@ -1911,22 +1856,12 @@ export function BinControlsPanel({
             </div>
           ) : null}
 
-          <p className="text-xs text-muted-foreground">
-            You can include an editable project JSON when downloading a model or
-            layout. Select the checkbox in the export dialog to save both files.
-          </p>
-
           <div
             className="space-y-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 p-2.5"
             data-testid="export-final-model"
           >
             <div>
-              <Label className="text-xs">Export printable bin</Label>
-              <p className="text-[11px] text-muted-foreground">
-                {cutouts.length === 0 && fingerHoles.length === 0
-                  ? "Export the solid bin at print quality. Use 3MF to preserve optional material colors."
-                  : "Export the complete bin at print quality. Use 3MF to preserve optional material colors."}
-              </p>
+              <SettingLabel label="Export printable bin" hint="Export the complete bin at print quality. Use 3MF to preserve optional material colors. Select the editable-project checkbox in the export dialog to also save a project JSON with your tools and settings." />
             </div>
             <div className="flex gap-2">
               <Button
@@ -2147,20 +2082,15 @@ function ProjectControls({
         className="rounded-md border bg-muted/40 px-3 py-2"
         data-testid="project-autosave-status"
       >
-        <p className="text-xs font-medium">
-          {!ready
-            ? "Checking for saved projects…"
-            : (currentProjectName ?? "Untitled project")}
-        </p>
-        <p className="mt-0.5 text-[11px] text-muted-foreground">
-          {!ready
-            ? "Project actions will be ready in a moment."
-            : saveStatus === "error"
-              ? "Autosave is unavailable. Download an editable project to keep your work."
-              : activeProjectId
-                ? "Saved automatically in this browser’s Project Library."
-                : "This draft resumes automatically; save it to the library to name it."}
-        </p>
+        <div className="flex items-center gap-1">
+          <p className="min-w-0 truncate text-xs font-medium">
+            {!ready ? "Checking for saved projects…" : (currentProjectName ?? "Untitled project")}
+          </p>
+          {ready && <HelpHint label="project autosave">{activeProjectId
+            ? "Saved automatically in this browser’s Project Library."
+            : "This draft resumes automatically; save it to the library to name it."}</HelpHint>}
+        </div>
+        {saveStatus === "error" && <p className="mt-0.5 text-[11px] text-destructive" role="status">Autosave is unavailable. Download an editable project to keep your work.</p>}
       </div>
 
       <div className="grid grid-cols-2 gap-2">
@@ -2365,7 +2295,7 @@ function ProjectControls({
       </div>
 
       <div className="space-y-1.5 border-t pt-3">
-        <Label className="text-xs">Portable backup</Label>
+        <SettingLabel label="Portable backup" hint="Editable .pocketry.json files preserve tools and settings. STL and 3MF are for printing." />
         <div className="grid grid-cols-2 gap-2">
           <Button
             variant="outline"
@@ -2399,9 +2329,6 @@ function ProjectControls({
             event.target.value = "";
           }}
         />
-        <p className="text-[11px] text-muted-foreground">
-          Editable .pocketry.json files preserve tools and settings. STL and 3MF are for printing.
-        </p>
       </div>
     </>
   );
@@ -2432,16 +2359,16 @@ function CellSlider({
   const step = pitch === "quarter" ? 0.25 : 0.5;
   return (
     <div className="space-y-1.5">
-      <div className="flex items-baseline justify-between">
+      <div className="flex items-baseline justify-between gap-2">
         <Label className="text-xs">{label}</Label>
         <span className="text-xs tabular-nums text-muted-foreground">
           <DraftNumberInput className="inline-block h-8 w-16" aria-label={`${label} in standard cells`} value={standardCells} min={step} max={MAX_GRID / divisor} step={step} normalize={(value) => Math.round(value / step) * step} onValueChange={(value) => onChange(value, true)} onValueCommit={(value) => onChange(value, false)} /> × 42 mm
         </span>
       </div>
-      <Label className="flex items-center justify-between text-xs">{label} outer size
-        <span><DraftNumberInput className="inline-block h-8 w-20" aria-label={`${label} outer size in millimetres`} value={Number(binFootprintMm(cells, pitch).toFixed(1))} min={step * 42 - 0.5} max={MAX_GRID / divisor * 42 - 0.5} step={step * 42} normalize={(value) => Math.round((value + 0.5) / (42 * step)) * 42 * step - 0.5} onValueChange={(value) => onChange((value + 0.5) / 42, true)} onValueCommit={(value) => onChange((value + 0.5) / 42, false)} /> mm</span>
-      </Label>
-      <p className="text-[11px] text-muted-foreground">Snaps to {step * 42} mm grid increments.</p>
+      <div className="flex items-center justify-between gap-2 text-xs">
+        <SettingLabel label={`${label} outer size`} hint={`Snaps to ${step * 42} mm grid increments.`} />
+        <span className="shrink-0 whitespace-nowrap"><DraftNumberInput className="inline-block h-8 w-20" aria-label={`${label} outer size in millimetres`} value={Number(binFootprintMm(cells, pitch).toFixed(1))} min={step * 42 - 0.5} max={MAX_GRID / divisor * 42 - 0.5} step={step * 42} normalize={(value) => Math.round((value + 0.5) / (42 * step)) * 42 * step - 0.5} onValueChange={(value) => onChange((value + 0.5) / 42, true)} onValueCommit={(value) => onChange((value + 0.5) / 42, false)} /> mm</span>
+      </div>
       <Slider
         value={[standardCells]}
         onValueChange={([value]) => onChange(value, true)}
@@ -2462,7 +2389,8 @@ function MmSlider({
   max,
   step,
   hint,
-  hintAsTooltip = false,
+  hintAsTooltip = true,
+  centered = false,
   onChange,
 }: {
   label: string;
@@ -2472,21 +2400,23 @@ function MmSlider({
   step: number;
   hint?: ReactNode;
   hintAsTooltip?: boolean;
+  centered?: boolean;
   onChange: (value: number, transient: boolean) => void;
 }): JSX.Element {
   const decimalPlaces = Math.max(0, (String(step).split(".")[1] ?? "").length);
   return (
     <div className="space-y-1.5">
-      <div className="flex items-baseline justify-between">
+      <div className="flex items-baseline justify-between gap-2">
         <div className="flex items-center gap-1">
           <Label className="text-xs">{label}</Label>
           {hint && hintAsTooltip && <HelpHint label={label.toLowerCase()}>{hint}</HelpHint>}
         </div>
-        <span className="text-xs tabular-nums text-muted-foreground">
-          <DraftNumberInput className="inline-block h-8 w-20" aria-label={`${label} in millimetres`} value={value} displayPrecision={2} min={min} max={max} step={step} onValueChange={(next) => onChange(next, true)} onValueCommit={(next) => onChange(next, false)} /> mm
+        <span className="shrink-0 whitespace-nowrap text-xs tabular-nums text-muted-foreground">
+          <DraftNumberInput className="inline-block h-8 w-16" aria-label={`${label} in millimetres`} value={value} displayPrecision={2} min={min} max={max} step={step} onValueChange={(next) => onChange(next, true)} onValueCommit={(next) => onChange(next, false)} /> mm
         </span>
       </div>
       <Slider
+        centerOrigin={centered}
         value={[value]}
         onValueChange={([next]) =>
           onChange(Number(next.toFixed(decimalPlaces)), true)
@@ -2499,9 +2429,23 @@ function MmSlider({
         step={step}
         aria-label={label}
       />
+      {centered && <div className="relative flex justify-between text-[10px] tabular-nums text-muted-foreground" aria-hidden="true"><span>{min} · Shrink</span><span className="absolute left-1/2 -translate-x-1/2">0</span><span>Enlarge · +{max}</span></div>}
       {hint && !hintAsTooltip && <p className="text-[11px] text-muted-foreground">{hint}</p>}
     </div>
   );
+}
+
+/** Field guidance stays beside its label without taking another panel row. */
+function SettingLabel({ label, hint, htmlFor, className }: {
+  label: string;
+  hint?: ReactNode;
+  htmlFor?: string;
+  className?: string;
+}): JSX.Element {
+  return <div className={cn("flex min-w-0 items-center gap-1", className)}>
+    <Label htmlFor={htmlFor} className="text-xs">{label}</Label>
+    {hint && <HelpHint label={label.toLowerCase()}>{hint}</HelpHint>}
+  </div>;
 }
 
 function FeatureSwitch({
@@ -2520,10 +2464,8 @@ function FeatureSwitch({
   return (
     <div className="flex items-center justify-between gap-3">
       <div className="min-w-0">
-        <Label className="text-xs">{label}</Label>
-        {description && (
-          <p className="truncate text-[11px] text-muted-foreground">{description}</p>
-        )}
+        <SettingLabel label={label} hint={disabled ? undefined : description} />
+        {disabled && description && <p className="text-[11px] text-muted-foreground">{description}</p>}
       </div>
       <Switch
         checked={checked}

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -45,7 +45,7 @@ import {
   standardCellSpan,
   type GridPitch,
 } from "@shared/gridfinity/standard";
-import { MAX_GRID, type BinSpecInput } from "@shared/gridfinity/types";
+import { MAX_GRID, maxGridCells, type BinSpecInput } from "@shared/gridfinity/types";
 import type { ValidationIssue } from "@shared/gridfinity/validate";
 
 import {
@@ -114,7 +114,7 @@ import { useShapeLibrary } from "@/state/shape-library";
 const MAX_HEIGHT_UNITS_UI = 12;
 /** Slider ceiling: at most eight full cells, within the schema hard cap. */
 const maxGridUi = (pitch: GridPitch): number =>
-  Math.min(MAX_GRID, 8 * GRID_PITCH_DIVISOR[pitch]);
+  Math.min(maxGridCells(pitch), 8 * GRID_PITCH_DIVISOR[pitch]);
 
 const formatUnitCount = (value: number): string =>
   Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/0$/, "");
@@ -367,7 +367,7 @@ export function BinControlsPanel({
     transient: boolean,
   ) => {
     const resized = resizeGridToStandardCellSpan(spec, axis, span);
-    if (resized.gridX > MAX_GRID || resized.gridY > MAX_GRID) return;
+    if (resized.gridX > maxGridCells(resized.gridPitch) || resized.gridY > maxGridCells(resized.gridPitch)) return;
     const promotedToFractionalPitch =
       resized.gridPitch !== spec.gridPitch && resized.gridPitch !== "full";
     patchSpec(
@@ -509,7 +509,7 @@ export function BinControlsPanel({
               onValueChange={(value) => {
                 const gridPitch = value as GridPitch;
                 const resized = changeGridPitchPreservingSize(spec, gridPitch);
-                if (!resized || resized.gridX > MAX_GRID || resized.gridY > MAX_GRID || spec.footprint.kind !== "rectangle") return;
+                if (!resized || resized.gridX > maxGridCells(gridPitch) || resized.gridY > maxGridCells(gridPitch) || spec.footprint.kind !== "rectangle") return;
                 patchSpec({
                   ...resized,
                   ...(gridPitch === "full"
@@ -528,7 +528,7 @@ export function BinControlsPanel({
               <SelectContent>
                 {(["full", "half", "quarter"] as const).map((pitch) => {
                   const resized = changeGridPitchPreservingSize(spec, pitch);
-                  const available = resized && resized.gridX <= MAX_GRID && resized.gridY <= MAX_GRID && spec.footprint.kind === "rectangle";
+                  const available = resized && resized.gridX <= maxGridCells(pitch) && resized.gridY <= maxGridCells(pitch) && spec.footprint.kind === "rectangle";
                   return <SelectItem key={pitch} value={pitch} disabled={!available}>{pitch === "full" ? "Full · 42 mm" : pitch === "half" ? "Half · 21 mm" : "Quarter · 10.5 mm"}{!available ? " (size incompatible)" : ""}</SelectItem>;
                 })}
               </SelectContent>
@@ -695,6 +695,13 @@ export function BinControlsPanel({
             </>
           )}
 
+          <FeatureSwitch
+            label="Flat bottom"
+            description="Smooth underside; no Gridfinity base."
+            checked={spec.flatBottom}
+            onChange={(flatBottom) => patchSpec({ flatBottom })}
+          />
+
           <div className="space-y-2 border-t pt-3">
             <div className="flex items-center gap-2">
               <SettingLabel label="Label tab" hint="A sloped shelf under the rim for labelling the bin." className="shrink-0" />
@@ -768,12 +775,6 @@ export function BinControlsPanel({
               </div>
             )}
           </div>
-          <FeatureSwitch
-            label="Flat bottom"
-            description="Smooth underside; no Gridfinity base."
-            checked={spec.flatBottom}
-            onChange={(flatBottom) => patchSpec({ flatBottom })}
-          />
         </PanelSection>
 
         {/* Keyed on emptiness: defaultOpen is uncontrolled, and the section
@@ -2363,12 +2364,12 @@ function CellSlider({
       <div className="flex items-baseline justify-between gap-2">
         <Label className="text-xs">{label}</Label>
         <span className="text-xs tabular-nums text-muted-foreground">
-          <DraftNumberInput className="inline-block h-8 w-16" aria-label={`${label} in standard cells`} value={standardCells} min={step} max={MAX_GRID / divisor} step={step} normalize={(value) => Math.round(value / step) * step} onValueChange={(value) => onChange(value, true)} onValueCommit={(value) => onChange(value, false)} /> × 42 mm
+          <DraftNumberInput className="inline-block h-8 w-16" aria-label={`${label} in standard cells`} value={standardCells} min={step} max={MAX_GRID} step={step} normalize={(value) => Math.round(value / step) * step} onValueChange={(value) => onChange(value, true)} onValueCommit={(value) => onChange(value, false)} /> × 42 mm
         </span>
       </div>
       <div className="flex items-center justify-between gap-2 text-xs">
         <SettingLabel label={`${label} outer size`} hint={`Snaps to ${step * 42} mm grid increments.`} />
-        <span className="shrink-0 whitespace-nowrap"><DraftNumberInput className="inline-block h-8 w-20" aria-label={`${label} outer size in millimetres`} value={Number(binFootprintMm(cells, pitch).toFixed(1))} min={step * 42 - 0.5} max={MAX_GRID / divisor * 42 - 0.5} step={step * 42} normalize={(value) => Math.round((value + 0.5) / (42 * step)) * 42 * step - 0.5} onValueChange={(value) => onChange((value + 0.5) / 42, true)} onValueCommit={(value) => onChange((value + 0.5) / 42, false)} /> mm</span>
+        <span className="shrink-0 whitespace-nowrap"><DraftNumberInput className="inline-block h-8 w-20" aria-label={`${label} outer size in millimetres`} value={Number(binFootprintMm(cells, pitch).toFixed(1))} min={step * 42 - 0.5} max={MAX_GRID * 42 - 0.5} step={step * 42} normalize={(value) => Math.round((value + 0.5) / (42 * step)) * 42 * step - 0.5} onValueChange={(value) => onChange((value + 0.5) / 42, true)} onValueCommit={(value) => onChange((value + 0.5) / 42, false)} /> mm</span>
       </div>
       <Slider
         value={[standardCells]}

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -89,7 +89,6 @@ import {
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { fitRectangularBinToPlacements } from "@/lib/gridfinity/autoplace";
-import { occupiedCellCount } from "@shared/gridfinity/footprint";
 import {
   binDimensionsMm,
   MULTICOLOR_FLOOR_MAX_THICKNESS_MM,
@@ -556,28 +555,29 @@ export function BinControlsPanel({
             </>
           ) : (
             <div className="rounded-md border bg-muted/30 px-2.5 py-2 text-xs text-muted-foreground">
-              Bounding grid {spec.gridX} × {spec.gridY}. Add or remove cells in the Layout view,
+              Custom footprint. Add or remove cells in the Layout view,
               or reset to a rectangle to use the size sliders.
             </div>
           )}
           <div className="space-y-1.5">
-            <div className="flex items-baseline justify-between gap-2">
-              <Label className="text-xs">Height</Label>
-              <span className="text-xs tabular-nums text-muted-foreground">
-                <DraftNumberInput className="inline-block h-8 w-20" aria-label="Bin height in units" value={spec.heightUnits} min={1} max={MAX_HEIGHT_UNITS_UI} step={0.5} normalize={(value) => Math.round(value * 2) / 2} onValueChange={(heightUnits) => patchSpec({ heightUnits }, true)} onValueCommit={(heightUnits) => patchSpec({ heightUnits })} /> u · {spec.heightUnits * 7} mm
+            <Label className="text-xs">Height</Label>
+            <div className="flex items-center gap-2">
+              <Slider
+                className="min-w-12 flex-1"
+                value={[spec.heightUnits]}
+                onValueChange={([heightUnits]) =>
+                  patchSpec({ heightUnits }, true)
+                }
+                onValueCommit={([heightUnits]) => patchSpec({ heightUnits })}
+                min={1}
+                max={MAX_HEIGHT_UNITS_UI}
+                step={0.5}
+                aria-label="Height in 0.5u increments"
+              />
+              <span className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs tabular-nums text-muted-foreground">
+                <DraftNumberInput className="h-8 w-16" aria-label="Bin height in units" value={spec.heightUnits} min={1} max={MAX_HEIGHT_UNITS_UI} step={0.5} normalize={(value) => Math.round(value * 2) / 2} onValueChange={(heightUnits) => patchSpec({ heightUnits }, true)} onValueCommit={(heightUnits) => patchSpec({ heightUnits })} /> u · {spec.heightUnits * 7} mm
               </span>
             </div>
-            <Slider
-              value={[spec.heightUnits]}
-              onValueChange={([heightUnits]) =>
-                patchSpec({ heightUnits }, true)
-              }
-              onValueCommit={([heightUnits]) => patchSpec({ heightUnits })}
-              min={1}
-              max={MAX_HEIGHT_UNITS_UI}
-              step={0.5}
-              aria-label="Height in 0.5u increments"
-            />
           </div>
           <p className="text-xs text-muted-foreground">
             Outer size {dims.widthMm.toFixed(1)} × {dims.lengthMm.toFixed(1)} ×{" "}
@@ -585,10 +585,6 @@ export function BinControlsPanel({
             {spec.lip === "standard"
               ? ` (rim + ${STACKING_LIP_HEIGHT_ACTUAL.toFixed(1)} mm lip)`
               : ""}
-          </p>
-          <p className="text-xs text-muted-foreground" data-testid="bin-footprint-summary">
-            {occupiedCellCount(spec)} of {spec.gridX * spec.gridY} {spec.gridPitch}-pitch cells occupied
-            {spec.footprint.kind === "custom" ? " · custom footprint" : ""}
           </p>
           {building && (
             <div
@@ -2361,25 +2357,25 @@ function CellSlider({
   const step = pitch === "quarter" ? 0.25 : 0.5;
   return (
     <div className="space-y-1.5">
-      <div className="flex items-baseline justify-between gap-2">
-        <Label className="text-xs">{label}</Label>
-        <span className="text-xs tabular-nums text-muted-foreground">
-          <DraftNumberInput className="inline-block h-8 w-16" aria-label={`${label} in standard cells`} value={standardCells} min={step} max={MAX_GRID} step={step} normalize={(value) => Math.round(value / step) * step} onValueChange={(value) => onChange(value, true)} onValueCommit={(value) => onChange(value, false)} /> × 42 mm
+      <SettingLabel label={label} hint={`Standard cells are 42 mm. Outer size includes the 0.5 mm fitting gap. Snaps to ${step * 42} mm grid increments.`} />
+      <div className="flex items-center gap-2">
+        <Slider
+          className="min-w-12 flex-1"
+          value={[standardCells]}
+          onValueChange={([value]) => onChange(value, true)}
+          onValueCommit={([value]) => onChange(value, false)}
+          min={step}
+          max={Math.max(standardCells, maxGridUi(pitch) / divisor)}
+          step={step}
+          aria-label={`${label} in standard Gridfinity cells`}
+        />
+        <span className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs tabular-nums text-muted-foreground">
+          <DraftNumberInput className="h-8 w-16" aria-label={`${label} in standard cells`} value={standardCells} min={step} max={MAX_GRID} step={step} normalize={(value) => Math.round(value / step) * step} onValueChange={(value) => onChange(value, true)} onValueCommit={(value) => onChange(value, false)} /> × 42 mm
+        </span>
+        <span className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs tabular-nums">
+          <DraftNumberInput className="h-8 w-20" aria-label={`${label} outer size in millimetres`} value={Number(binFootprintMm(cells, pitch).toFixed(1))} min={step * 42 - 0.5} max={MAX_GRID * 42 - 0.5} step={step * 42} normalize={(value) => Math.round((value + 0.5) / (42 * step)) * 42 * step - 0.5} onValueChange={(value) => onChange((value + 0.5) / 42, true)} onValueCommit={(value) => onChange((value + 0.5) / 42, false)} /> mm
         </span>
       </div>
-      <div className="flex items-center justify-between gap-2 text-xs">
-        <SettingLabel label={`${label} outer size`} hint={`Snaps to ${step * 42} mm grid increments.`} />
-        <span className="shrink-0 whitespace-nowrap"><DraftNumberInput className="inline-block h-8 w-20" aria-label={`${label} outer size in millimetres`} value={Number(binFootprintMm(cells, pitch).toFixed(1))} min={step * 42 - 0.5} max={MAX_GRID * 42 - 0.5} step={step * 42} normalize={(value) => Math.round((value + 0.5) / (42 * step)) * 42 * step - 0.5} onValueChange={(value) => onChange((value + 0.5) / 42, true)} onValueCommit={(value) => onChange((value + 0.5) / 42, false)} /> mm</span>
-      </div>
-      <Slider
-        value={[standardCells]}
-        onValueChange={([value]) => onChange(value, true)}
-        onValueCommit={([value]) => onChange(value, false)}
-        min={step}
-        max={Math.max(standardCells, maxGridUi(pitch) / divisor)}
-        step={step}
-        aria-label={`${label} in standard Gridfinity cells`}
-      />
     </div>
   );
 }

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   ChevronDown,
-  ChevronRight,
   CircleDot,
   ClipboardCheck,
   Copy,
@@ -21,11 +20,10 @@ import {
   Scaling,
   Save,
   Scissors,
-  SlidersHorizontal,
   Spline,
   Trash2,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from "react";
 import { useLocation } from "wouter";
 
 import {
@@ -78,6 +76,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { HelpHint } from "@/components/ui/help-hint";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -106,7 +105,7 @@ import {
 } from "@/lib/gridfinity/worker-api";
 import type { ProjectLibraryItem } from "@/lib/project/persist";
 import { cn } from "@/lib/utils";
-import { PocketMeasurements, PocketSizeInputs, PositionInputs } from "./pocket-measurements";
+import { PocketDepthSummary, PocketMeasurements, PocketSizeInputs, PositionInputs } from "./pocket-measurements";
 import { ExportConfirmationDialog, ProjectBackupOption } from "./export-confirmation-dialog";
 import { useBin } from "@/state/bin-store";
 import { useShapeLibrary } from "@/state/shape-library";
@@ -151,64 +150,36 @@ function MaterialColorSwatch({
   );
 }
 
-function EditableShapeName({
-  shape,
-  onRename,
-}: {
+function EditableShapeName({ shape, onRename, onDone }: {
   shape: TracedShape;
   onRename: (name: string) => void;
+  onDone: () => void;
 }): JSX.Element {
   const [draft, setDraft] = useState(shape.name);
-  const [editing, setEditing] = useState(false);
-
-  useEffect(() => setDraft(shape.name), [shape.id, shape.name]);
-
   const commit = () => {
     const name = draft.trim();
-    if (name.length === 0) {
-      setDraft(shape.name);
-      setEditing(false);
-      return;
-    }
-    if (name !== shape.name) onRename(name);
-    setEditing(false);
+    if (name.length > 0 && name !== shape.name) onRename(name);
+    onDone();
   };
-
-  if (editing) {
-    return (
-      <Input
-        autoFocus
-        value={draft}
-        onChange={(event) => setDraft(event.target.value)}
-        onBlur={commit}
-        onKeyDown={(event) => {
-          if (event.key === "Enter") event.currentTarget.blur();
-          if (event.key === "Escape") {
-            setDraft(shape.name);
-            setEditing(false);
-          }
-        }}
-        className="h-8 font-medium"
-        aria-label="Tool shape name"
-        data-testid="input-shape-name"
-      />
-    );
-  }
-
   return (
-    <button
-      type="button"
-      className="group flex w-full min-w-0 items-center justify-between gap-2 rounded py-1 text-left text-sm font-medium hover:bg-violet-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      onClick={() => setEditing(true)}
-      aria-label={`Rename ${shape.name}`}
-      title="Click to rename"
-      data-testid="button-edit-shape-name"
-    >
-      <span className="truncate">{shape.name}</span>
-      <span className="flex shrink-0 items-center gap-1 text-[11px] font-normal text-muted-foreground">
-        <Pencil className="h-3 w-3" />Rename
-      </span>
-    </button>
+    <Input
+      autoFocus
+      value={draft}
+      onChange={(event) => setDraft(event.target.value)}
+      onFocus={(event) => event.currentTarget.select()}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") event.currentTarget.blur();
+        if (event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          onDone();
+        }
+      }}
+      className="h-8 min-w-0 flex-1 text-xs font-medium"
+      aria-label="Pocket name"
+      data-testid="input-shape-name"
+    />
   );
 }
 
@@ -334,21 +305,13 @@ export function BinControlsPanel({
   } = useBin();
   const [, navigate] = useLocation();
   const { shapes, storeShape } = useShapeLibrary();
-  const pocketPropertiesHeadingRef = useRef<HTMLDivElement>(null);
-  const revealPocketProperties = () => {
-    // Scroll only this panel, preserving the canvas and mobile drawer position.
-    const scroller = pocketPropertiesHeadingRef.current?.parentElement?.parentElement;
-    if (scroller) scroller.scrollTop = 0;
-  };
+  const [renamingPocketId, setRenamingPocketId] = useState<string | null>(null);
   useEffect(() => {
-    if (!selectedCutoutId) return;
-    const frame = requestAnimationFrame(revealPocketProperties);
-    return () => cancelAnimationFrame(frame);
-  }, [selectedCutoutId, pocketEditorRequest]);
-  const selectPocketProperties = (id: string) => {
-    dispatch({ type: "SELECT_CUTOUT", id });
-    requestAnimationFrame(revealPocketProperties);
-  };
+    if (!selectedCutoutId || renamingPocketId === selectedCutoutId) return;
+    // Selection brings the fixed Pockets section into view. Re-selecting the
+    // same canvas pocket increments the request so it is reachable from any section.
+    revealPanelSection("bin-settings-pockets", BIN_SETTINGS_SECTIONS, "pocket-properties");
+  }, [selectedCutoutId, pocketEditorRequest, renamingPocketId]);
   const shapesById = useMemo(
     () => new Map(shapes.map((shape) => [shape.id, shape])),
     [shapes],
@@ -504,276 +467,6 @@ export function BinControlsPanel({
         />
       </div>
       <PanelBody className="flex-1">
-        {selectedCutout && selectedShape && (
-          <div className="space-y-3 border-b bg-violet-500/[0.025] px-3 pb-4" id="pocket-properties" role="region" aria-label="Selected pocket properties" key={selectedCutout.id}>
-            <div ref={pocketPropertiesHeadingRef} className="sticky top-0 z-10 -mx-3 border-b border-violet-500/30 bg-background px-3 py-2" data-testid="pocket-properties-heading">
-              <div className="flex items-center justify-between gap-2">
-                <h3 className="text-[11px] font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">Pocket properties</h3>
-                <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={() => revealPanelSection("bin-settings-pockets", BIN_SETTINGS_SECTIONS)}>All pockets</Button>
-              </div>
-              <EditableShapeName key={selectedCutout.id} shape={selectedShape} onRename={(name) => storeShape({ ...selectedShape, name })} />
-            </div>
-            <PocketSizeInputs cutout={selectedCutout} shape={selectedShape} setScale={setPocketScale} />
-            <div className="flex items-center gap-2">
-              <Label className="w-16 shrink-0 text-xs">Depth</Label>
-              <Select
-                value={selectedCutout.depth.mode}
-                onValueChange={(mode) => {
-                  const resolved = resolvePocketDepth(spec, selectedCutout.depth);
-                  const depth =
-                    mode === "through"
-                      ? ({ mode: "through" } as const)
-                      : mode === "mm"
-                        ? ({ mode: "mm", value: Math.max(0.1, resolved.depthMm ?? resolved.infillTopZ - defaultPocketFloorThicknessMm(spec)) } as const)
-                        : ({ mode: "remaining", floorThicknessMm: spec.flatBottom ? defaultPocketFloorThicknessMm(spec) : Math.max(0, resolved.floorZ ?? defaultPocketFloorThicknessMm(spec)) } as const);
-                  dispatch({
-                    type: "UPDATE_CUTOUT",
-                    id: selectedCutout.id,
-                    patch: { depth },
-                    historyLabel: "Change pocket depth",
-                  });
-                }}
-              >
-                <SelectTrigger className="h-8 flex-1" aria-label="Pocket depth mode">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="remaining">Keep floor thickness</SelectItem>
-                  <SelectItem value="mm">Fixed depth</SelectItem>
-                  <SelectItem value="through">Through</SelectItem>
-                </SelectContent>
-              </Select>
-              {selectedCutout.depth.mode === "mm" && (
-                <DraftNumberInput
-                  className="h-8 w-20"
-                  aria-label="Pocket cut depth in millimetres"
-                  value={selectedCutout.depth.value}
-                  min={1}
-                  step={1}
-                  onValueChange={(value) =>
-                    dispatch({
-                      type: "UPDATE_CUTOUT",
-                      id: selectedCutout.id,
-                      patch: { depth: { mode: "mm", value } },
-                      historyLabel: "Change pocket depth",
-                    })
-                  }
-                />
-              )}
-            </div>
-
-            {spec.flatBottom && selectedCutout.depth.mode === "remaining" && (
-              <p className="text-[11px] text-muted-foreground">Measured from the flat underside. A 2 mm floor lets pockets extend into the former base area.</p>
-            )}
-            {selectedCutout.depth.mode === "remaining" && <MmSlider label="Remaining floor thickness" value={selectedCutout.depth.floorThicknessMm} min={0} max={Math.max(7, spec.heightUnits * 7)} step={0.5}
-              onChange={(floorThicknessMm, transient) => dispatch({ type: "UPDATE_CUTOUT", id: selectedCutout.id, patch: { depth: { mode: "remaining", floorThicknessMm } }, transient, historyLabel: "Change remaining floor" })} />}
-
-            <MmSlider
-              label="Extra pocket clearance"
-              value={selectedCutout.clearanceMm}
-              min={0}
-              max={2}
-              step={0.1}
-              onChange={(clearanceMm, transient) =>
-                dispatch({
-                  type: "UPDATE_CUTOUT",
-                  id: selectedCutout.id,
-                  patch: { clearanceMm },
-                  historyLabel: "Change pocket clearance",
-                  transient,
-                })
-              }
-              hint="Added after the Trace margin; new pockets start at 0 mm."
-            />
-
-            <Button
-              variant={editorMode === "contour" ? "default" : "outline"}
-              size="sm"
-              className="w-full"
-              data-testid="button-edit-contour"
-              onClick={() => {
-                const editing = editorMode === "contour";
-                dispatch({
-                  type: "SET_EDITOR_MODE",
-                  editorMode: editing ? "placement" : "contour",
-                });
-                if (!editing) {
-                  dispatch({ type: "SET_VIEW_MODE", viewMode: "2d" });
-                }
-              }}
-            >
-              <Spline className="mr-1.5 h-3.5 w-3.5" />
-              {editorMode === "contour" ? "Finish contour editing" : "Edit contour"}
-            </Button>
-            {editorMode === "contour" && (
-              <p className="rounded-md bg-violet-500/10 px-2.5 py-2 text-[11px] text-violet-800 dark:text-violet-200">
-                Drag points to reshape. Click an edge to add a point; right-click a
-                point to remove it.
-              </p>
-            )}
-
-            <PocketMeasurements cutout={selectedCutout} shape={selectedShape} section={section} inspect={onSectionChange} />
-            <details className="group/more text-xs" data-testid="pocket-more-settings">
-              <summary className="flex cursor-pointer list-none items-center justify-between py-1.5 font-medium [&::-webkit-details-marker]:hidden">
-                Rotation, scale &amp; rounding
-                <ChevronDown className="h-3.5 w-3.5 transition-transform group-open/more:rotate-180" />
-              </summary>
-              <div className="space-y-3 pt-2">
-                <div className="flex items-center gap-2">
-                  <Label className="w-16 shrink-0 text-xs">Rotation</Label>
-                  <DraftNumberInput
-                    className="h-8"
-                    value={Math.round(selectedCutout.rotationDeg * 10) / 10}
-                    step={15}
-                    normalize={(value) => ((value % 360) + 360) % 360}
-                    onValueChange={(rotationDeg) =>
-                      dispatch({
-                        type: "UPDATE_CUTOUT",
-                        id: selectedCutout.id,
-                        patch: { rotationDeg },
-                        historyLabel: "Rotate tool pocket",
-                      })
-                    }
-                  />
-                  <FeatureSwitch
-                    label="Mirror"
-                    description=""
-                    checked={selectedCutout.mirrored}
-                    onChange={(mirrored) =>
-                      dispatch({
-                        type: "UPDATE_CUTOUT",
-                        id: selectedCutout.id,
-                        patch: { mirrored },
-                        historyLabel: "Mirror tool pocket",
-                      })
-                    }
-                  />
-                </div>
-
-                <div className="space-y-1.5">
-                  <div className="flex items-center gap-2">
-                    <Label className="w-16 shrink-0 text-xs">Scale</Label>
-                    <div className="flex min-w-0 flex-1 items-center gap-1.5">
-                      <Label
-                        className="text-[11px] text-muted-foreground"
-                        htmlFor="pocket-scale-width"
-                      >
-                        W
-                      </Label>
-                      <DraftNumberInput
-                        id="pocket-scale-width"
-                        className="h-8 min-w-0"
-                        aria-label="Pocket width scale percent"
-                        data-testid="input-pocket-scale-x"
-                        value={Math.round(selectedCutout.scaleX * 1000) / 10}
-                        min={5}
-                        max={2000}
-                        step={1}
-                        onValueChange={(percent) => setPocketScale("x", percent)}
-                      />
-                      <span className="text-xs text-muted-foreground">%</span>
-                      <Label
-                        className="text-[11px] text-muted-foreground"
-                        htmlFor="pocket-scale-height"
-                      >
-                        H
-                      </Label>
-                      <DraftNumberInput
-                        id="pocket-scale-height"
-                        className="h-8 min-w-0"
-                        aria-label="Pocket height scale percent"
-                        data-testid="input-pocket-scale-y"
-                        value={Math.round(selectedCutout.scaleY * 1000) / 10}
-                        min={5}
-                        max={2000}
-                        step={1}
-                        onValueChange={(percent) => setPocketScale("y", percent)}
-                      />
-                      <span className="text-xs text-muted-foreground">%</span>
-
-                    </div>
-                  </div>
-                  <div className="ml-[4.5rem] flex items-start justify-between gap-2">
-                    <p className="text-[11px] leading-4 text-muted-foreground">
-                      Drag layout edges or corners. Keep proportions links width and length.
-                    </p>
-                    {(selectedCutout.scaleX !== 1 || selectedCutout.scaleY !== 1) && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 shrink-0 px-2 text-[11px]"
-                        onClick={() =>
-                          dispatch({
-                            type: "UPDATE_CUTOUT",
-                            id: selectedCutout.id,
-                            patch: { scaleX: 1, scaleY: 1 },
-                            historyLabel: "Reset tool pocket scale",
-                          })
-                        }
-                      >
-                        Reset 100%
-                      </Button>
-                    )}
-                  </div>
-                </div>
-
-                <MmSlider
-                  label="Outline corner round"
-                  value={selectedCutout.cornerRoundMm}
-                  min={0}
-                  max={3}
-                  step={0.5}
-                  onChange={(cornerRoundMm, transient) =>
-                    dispatch({
-                      type: "UPDATE_CUTOUT",
-                      id: selectedCutout.id,
-                      patch: { cornerRoundMm },
-                      historyLabel: "Change outline corner round",
-                      transient,
-                    })
-                  }
-                  hint="Rounds sharp corners in the pocket outline from top to bottom."
-                />
-                <MmSlider
-                  label="Top edge round"
-                  value={selectedCutout.topFilletMm}
-                  min={0}
-                  max={5}
-                  step={0.2}
-                  onChange={(topFilletMm, transient) =>
-                    dispatch({
-                      type: "UPDATE_CUTOUT",
-                      id: selectedCutout.id,
-                      patch: { topFilletMm },
-                      historyLabel: "Change top edge round",
-                      transient,
-                    })
-                  }
-                  hint="Rounds the pocket wall into the top surface of the bin."
-                />
-                <MmSlider
-                  label="Bottom fillet"
-                  value={selectedCutout.bottomFilletMm}
-                  min={0}
-                  max={4}
-                  step={0.2}
-                  onChange={(bottomFilletMm, transient) =>
-                    dispatch({
-                      type: "UPDATE_CUTOUT",
-                      id: selectedCutout.id,
-                      patch: { bottomFilletMm },
-                      historyLabel: "Change bottom fillet",
-                      transient,
-                    })
-                  }
-                  hint="Rounds the wall into the floor; the transition ends one radius above the floor."
-                />
-
-              </div>
-            </details>
-          </div>
-        )}
         <PanelSection
           id="bin-settings-project"
           title="Project"
@@ -1099,99 +792,292 @@ export function BinControlsPanel({
           defaultOpen={cutouts.length > 0}
           className="scroll-mt-16"
         >
-          {cutouts.length === 0 ? (
-            <p className="text-xs text-muted-foreground">
-              Trace a tool and press “Add to bin” — pockets land here and can
-              be moved and rotated in the Layout view.
+          {cutouts.length > 0 && (
+            <div className="space-y-1" aria-label="Choose a pocket to edit">
+              {cutouts.map((cutout) => {
+                const shape = shapesById.get(cutout.shapeId);
+                const isSelected = cutout.id === selectedCutoutId;
+                return (
+                  <div key={cutout.id} data-testid={`cutout-row-${cutout.id}`} className={cn(
+                    "flex items-center rounded-md border text-xs",
+                    isSelected ? "border-violet-500/50 bg-violet-500/10" : "border-transparent hover:bg-accent",
+                  )}>
+                    {renamingPocketId === cutout.id && shape ? (
+                      <EditableShapeName key={cutout.id} shape={shape} onRename={(name) => storeShape({ ...shape, name })} onDone={() => setRenamingPocketId(null)} />
+                    ) : (
+                    <button
+                      type="button"
+                      className="flex min-h-8 min-w-0 flex-1 items-center gap-2 rounded px-2 py-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      aria-label={`${shape?.name ?? "Missing shape"} — edit pocket properties`}
+                      aria-pressed={isSelected}
+                      aria-controls="pocket-properties"
+                      data-testid={`button-select-${cutout.id}`}
+                      onClick={() => {
+                        dispatch({ type: "SELECT_CUTOUT", id: cutout.id });
+                        if (isSelected) revealPanelSection("bin-settings-pockets", BIN_SETTINGS_SECTIONS, "pocket-properties");
+                      }}
+                    >
+                      <span className={cn("min-w-0 flex-1 truncate", isSelected && "font-medium text-violet-700 dark:text-violet-300")}>{shape?.name ?? "Missing shape"}</span>
+                    </button>
+                    )}
+                    <button type="button" className="flex h-8 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label={`Rename ${shape?.name ?? "pocket"}`} disabled={!shape} data-testid={`button-rename-${cutout.id}`} onClick={() => {
+                      dispatch({ type: "SELECT_CUTOUT", id: cutout.id });
+                      setRenamingPocketId(cutout.id);
+                    }}>
+                      <Pencil className="h-3.5 w-3.5" />
+                    </button>
+                    <button type="button" className="flex h-8 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label={`Duplicate ${shape?.name ?? "pocket"}`} data-testid={`button-duplicate-${cutout.id}`} onClick={() => dispatch({ type: "DUPLICATE_CUTOUT", id: cutout.id, newId: crypto.randomUUID() })}>
+                      <Copy className="h-3.5 w-3.5" />
+                    </button>
+                    <button type="button" className="flex h-8 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label={`Remove ${shape?.name ?? "pocket"}`} data-testid={`button-remove-${cutout.id}`} onClick={() => dispatch({ type: "REQUEST_REMOVE_CUTOUT", id: cutout.id })}>
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          {!selectedCutout && (
+            <p className="rounded-md border border-dashed px-3 py-4 text-xs text-muted-foreground" id="pocket-properties" data-testid="pocket-selection-help">
+              {cutouts.length === 0
+                ? "Trace a tool and press “Add to bin” to create a pocket."
+                : "Select a pocket on the canvas or in the list above. Its properties appear here."}
             </p>
-          ) : (
-            <>
-              <div
-                className="flex gap-2 rounded-md border border-violet-500/25 bg-violet-500/10 px-2.5 py-2 text-[11px] text-violet-900 dark:text-violet-100"
-                data-testid="pocket-selection-help"
-              >
-                <MousePointerClick className="mt-0.5 h-4 w-4 shrink-0" />
-                <p>
-                  Click a pocket in Layout or choose one below to edit its properties.
-                </p>
+          )}
+          {selectedCutout && selectedShape && (
+            <div className="space-y-3 rounded-md border border-violet-500/30 bg-violet-500/[0.025] p-2.5" id="pocket-properties" role="region" aria-label="Selected pocket properties">
+              <div className="flex min-w-0 items-center gap-2 border-b border-violet-500/20 pb-2" data-testid="pocket-properties-heading">
+                <h3 className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">Pocket properties</h3>
+                <span className="min-w-0 truncate text-xs font-medium" title={selectedShape.name}>{selectedShape.name}</span>
               </div>
+              <section className="space-y-2" aria-label="Pocket depth" key={selectedCutout.id}>
+                <div className="flex items-center gap-1">
+                  <h4 className="text-sm font-semibold">Depth</h4>
+                  {spec.flatBottom && selectedCutout.depth.mode === "remaining" && <HelpHint label="remaining floor thickness">Measured from the flat underside. A 2 mm floor lets pockets extend into the former base area.</HelpHint>}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Select
+                    value={selectedCutout.depth.mode}
+                    onValueChange={(mode) => {
+                      const resolved = resolvePocketDepth(spec, selectedCutout.depth);
+                      const depth =
+                        mode === "through"
+                          ? ({ mode: "through" } as const)
+                          : mode === "mm"
+                            ? ({ mode: "mm", value: Math.max(0.1, resolved.depthMm ?? resolved.infillTopZ - defaultPocketFloorThicknessMm(spec)) } as const)
+                            : ({ mode: "remaining", floorThicknessMm: spec.flatBottom ? defaultPocketFloorThicknessMm(spec) : Math.max(0, resolved.floorZ ?? defaultPocketFloorThicknessMm(spec)) } as const);
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { depth },
+                        historyLabel: "Change pocket depth",
+                      });
+                    }}
+                  >
+                    <SelectTrigger className="h-9 flex-1" aria-label="Pocket depth mode">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="remaining">Keep floor thickness</SelectItem>
+                      <SelectItem value="mm">Fixed depth</SelectItem>
+                      <SelectItem value="through">Through</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  {selectedCutout.depth.mode === "mm" && (
+                    <DraftNumberInput
+                      className="h-9 w-20 text-base font-semibold"
+                      aria-label="Pocket cut depth in millimetres"
+                      value={selectedCutout.depth.value}
+                      min={1}
+                      step={1}
+                      onValueChange={(value) =>
+                        dispatch({
+                          type: "UPDATE_CUTOUT",
+                          id: selectedCutout.id,
+                          patch: { depth: { mode: "mm", value } },
+                          historyLabel: "Change pocket depth",
+                        })
+                      }
+                    />
+                  )}
+                </div>
+
+                {selectedCutout.depth.mode === "remaining" && <MmSlider label="Remaining floor thickness" value={selectedCutout.depth.floorThicknessMm} min={0} max={Math.max(7, spec.heightUnits * 7)} step={0.5}
+                  onChange={(floorThicknessMm, transient) => dispatch({ type: "UPDATE_CUTOUT", id: selectedCutout.id, patch: { depth: { mode: "remaining", floorThicknessMm } }, transient, historyLabel: "Change remaining floor" })} />}
+
+                <PocketDepthSummary cutout={selectedCutout} shape={selectedShape} section={section} inspect={onSectionChange} />
+              </section>
+              <details className="group/size border-t pt-1 text-xs" aria-label="Pocket size and scale" data-testid="pocket-size-settings">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2 font-medium [&::-webkit-details-marker]:hidden">
+                  Size &amp; scale
+                  <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/size:rotate-180" />
+                </summary>
+                <div className="pb-2" key={selectedCutout.id}><PocketSizeInputs cutout={selectedCutout} shape={selectedShape} setScale={setPocketScale} /></div>
+              </details>
+
+              <details className="group/clearance border-t pt-1 text-xs" data-testid="pocket-clearance-settings">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2 font-medium [&::-webkit-details-marker]:hidden">
+                  Extra pocket clearance
+                  <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/clearance:rotate-180" />
+                </summary>
+                <div className="space-y-2 pb-2" key={selectedCutout.id}>
+                  <MmSlider
+                    label="Extra pocket clearance"
+                    value={selectedCutout.clearanceMm}
+                    min={0}
+                    max={2}
+                    step={0.1}
+                    onChange={(clearanceMm, transient) =>
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { clearanceMm },
+                        historyLabel: "Change pocket clearance",
+                        transient,
+                      })
+                    }
+                    hintAsTooltip
+                    hint={<>
+                      Added after the Trace margin; new pockets start at 0 mm.
+                      <span className="mt-1 block">{selectedShape.traceMarginMm === undefined
+                        ? `Original trace margin unknown (older project). Extra allowance: ${selectedCutout.clearanceMm.toFixed(2)} mm per edge.`
+                        : `Trace margin: ${selectedShape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(selectedShape.traceMarginMm * selectedCutout.scaleX + selectedCutout.clearanceMm).toFixed(2)} / ${(selectedShape.traceMarginMm * selectedCutout.scaleY + selectedCutout.clearanceMm).toFixed(2)} mm per edge.`}</span>
+                    </>}
+                  />
+                </div>
+              </details>
+
+              <details className="group/more border-t pt-1 text-xs" data-testid="pocket-edge-settings">
+                <summary className="flex cursor-pointer list-none items-center justify-between py-1.5 font-medium [&::-webkit-details-marker]:hidden">
+                  <span className="flex items-center gap-1">Edges &amp; corners <HelpHint label="edges and corners">Soften sharp corners and edges. Values are rounding radii in millimetres; 0 keeps an edge sharp.</HelpHint></span>
+                  <ChevronDown className="h-3.5 w-3.5 transition-transform group-open/more:rotate-180" />
+                </summary>
+                <div className="space-y-3 pt-2" key={selectedCutout.id}>
+                  <MmSlider
+                    label="Outline corners"
+                    value={selectedCutout.cornerRoundMm}
+                    min={0}
+                    max={3}
+                    step={0.5}
+                    onChange={(cornerRoundMm, transient) =>
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { cornerRoundMm },
+                        historyLabel: "Change outline corner round",
+                        transient,
+                      })
+                    }
+                    hintAsTooltip
+                    hint="Rounds sharp corners in the pocket outline from top to bottom."
+                  />
+                  <MmSlider
+                    label="Top edge"
+                    value={selectedCutout.topFilletMm}
+                    min={0}
+                    max={5}
+                    step={0.2}
+                    onChange={(topFilletMm, transient) =>
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { topFilletMm },
+                        historyLabel: "Change top edge round",
+                        transient,
+                      })
+                    }
+                    hintAsTooltip
+                    hint="Rounds the pocket wall into the top surface of the bin."
+                  />
+                  <MmSlider
+                    label="Bottom edge"
+                    value={selectedCutout.bottomFilletMm}
+                    min={0}
+                    max={4}
+                    step={0.2}
+                    onChange={(bottomFilletMm, transient) =>
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { bottomFilletMm },
+                        historyLabel: "Change bottom fillet",
+                        transient,
+                      })
+                    }
+                    hintAsTooltip
+                    hint="Rounds the wall into the floor; the transition ends one radius above the floor."
+                  />
+
+                </div>
+              </details>
+              <PocketMeasurements cutout={selectedCutout} shape={selectedShape}>
+                <div className="flex items-center gap-2">
+                  <Label className="w-16 shrink-0 text-xs">Rotation</Label>
+                  <DraftNumberInput
+                    className="h-8"
+                    aria-label="Pocket rotation in degrees"
+                    value={Math.round(selectedCutout.rotationDeg * 10) / 10}
+                    step={15}
+                    normalize={(value) => ((value % 360) + 360) % 360}
+                    onValueChange={(rotationDeg) =>
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { rotationDeg },
+                        historyLabel: "Rotate tool pocket",
+                      })
+                    }
+                  />
+                  <FeatureSwitch
+                    label="Mirror"
+                    description=""
+                    checked={selectedCutout.mirrored}
+                    onChange={(mirrored) =>
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { mirrored },
+                        historyLabel: "Mirror tool pocket",
+                      })
+                    }
+                  />
+                </div>
+
+              </PocketMeasurements>
               <Button
-                variant="outline"
+                variant={editorMode === "contour" ? "default" : "outline"}
                 size="sm"
                 className="w-full"
-                onClick={onAutoArrange}
-                data-testid="button-auto-arrange"
+                data-testid="button-edit-contour"
+                onClick={() => {
+                  const editing = editorMode === "contour";
+                  dispatch({
+                    type: "SET_EDITOR_MODE",
+                    editorMode: editing ? "placement" : "contour",
+                  });
+                  if (!editing) {
+                    dispatch({ type: "SET_VIEW_MODE", viewMode: "2d" });
+                  }
+                }}
               >
-                <LayoutGrid className="mr-1.5 h-3.5 w-3.5" />
-                Auto-arrange
+                <Spline className="mr-1.5 h-3.5 w-3.5" />
+                {editorMode === "contour" ? "Finish contour editing" : "Edit contour"}
               </Button>
-              <div className="space-y-2" aria-label="Choose a pocket to edit">
-                {cutouts.map((cutout) => {
-                  const shape = shapesById.get(cutout.shapeId);
-                  const isSelected = cutout.id === selectedCutoutId;
-                  return (
-                    <div
-                      key={cutout.id}
-                      className={cn(
-                        "flex items-center rounded-md border text-xs transition-colors",
-                        isSelected
-                          ? "border-violet-500 bg-violet-500/10 ring-1 ring-violet-500/30"
-                          : "border-input bg-background hover:border-violet-400 hover:bg-violet-500/5",
-                      )}
-                      data-testid={`cutout-row-${cutout.id}`}
-                    >
-                      <button
-                        type="button"
-                        className="flex min-h-12 min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2"
-                        aria-label={`${shape?.name ?? "Missing shape"} — edit pocket properties`}
-                        aria-pressed={isSelected}
-                        aria-controls={selectedCutoutId ? "pocket-properties" : undefined}
-                        onClick={() => selectPocketProperties(cutout.id)}
-                        data-testid={`button-select-${cutout.id}`}
-                      >
-                        <SlidersHorizontal className="h-4 w-4 shrink-0 text-violet-600 dark:text-violet-300" />
-                        <span className="min-w-0 flex-1">
-                          <span className="block truncate font-medium">{shape?.name ?? "Missing shape"}</span>
-                          <span className={cn("mt-0.5 block text-[11px]", isSelected ? "font-medium text-violet-700 dark:text-violet-300" : "text-muted-foreground")}>
-                            {isSelected ? "Editing this pocket" : "Edit properties"}
-                          </span>
-                        </span>
-                        {isSelected ? <ChevronDown className="h-4 w-4 shrink-0 text-violet-600 dark:text-violet-300" /> : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
-                      </button>
-                      <button
-                        type="button"
-                        className="flex h-8 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        aria-label="Duplicate pocket"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          dispatch({
-                            type: "DUPLICATE_CUTOUT",
-                            id: cutout.id,
-                            newId: crypto.randomUUID(),
-                          });
-                        }}
-                        data-testid={`button-duplicate-${cutout.id}`}
-                      >
-                        <Copy className="h-3.5 w-3.5" />
-                      </button>
-                      <button
-                        type="button"
-                        className="mr-1 flex h-8 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        aria-label="Remove pocket"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          dispatch({ type: "REQUEST_REMOVE_CUTOUT", id: cutout.id });
-                        }}
-                        data-testid={`button-remove-${cutout.id}`}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
-                  );
-                })}
-              </div>
-            </>
+              {editorMode === "contour" && (
+                <p className="rounded-md bg-violet-500/10 px-2.5 py-2 text-[11px] text-violet-800 dark:text-violet-200">
+                  Drag points to reshape. Click an edge to add a point; right-click a
+                  point to remove it.
+                </p>
+              )}
+
+            </div>
           )}
+
+          <div className="flex flex-wrap gap-2 border-t pt-3">
+            <Button variant="outline" size="sm" onClick={onAutoArrange} disabled={cutouts.length === 0} data-testid="button-auto-arrange">
+              <LayoutGrid className="mr-1.5 h-3.5 w-3.5" />Auto-arrange
+            </Button>
+          </div>
 
         </PanelSection>
 
@@ -2576,6 +2462,7 @@ function MmSlider({
   max,
   step,
   hint,
+  hintAsTooltip = false,
   onChange,
 }: {
   label: string;
@@ -2583,14 +2470,18 @@ function MmSlider({
   min: number;
   max: number;
   step: number;
-  hint?: string;
+  hint?: ReactNode;
+  hintAsTooltip?: boolean;
   onChange: (value: number, transient: boolean) => void;
 }): JSX.Element {
   const decimalPlaces = Math.max(0, (String(step).split(".")[1] ?? "").length);
   return (
     <div className="space-y-1.5">
       <div className="flex items-baseline justify-between">
-        <Label className="text-xs">{label}</Label>
+        <div className="flex items-center gap-1">
+          <Label className="text-xs">{label}</Label>
+          {hint && hintAsTooltip && <HelpHint label={label.toLowerCase()}>{hint}</HelpHint>}
+        </div>
         <span className="text-xs tabular-nums text-muted-foreground">
           <DraftNumberInput className="inline-block h-8 w-20" aria-label={`${label} in millimetres`} value={value} displayPrecision={2} min={min} max={max} step={step} onValueChange={(next) => onChange(next, true)} onValueCommit={(next) => onChange(next, false)} /> mm
         </span>
@@ -2608,7 +2499,7 @@ function MmSlider({
         step={step}
         aria-label={label}
       />
-      {hint && <p className="text-[11px] text-muted-foreground">{hint}</p>}
+      {hint && !hintAsTooltip && <p className="text-[11px] text-muted-foreground">{hint}</p>}
     </div>
   );
 }

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -48,7 +48,7 @@ import {
   type GridPitch,
 } from "@shared/gridfinity/standard";
 import { MAX_GRID, type BinSpecInput } from "@shared/gridfinity/types";
-import { validateBinSpec, validateLayout, validatePocketFloorMaterials, type ValidationIssue } from "@shared/gridfinity/validate";
+import type { ValidationIssue } from "@shared/gridfinity/validate";
 
 import {
   PanelBody,
@@ -225,6 +225,9 @@ const BIN_SETTINGS_SECTIONS = [
 ] as const;
 
 export interface BinControlsPanelProps {
+  issues: readonly ValidationIssue[];
+  /** A fresh request reveals settings after the controls drawer mounts. */
+  settingsSectionRequest?: { id: string };
   /** Changes when the canvas explicitly requests the selected pocket editor. */
   pocketEditorRequest?: number;
   keepBinSize?: boolean;
@@ -275,6 +278,8 @@ export interface BinControlsPanelProps {
  * hook.
  */
 export function BinControlsPanel({
+  issues,
+  settingsSectionRequest,
   stats,
   building,
   exporting,
@@ -352,34 +357,10 @@ export function BinControlsPanel({
   const dims = useMemo(() => binDimensionsMm(spec), [spec]);
   const widthCellSpan = standardCellSpan(spec.gridX, spec.gridPitch);
   const lengthCellSpan = standardCellSpan(spec.gridY, spec.gridPitch);
-  const floorMaterialIssues = useMemo(
-    () => validatePocketFloorMaterials(spec, cutouts, shapesById, colorPocketFloors ? pocketFloorThicknessMm : 0),
-    [spec, cutouts, shapesById, colorPocketFloors, pocketFloorThicknessMm],
-  );
-  const issues = useMemo(
-    () => [
-      ...validateBinSpec(spec).issues,
-      ...validateLayout(spec, cutouts, shapesById, fingerHoles),
-      ...floorMaterialIssues,
-    ],
-    [spec, cutouts, shapesById, fingerHoles, floorMaterialIssues],
-  );
-  const revealIssue = (issue: ValidationIssue) => {
-    dispatch({ type: "SET_VIEW_MODE", viewMode: "2d" });
-    if (issue.cutoutIds?.length) {
-      const next = issue.cutoutIds.find((id) => id !== selectedCutoutId) ?? issue.cutoutIds[0];
-      dispatch({ type: "SELECT_CUTOUT", id: next });
-      requestAnimationFrame(revealPocketProperties);
-    } else if (issue.fingerHoleIds?.length) {
-      dispatch({ type: "SELECT_FINGER_HOLE", id: issue.fingerHoleIds[0] });
-      revealPanelSection("bin-settings-finger-holes", BIN_SETTINGS_SECTIONS);
-    } else revealPanelSection("bin-settings-size", BIN_SETTINGS_SECTIONS);
-  };
-  const issueButton = (issue: ValidationIssue, index: number) => <button type="button" key={`${issue.code}-${index}`} data-issue-code={issue.code} onClick={() => revealIssue(issue)}
-    className={`block w-full rounded border px-2 py-1.5 text-left text-xs hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring ${issue.code === "cutout-overlap" ? "border-orange-500/40 text-orange-700 dark:text-orange-300" : issue.severity === "error" ? "border-destructive/40 text-destructive" : "border-amber-500/40 text-amber-700 dark:text-amber-300"}`}>
-    {issue.message} <span className="underline">Show {issue.cutoutIds?.length === 2 ? "pockets (click to switch)" : "location"}</span>
-  </button>;
-  const selectedIssues = issues.filter((issue) => (selectedCutoutId && issue.cutoutIds?.includes(selectedCutoutId)) || (selectedFingerHoleId && issue.fingerHoleIds?.includes(selectedFingerHoleId)));
+  const hasFloorMaterialWarning = issues.some((issue) => issue.code === "floor-color-on-underside");
+  useEffect(() => {
+    if (settingsSectionRequest) revealPanelSection(settingsSectionRequest.id, BIN_SETTINGS_SECTIONS);
+  }, [settingsSectionRequest]);
   const hasErrors = issues.some((issue) => issue.severity === "error");
   const enabledFeatureCount = [
     spec.lip === "standard",
@@ -522,7 +503,6 @@ export function BinControlsPanel({
           items={BIN_SETTINGS_SECTIONS}
         />
       </div>
-      {selectedIssues.length > 0 && <div className="max-h-32 shrink-0 space-y-1 overflow-y-auto border-b p-2" data-testid="selected-object-issues" aria-label="Issues for selected object">{selectedIssues.map(issueButton)}</div>}
       <PanelBody className="flex-1">
         {selectedCutout && selectedShape && (
           <div className="space-y-3 border-b bg-violet-500/[0.025] px-3 pb-4" id="pocket-properties" role="region" aria-label="Selected pocket properties" key={selectedCutout.id}>
@@ -1692,11 +1672,7 @@ export function BinControlsPanel({
                 <span className="text-[11px] text-muted-foreground">mm down</span>
               </div>
             </div>
-            {floorMaterialIssues.length > 0 && (
-              <div className="space-y-1" role="status" aria-label="Pocket floor color warnings">
-                {floorMaterialIssues.map(issueButton)}
-              </div>
-            )}
+
           </div>
           <div
             className="space-y-2 rounded-md border bg-background/60 px-2.5 py-2"
@@ -2048,7 +2024,6 @@ export function BinControlsPanel({
               </p>
             </div>
           ) : null}
-          <div className="space-y-1.5">{issues.map(issueButton)}</div>
 
           <p className="text-xs text-muted-foreground">
             You can include an editable project JSON when downloading a model or
@@ -2157,10 +2132,10 @@ export function BinControlsPanel({
               selected in Materials.
             </DialogDescription>
           </DialogHeader>
-          {floorMaterialIssues.length > 0 && (
+          {hasFloorMaterialWarning && (
             <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 text-xs text-amber-900 dark:text-amber-100" role="status" data-testid="export-floor-color-warning">
               <p className="font-medium">Floor color may show on the underside.</p>
-              <p className="mt-1">Review the pocket warnings in Materials before exporting multiple colors. A shallower pocket or thinner color layer can keep the color inside the bin.</p>
+              <p className="mt-1">Review the warnings on the canvas before exporting multiple colors. A shallower pocket or thinner color layer can keep the color inside the bin.</p>
             </div>
           )}
           <ProjectBackupOption checked={includeThreeMfProject} onChange={setIncludeThreeMfProject} />

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -1031,7 +1031,14 @@ export function BinControlsPanel({
               </PocketMeasurements>
               <details className="group/clearance border-t pt-1 text-xs" data-testid="pocket-clearance-settings">
                 <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2 font-medium [&::-webkit-details-marker]:hidden">
-                  Extra pocket clearance
+                  <span className="flex items-center gap-1">Extra pocket clearance
+                    <HelpHint label="extra pocket clearance">
+                      Adjusts each edge after the Trace margin and scaling. Negative values shrink the pocket to reduce excess padding; positive values enlarge it. Zero keeps the traced size. Narrow features can disappear when shrunk.
+                      <span className="mt-1 block">{selectedShape.traceMarginMm === undefined
+                        ? `Original trace margin unknown (older project). Extra allowance: ${selectedCutout.clearanceMm.toFixed(2)} mm per edge.`
+                        : `Trace margin: ${selectedShape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(selectedShape.traceMarginMm * selectedCutout.scaleX + selectedCutout.clearanceMm).toFixed(2)} / ${(selectedShape.traceMarginMm * selectedCutout.scaleY + selectedCutout.clearanceMm).toFixed(2)} mm per edge.`}</span>
+                    </HelpHint>
+                  </span>
                   <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/clearance:rotate-180" />
                 </summary>
                 <div className="space-y-2 pb-2" key={selectedCutout.id}>
@@ -1039,6 +1046,7 @@ export function BinControlsPanel({
                     label="Extra pocket clearance"
                     value={selectedCutout.clearanceMm}
                     centered
+                    inline
                     min={-2}
                     max={2}
                     step={0.1}
@@ -1051,13 +1059,6 @@ export function BinControlsPanel({
                         transient,
                       })
                     }
-                    hintAsTooltip
-                    hint={<>
-                      Adjusts each edge after the Trace margin and scaling. Negative values shrink the pocket to reduce excess padding; positive values enlarge it. Zero keeps the traced size. Narrow features can disappear when shrunk.
-                      <span className="mt-1 block">{selectedShape.traceMarginMm === undefined
-                        ? `Original trace margin unknown (older project). Extra allowance: ${selectedCutout.clearanceMm.toFixed(2)} mm per edge.`
-                        : `Trace margin: ${selectedShape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(selectedShape.traceMarginMm * selectedCutout.scaleX + selectedCutout.clearanceMm).toFixed(2)} / ${(selectedShape.traceMarginMm * selectedCutout.scaleY + selectedCutout.clearanceMm).toFixed(2)} mm per edge.`}</span>
-                    </>}
                   />
                 </div>
               </details>
@@ -2391,6 +2392,7 @@ function MmSlider({
   hint,
   hintAsTooltip = true,
   centered = false,
+  inline = false,
   onChange,
 }: {
   label: string;
@@ -2401,35 +2403,39 @@ function MmSlider({
   hint?: ReactNode;
   hintAsTooltip?: boolean;
   centered?: boolean;
+  /** The enclosing section supplies the visible label; show slider and number together. */
+  inline?: boolean;
   onChange: (value: number, transient: boolean) => void;
 }): JSX.Element {
   const decimalPlaces = Math.max(0, (String(step).split(".")[1] ?? "").length);
   return (
-    <div className="space-y-1.5">
-      <div className="flex items-baseline justify-between gap-2">
-        <div className="flex items-center gap-1">
+    <div className={cn("space-y-1.5", inline && "grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 space-y-0")}>
+      <div className={cn("flex items-baseline justify-between gap-2", inline && "col-start-2 row-start-1")}>
+        {!inline && <div className="flex items-center gap-1">
           <Label className="text-xs">{label}</Label>
           {hint && hintAsTooltip && <HelpHint label={label.toLowerCase()}>{hint}</HelpHint>}
-        </div>
+        </div>}
         <span className="shrink-0 whitespace-nowrap text-xs tabular-nums text-muted-foreground">
           <DraftNumberInput className="inline-block h-8 w-16" aria-label={`${label} in millimetres`} value={value} displayPrecision={2} min={min} max={max} step={step} onValueChange={(next) => onChange(next, true)} onValueCommit={(next) => onChange(next, false)} /> mm
         </span>
       </div>
-      <Slider
-        centerOrigin={centered}
-        value={[value]}
-        onValueChange={([next]) =>
-          onChange(Number(next.toFixed(decimalPlaces)), true)
-        }
-        onValueCommit={([next]) =>
-          onChange(Number(next.toFixed(decimalPlaces)), false)
-        }
-        min={min}
-        max={max}
-        step={step}
-        aria-label={label}
-      />
-      {centered && <div className="relative flex justify-between text-[10px] tabular-nums text-muted-foreground" aria-hidden="true"><span>{min} · Shrink</span><span className="absolute left-1/2 -translate-x-1/2">0</span><span>Enlarge · +{max}</span></div>}
+      <div className={cn("space-y-1.5", inline && "col-start-1 row-start-1 pt-3")}>
+        <Slider
+          centerOrigin={centered}
+          value={[value]}
+          onValueChange={([next]) =>
+            onChange(Number(next.toFixed(decimalPlaces)), true)
+          }
+          onValueCommit={([next]) =>
+            onChange(Number(next.toFixed(decimalPlaces)), false)
+          }
+          min={min}
+          max={max}
+          step={step}
+          aria-label={label}
+        />
+        {centered && <div className="relative flex justify-between text-[10px] tabular-nums text-muted-foreground" aria-hidden="true"><span>{min} · Shrink</span><span className="absolute left-1/2 -translate-x-1/2">0</span><span>Enlarge · +{max}</span></div>}
+      </div>
       {hint && !hintAsTooltip && <p className="text-[11px] text-muted-foreground">{hint}</p>}
     </div>
   );

--- a/client/src/components/gridfinity/canvas-warnings.tsx
+++ b/client/src/components/gridfinity/canvas-warnings.tsx
@@ -1,7 +1,6 @@
 import { AlertTriangle, ChevronDown, CircleAlert } from "lucide-react";
 import { useState } from "react";
 
-import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 import type { ValidationIssue } from "@shared/gridfinity/validate";
 
@@ -12,9 +11,7 @@ export function CanvasWarnings({ issues, selectedCutoutId, selectedFingerHoleId,
   selectedFingerHoleId: string | null;
   onRevealIssue: (issue: ValidationIssue) => void;
 }): JSX.Element | null {
-  const isMobile = useIsMobile();
-  const [expandedOverride, setExpandedOverride] = useState<boolean | null>(null);
-  const expanded = expandedOverride ?? !isMobile;
+  const [expanded, setExpanded] = useState(false);
   if (issues.length === 0) return null;
 
   const errors = issues.filter((issue) => issue.severity === "error").length;
@@ -31,8 +28,8 @@ export function CanvasWarnings({ issues, selectedCutoutId, selectedFingerHoleId,
     <section
       className={cn(
         "absolute bottom-12 right-3 z-30 flex max-h-[min(50%,22rem)] max-w-[calc(100%_-_1.5rem)] flex-col overflow-hidden rounded-lg border bg-background/95 shadow-md backdrop-blur",
-        expanded ? "w-80" : "w-auto",
-        errors > 0 ? "border-destructive/40" : "border-amber-500/40",
+        expanded ? "w-80" : "w-auto motion-safe:animate-warning-attention",
+        errors > 0 ? "border-destructive/40 [--warning-pulse-color:239_68_68]" : "border-amber-500/40 [--warning-pulse-color:245_158_11]",
       )}
       aria-label="Model warnings and errors"
       data-testid="canvas-warnings"
@@ -43,11 +40,11 @@ export function CanvasWarnings({ issues, selectedCutoutId, selectedFingerHoleId,
         aria-label={`${expanded ? "Collapse" : "Expand"} ${summary}`}
         aria-expanded={expanded}
         aria-controls="canvas-warning-list"
-        onClick={() => setExpandedOverride(!expanded)}
+        onClick={() => setExpanded(!expanded)}
       >
         {errors > 0 ? <CircleAlert className="h-4 w-4 shrink-0 text-destructive" /> : <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />}
         <span className="flex-1" role="status" aria-live="polite" aria-atomic="true">{summary}</span>
-        <ChevronDown className={cn("h-3.5 w-3.5 shrink-0 transition-transform", expanded && "rotate-180")} />
+        <ChevronDown className={cn("h-3.5 w-3.5 shrink-0 transition-transform motion-reduce:transition-none", !expanded && "rotate-180")} />
       </button>
       {expanded && (
         <div id="canvas-warning-list" className="min-h-0 space-y-1 overflow-y-auto overscroll-contain border-t p-2">

--- a/client/src/components/gridfinity/canvas-warnings.tsx
+++ b/client/src/components/gridfinity/canvas-warnings.tsx
@@ -1,0 +1,83 @@
+import { AlertTriangle, ChevronDown, CircleAlert } from "lucide-react";
+import { useState } from "react";
+
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+import type { ValidationIssue } from "@shared/gridfinity/validate";
+
+/** Persistent model feedback shared by Layout and 3D, separate from property fields. */
+export function CanvasWarnings({ issues, selectedCutoutId, selectedFingerHoleId, onRevealIssue }: {
+  issues: readonly ValidationIssue[];
+  selectedCutoutId: string | null;
+  selectedFingerHoleId: string | null;
+  onRevealIssue: (issue: ValidationIssue) => void;
+}): JSX.Element | null {
+  const isMobile = useIsMobile();
+  const [expandedOverride, setExpandedOverride] = useState<boolean | null>(null);
+  const expanded = expandedOverride ?? !isMobile;
+  if (issues.length === 0) return null;
+
+  const errors = issues.filter((issue) => issue.severity === "error").length;
+  const warnings = issues.length - errors;
+  const summary = [
+    errors > 0 ? `${errors} ${errors === 1 ? "error" : "errors"}` : null,
+    warnings > 0 ? `${warnings} ${warnings === 1 ? "warning" : "warnings"}` : null,
+  ].filter(Boolean).join(" · ");
+  // Keep a stable order while selecting and cycling through overlapping pockets.
+  const orderedIssues = [...issues].sort((a, b) => Number(b.severity === "error") - Number(a.severity === "error"));
+
+  return (
+    // Leave the canvas gesture hint visible beneath the warning panel.
+    <section
+      className={cn(
+        "absolute bottom-12 right-3 z-30 flex max-h-[min(50%,22rem)] max-w-[calc(100%_-_1.5rem)] flex-col overflow-hidden rounded-lg border bg-background/95 shadow-md backdrop-blur",
+        expanded ? "w-80" : "w-auto",
+        errors > 0 ? "border-destructive/40" : "border-amber-500/40",
+      )}
+      aria-label="Model warnings and errors"
+      data-testid="canvas-warnings"
+    >
+      <button
+        type="button"
+        className="flex min-h-10 shrink-0 items-center gap-2 px-3 py-2 text-left text-xs font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        aria-label={`${expanded ? "Collapse" : "Expand"} ${summary}`}
+        aria-expanded={expanded}
+        aria-controls="canvas-warning-list"
+        onClick={() => setExpandedOverride(!expanded)}
+      >
+        {errors > 0 ? <CircleAlert className="h-4 w-4 shrink-0 text-destructive" /> : <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />}
+        <span className="flex-1" role="status" aria-live="polite" aria-atomic="true">{summary}</span>
+        <ChevronDown className={cn("h-3.5 w-3.5 shrink-0 transition-transform", expanded && "rotate-180")} />
+      </button>
+      {expanded && (
+        <div id="canvas-warning-list" className="min-h-0 space-y-1 overflow-y-auto overscroll-contain border-t p-2">
+          {orderedIssues.map((issue, index) => {
+            const selected = Boolean(
+              (selectedCutoutId && issue.cutoutIds?.includes(selectedCutoutId)) ||
+              (selectedFingerHoleId && issue.fingerHoleIds?.includes(selectedFingerHoleId)),
+            );
+            return (
+              <button
+                type="button"
+                key={`${issue.code}-${issue.cutoutIds?.join(",") ?? issue.fingerHoleIds?.join(",") ?? index}`}
+                data-issue-code={issue.code}
+                data-selected={selected || undefined}
+                onClick={() => onRevealIssue(issue)}
+                className={cn(
+                  "block w-full rounded-md border px-2.5 py-2 text-left text-xs leading-relaxed hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  issue.severity === "error" ? "border-destructive/30 text-destructive" : "border-amber-500/25 text-amber-900 dark:text-amber-100",
+                  selected && "bg-accent/60",
+                )}
+              >
+                <span className="block">{issue.message}</span>
+                <span className="mt-1 block font-medium underline underline-offset-2">
+                  {issue.cutoutIds?.length ? issue.cutoutIds.length > 1 ? "Show pockets · click to switch" : "Edit pocket" : issue.fingerHoleIds?.length ? "Edit finger access" : "Open bin settings"}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/components/gridfinity/layout-canvas.tsx
+++ b/client/src/components/gridfinity/layout-canvas.tsx
@@ -1625,25 +1625,6 @@ function LayoutStage({ onEditPocket }: { onEditPocket?: () => void }): JSX.Eleme
         </div>
       ) : null}
 
-      {selected && (editorMode === "placement" || editorMode === "contour") && (
-        <div className="absolute left-3 top-12 z-30 flex max-w-[calc(100%_-_5rem)] flex-wrap gap-2">
-          <Button
-            className="h-8 shadow-sm"
-            variant={editorMode === "contour" ? "default" : "outline"}
-            size="sm"
-            data-testid="button-layout-edit-contour"
-            onClick={() => {
-              setRulerActive(false);
-              setMeasurementPoints([]);
-              dispatch({ type: "SET_EDITOR_MODE", editorMode: editorMode === "contour" ? "placement" : "contour" });
-            }}
-          >
-            <Spline className="h-4 w-4" />
-            {editorMode === "contour" ? "Finish contour editing" : "Edit Contour"}
-          </Button>
-        </div>
-      )}
-
       <div
         className="absolute right-3 top-12 z-30 flex flex-col overflow-hidden rounded-md border bg-background/90 shadow-sm backdrop-blur"
         data-testid="layout-tool-toolbar"
@@ -1681,6 +1662,24 @@ function LayoutStage({ onEditPocket }: { onEditPocket?: () => void }): JSX.Eleme
         >
           <Ruler className="h-4 w-4" />
         </Button>
+        {selected && (editorMode === "placement" || editorMode === "contour") && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn("h-9 w-9 rounded-none border-t", editorMode === "contour" && "bg-accent text-accent-foreground")}
+            aria-label={editorMode === "contour" ? "Finish contour editing" : "Edit contour"}
+            aria-pressed={editorMode === "contour"}
+            title={editorMode === "contour" ? "Finish contour editing" : "Edit contour"}
+            data-testid="button-layout-edit-contour"
+            onClick={() => {
+              setRulerActive(false);
+              setMeasurementPoints([]);
+              dispatch({ type: "SET_EDITOR_MODE", editorMode: editorMode === "contour" ? "placement" : "contour" });
+            }}
+          >
+            <Spline className="h-4 w-4" />
+          </Button>
+        )}
         {measurementPoints.length > 0 ? (
           <Button
             variant="ghost"

--- a/client/src/components/gridfinity/layout-canvas.tsx
+++ b/client/src/components/gridfinity/layout-canvas.tsx
@@ -1,6 +1,5 @@
 import {
   Ruler,
-  SlidersHorizontal,
   Spline,
   X,
 } from "lucide-react";
@@ -998,7 +997,7 @@ function LayoutStage({ onEditPocket }: { onEditPocket?: () => void }): JSX.Eleme
       return;
     }
     if (drag.kind === "move" && click) {
-      // Selection alone must not create a move in undo history.
+      // Open properties after a click or tap, leaving drag gestures uninterrupted.
       if (
         event.type === "pointerup" &&
         Math.hypot(event.clientX - click.clientX, event.clientY - click.clientY) <= CLICK_SLOP_PX
@@ -1628,11 +1627,6 @@ function LayoutStage({ onEditPocket }: { onEditPocket?: () => void }): JSX.Eleme
 
       {selected && (editorMode === "placement" || editorMode === "contour") && (
         <div className="absolute left-3 top-12 z-30 flex max-w-[calc(100%_-_5rem)] flex-wrap gap-2">
-          {onEditPocket && (
-            <Button className="h-8 shadow-sm" variant="outline" size="sm" onClick={onEditPocket} data-testid="button-layout-edit-pocket">
-              <SlidersHorizontal className="mr-1.5 h-4 w-4" />Edit pocket
-            </Button>
-          )}
           <Button
             className="h-8 shadow-sm"
             variant={editorMode === "contour" ? "default" : "outline"}

--- a/client/src/components/gridfinity/layout-canvas.tsx
+++ b/client/src/components/gridfinity/layout-canvas.tsx
@@ -1730,7 +1730,7 @@ function LayoutStage({ onEditPocket }: { onEditPocket?: () => void }): JSX.Eleme
           : selectedFingerHoleId
             ? "Finger hole · drag moves · white handle resizes · arrows nudge · Del removes"
             : selectedCutoutId
-              ? "Pocket · drag edges/corners to resize · Option resizes from centre · round handle rotates"
+              ? "Pocket · drag edges/corners to resize · Option resizes from center · round handle rotates"
               : "Click a pocket or finger hole to select · Shift-drag pans · Ctrl-scroll zooms"}
       </div>
     </>

--- a/client/src/components/gridfinity/layout-canvas.tsx
+++ b/client/src/components/gridfinity/layout-canvas.tsx
@@ -31,7 +31,7 @@ import {
   binFootprintMm,
   gridPitchMm,
 } from "@shared/gridfinity/standard";
-import { MAX_GRID } from "@shared/gridfinity/types";
+import { maxGridCells } from "@shared/gridfinity/types";
 import {
   OUTER_RING,
   type Outline,
@@ -562,7 +562,7 @@ function LayoutStage({ onEditPocket }: { onEditPocket?: () => void }): JSX.Eleme
       // and an explicit label anchor receive the same lattice translation so
       // their position relative to the retained cells does not jump.
       const normalized = normalizeCustomFootprint(nextCells);
-      if (normalized.gridX > MAX_GRID || normalized.gridY > MAX_GRID) return;
+      if (normalized.gridX > maxGridCells(spec.gridPitch) || normalized.gridY > maxGridCells(spec.gridPitch)) return;
       if (
         footprintTopologyError(
           normalized.gridX,

--- a/client/src/components/gridfinity/layout-canvas.tsx
+++ b/client/src/components/gridfinity/layout-canvas.tsx
@@ -1,5 +1,6 @@
 import {
   Ruler,
+  SlidersHorizontal,
   Spline,
   X,
 } from "lucide-react";
@@ -203,15 +204,18 @@ function nearestContourEdge(
   return best;
 }
 
-export function LayoutCanvas(): JSX.Element {
+export function LayoutCanvas({ onEditPocket }: {
+  /** Called on a pocket tap or the explicit edit action, after any drag ends. */
+  onEditPocket?: () => void;
+} = {}): JSX.Element {
   return (
     <CanvasViewport>
-      <LayoutStage />
+      <LayoutStage onEditPocket={onEditPocket} />
     </CanvasViewport>
   );
 }
 
-function LayoutStage(): JSX.Element {
+function LayoutStage({ onEditPocket }: { onEditPocket?: () => void }): JSX.Element {
   const {
     spec,
     cutouts,
@@ -803,6 +807,7 @@ function LayoutStage(): JSX.Element {
     const hit = hitCutout(point);
     if (hit) {
       dispatch({ type: "SELECT_CUTOUT", id: hit.id });
+      clickRef.current = { clientX: event.clientX, clientY: event.clientY };
       dragRef.current = {
         kind: "move",
         id: hit.id,
@@ -848,6 +853,8 @@ function LayoutStage(): JSX.Element {
     }
 
     if (drag.kind === "move") {
+      // A tap must not snap or move the pocket, even with slight hand jitter.
+      if (clickRef.current) return;
       let x = point.x - drag.grabOffset.x;
       let y = point.y - drag.grabOffset.y;
       if (!event.altKey) {
@@ -987,6 +994,16 @@ function LayoutStage(): JSX.Element {
           draft.outline,
           drag.operation === "add" ? "Add contour node" : "Move contour node",
         );
+      }
+      return;
+    }
+    if (drag.kind === "move" && click) {
+      // Selection alone must not create a move in undo history.
+      if (
+        event.type === "pointerup" &&
+        Math.hypot(event.clientX - click.clientX, event.clientY - click.clientY) <= CLICK_SLOP_PX
+      ) {
+        onEditPocket?.();
       }
       return;
     }
@@ -1610,20 +1627,27 @@ function LayoutStage(): JSX.Element {
       ) : null}
 
       {selected && (editorMode === "placement" || editorMode === "contour") && (
-        <Button
-          className="absolute left-3 top-12 z-30 h-8 shadow-sm"
-          variant={editorMode === "contour" ? "default" : "outline"}
-          size="sm"
-          data-testid="button-layout-edit-contour"
-          onClick={() => {
-            setRulerActive(false);
-            setMeasurementPoints([]);
-            dispatch({ type: "SET_EDITOR_MODE", editorMode: editorMode === "contour" ? "placement" : "contour" });
-          }}
-        >
-          <Spline className="h-4 w-4" />
-          {editorMode === "contour" ? "Finish contour editing" : "Edit Contour"}
-        </Button>
+        <div className="absolute left-3 top-12 z-30 flex max-w-[calc(100%_-_5rem)] flex-wrap gap-2">
+          {onEditPocket && (
+            <Button className="h-8 shadow-sm" variant="outline" size="sm" onClick={onEditPocket} data-testid="button-layout-edit-pocket">
+              <SlidersHorizontal className="mr-1.5 h-4 w-4" />Edit pocket
+            </Button>
+          )}
+          <Button
+            className="h-8 shadow-sm"
+            variant={editorMode === "contour" ? "default" : "outline"}
+            size="sm"
+            data-testid="button-layout-edit-contour"
+            onClick={() => {
+              setRulerActive(false);
+              setMeasurementPoints([]);
+              dispatch({ type: "SET_EDITOR_MODE", editorMode: editorMode === "contour" ? "placement" : "contour" });
+            }}
+          >
+            <Spline className="h-4 w-4" />
+            {editorMode === "contour" ? "Finish contour editing" : "Edit Contour"}
+          </Button>
+        </div>
       )}
 
       <div

--- a/client/src/components/gridfinity/pocket-measurements.test.tsx
+++ b/client/src/components/gridfinity/pocket-measurements.test.tsx
@@ -6,7 +6,7 @@ import { parseCutoutPlacement, resolvePocketDepth, type TracedShape } from "@sha
 import { parseBinSpec } from "@shared/gridfinity/types";
 import { BinProvider, useBin, type BinStore } from "@/state/bin-store";
 import { ShapeLibraryProvider } from "@/state/shape-library";
-import { PocketMeasurements } from "./pocket-measurements";
+import { PocketMeasurements, PocketSizeInputs } from "./pocket-measurements";
 
 const shape: TracedShape = {
   id: "tool", name: "Test tool", sourceMmPerPx: 0.25, traceMarginMm: 0.5, pointCount: 4,
@@ -22,7 +22,7 @@ const scale = vi.fn();
 function Probe() {
   store = useBin();
   const cutout = store.cutouts[0];
-  return cutout ? <PocketMeasurements cutout={cutout} shape={shape} section={null} inspect={inspect} setScale={scale} /> : null;
+  return cutout ? <><PocketSizeInputs cutout={cutout} shape={shape} setScale={scale} /><PocketMeasurements cutout={cutout} shape={shape} section={null} inspect={inspect} /></> : null;
 }
 
 beforeEach(() => {
@@ -34,7 +34,7 @@ beforeEach(() => {
   React.act(() => root.render(<ShapeLibraryProvider><BinProvider><Probe /></BinProvider></ShapeLibraryProvider>));
   React.act(() => store.dispatch({ type: "HYDRATE", spec: parseBinSpec({ gridX: 4, gridY: 4, heightUnits: 6 }),
     cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 }, scaleX: 0.9, scaleY: 0.9, clearanceMm: 0.5, depth: { mode: "mm", value: 12 } })] }));
-  React.act(() => host.querySelector("summary")!.click());
+  React.act(() => [...host.querySelectorAll("summary")].find((summary) => summary.textContent?.includes("Fine-tune"))!.click());
 });
 afterEach(() => { React.act(() => root.unmount()); host.remove(); vi.unstubAllGlobals(); });
 

--- a/client/src/components/gridfinity/pocket-measurements.test.tsx
+++ b/client/src/components/gridfinity/pocket-measurements.test.tsx
@@ -71,6 +71,15 @@ describe("pocket measurements", () => {
     expect(store.cutouts[0].position.x).toBe(0);
   });
 
+  it("subtracts inward clearance from physical size and never displays a negative dimension", () => {
+    React.act(() => store.dispatch({ type: "UPDATE_CUTOUT", id: "pocket", patch: { clearanceMm: -0.5 } }));
+    expect(host.querySelector<HTMLInputElement>('[aria-label="Pocket width in millimetres"]')!.value).toBe("35");
+    enter("Pocket width in millimetres", "39");
+    expect(scale.mock.lastCall).toEqual(["x", 100]);
+    React.act(() => store.dispatch({ type: "UPDATE_CUTOUT", id: "pocket", patch: { clearanceMm: -2, scaleX: 0.05 } }));
+    expect(host.querySelector<HTMLInputElement>('[aria-label="Pocket width in millimetres"]')!.value).toBe("0");
+  });
+
   it("shows physical size and the geometry kernel's depth reference", () => {
     expect(host.querySelector<HTMLInputElement>('[aria-label="Pocket width in millimetres"]')!.value).toBe("37");
     const resolved = resolvePocketDepth(store.spec, store.cutouts[0].depth);

--- a/client/src/components/gridfinity/pocket-measurements.test.tsx
+++ b/client/src/components/gridfinity/pocket-measurements.test.tsx
@@ -6,7 +6,7 @@ import { parseCutoutPlacement, resolvePocketDepth, type TracedShape } from "@sha
 import { parseBinSpec } from "@shared/gridfinity/types";
 import { BinProvider, useBin, type BinStore } from "@/state/bin-store";
 import { ShapeLibraryProvider } from "@/state/shape-library";
-import { PocketMeasurements, PocketSizeInputs } from "./pocket-measurements";
+import { PocketDepthSummary, PocketMeasurements, PocketSizeInputs } from "./pocket-measurements";
 
 const shape: TracedShape = {
   id: "tool", name: "Test tool", sourceMmPerPx: 0.25, traceMarginMm: 0.5, pointCount: 4,
@@ -22,7 +22,7 @@ const scale = vi.fn();
 function Probe() {
   store = useBin();
   const cutout = store.cutouts[0];
-  return cutout ? <><PocketSizeInputs cutout={cutout} shape={shape} setScale={scale} /><PocketMeasurements cutout={cutout} shape={shape} section={null} inspect={inspect} /></> : null;
+  return cutout ? <><PocketSizeInputs cutout={cutout} shape={shape} setScale={scale} /><PocketMeasurements cutout={cutout} shape={shape} /><PocketDepthSummary cutout={cutout} shape={shape} section={null} inspect={inspect} /></> : null;
 }
 
 beforeEach(() => {
@@ -34,7 +34,7 @@ beforeEach(() => {
   React.act(() => root.render(<ShapeLibraryProvider><BinProvider><Probe /></BinProvider></ShapeLibraryProvider>));
   React.act(() => store.dispatch({ type: "HYDRATE", spec: parseBinSpec({ gridX: 4, gridY: 4, heightUnits: 6 }),
     cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 }, scaleX: 0.9, scaleY: 0.9, clearanceMm: 0.5, depth: { mode: "mm", value: 12 } })] }));
-  React.act(() => [...host.querySelectorAll("summary")].find((summary) => summary.textContent?.includes("Fine-tune"))!.click());
+  React.act(() => [...host.querySelectorAll("summary")].find((summary) => summary.textContent?.includes("Position"))!.click());
 });
 afterEach(() => { React.act(() => root.unmount()); host.remove(); vi.unstubAllGlobals(); });
 
@@ -71,9 +71,8 @@ describe("pocket measurements", () => {
     expect(store.cutouts[0].position.x).toBe(0);
   });
 
-  it("shows physical size, scaled allowance, and the geometry kernel's depth reference", () => {
+  it("shows physical size and the geometry kernel's depth reference", () => {
     expect(host.querySelector<HTMLInputElement>('[aria-label="Pocket width in millimetres"]')!.value).toBe("37");
-    expect(host.textContent).toContain("0.95 / 0.95 mm per edge");
     const resolved = resolvePocketDepth(store.spec, store.cutouts[0].depth);
     expect(host.textContent).toContain(`Floor: ${resolved.floorZ!.toFixed(1)} mm`);
     expect(host.textContent).toContain("Cut depth: 12.0 mm");

--- a/client/src/components/gridfinity/pocket-measurements.tsx
+++ b/client/src/components/gridfinity/pocket-measurements.tsx
@@ -1,6 +1,6 @@
 import { outlineBounds } from "@/lib/geometry/outline";
 import { useState } from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Lock, Unlock } from "lucide-react";
 import { placementFootprint, resolvePocketDepth, type CutoutPlacement, type TracedShape } from "@shared/gridfinity/cutout";
 import { binTotalHeightMm } from "@shared/gridfinity/standard";
 import { Button } from "@/components/ui/button";
@@ -27,9 +27,8 @@ export function PositionInputs({ position, onChange }: {
   </div>;
 }
 
-export function PocketMeasurements({ cutout, shape, setScale, section, inspect }: {
+export function PocketMeasurements({ cutout, shape, section, inspect }: {
   cutout: CutoutPlacement; shape: TracedShape;
-  setScale: (axis: "x" | "y", percent: number) => void;
   section: BuildBinSection | null;
   inspect: (section: BuildBinSection | null) => void;
 }): JSX.Element {
@@ -56,7 +55,7 @@ export function PocketMeasurements({ cutout, shape, setScale, section, inspect }
   return <div className="space-y-2">
     <details className="group/precision text-xs">
       <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded py-1.5 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-        Fine-tune position &amp; size
+        Fine-tune position &amp; spacing
         <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/precision:rotate-180" />
       </summary>
       <div className="space-y-3 pb-2 pt-2">
@@ -81,18 +80,7 @@ export function PocketMeasurements({ cutout, shape, setScale, section, inspect }
           <Button size="sm" variant="outline" disabled={!neighbor} onClick={spaceFromNeighbor}>Apply gap</Button>
           <p className="text-muted-foreground">Gap between opening bounds, including top rounding.</p>
         </details>}
-        <div className="space-y-1.5">
-          <p className="text-xs font-medium">Pocket size before rotation (mm)</p>
-          <div className="grid grid-cols-2 gap-2">{(["x", "y"] as const).map((axis) => {
-            const extent = axis === "x" ? shape.bboxMm.maxX - shape.bboxMm.minX : shape.bboxMm.maxY - shape.bboxMm.minY;
-            const scale = axis === "x" ? cutout.scaleX : cutout.scaleY;
-            return <Label key={axis} className="flex min-w-0 items-center gap-1 text-xs">{axis === "x" ? "W" : "L"}<DraftNumberInput className="h-8 min-w-0" aria-label={`Pocket ${axis === "x" ? "width" : "length"} in millimetres`} value={extent * scale + 2 * cutout.clearanceMm} displayPrecision={2} min={extent * 0.05 + 2 * cutout.clearanceMm} max={extent * 20 + 2 * cutout.clearanceMm} step={0.1} onValueChange={(value) => setScale(axis, (value - 2 * cutout.clearanceMm) / extent * 100)} /></Label>;
-          })}</div>
-          <p className="text-[11px] text-muted-foreground">Includes extra clearance. Top rounding widens the opening further.</p>
-          <p className="text-[11px] text-muted-foreground" data-testid="pocket-margin-summary">{shape.traceMarginMm === undefined
-            ? `Original trace margin unknown (older project). Extra allowance: ${cutout.clearanceMm.toFixed(2)} mm per edge.`
-            : `Trace margin: ${shape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(shape.traceMarginMm * cutout.scaleX + cutout.clearanceMm).toFixed(2)} / ${(shape.traceMarginMm * cutout.scaleY + cutout.clearanceMm).toFixed(2)} mm per edge.`}</p>
-        </div>
+
       </div>
     </details>
     <details className="group/depth text-xs" data-testid="pocket-depth-summary">
@@ -115,4 +103,64 @@ export function PocketMeasurements({ cutout, shape, setScale, section, inspect }
       inspect(section ? null : { axis: "x", offsetMm: (bounds.minX + bounds.maxX) / 2 });
     }}>{section ? "Show full bin" : "Inspect this pocket in 3D"}</Button>
   </div>;
+}
+
+/** Everyday dimensions are visible independently of precision placement controls. */
+export function PocketSizeInputs({ cutout, shape, setScale }: {
+  cutout: CutoutPlacement;
+  shape: TracedShape;
+  setScale: (axis: "x" | "y", percent: number) => void;
+}): JSX.Element {
+  const { dispatch } = useBin();
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs font-medium">Pocket size (mm)</p>
+        <Button
+          type="button"
+          variant={cutout.aspectRatioLocked ? "secondary" : "outline"}
+          size="sm"
+          className="h-6 shrink-0 gap-1 px-1.5 text-[11px]"
+          aria-label={cutout.aspectRatioLocked ? "Unlock pocket aspect ratio" : "Lock pocket aspect ratio"}
+          aria-pressed={cutout.aspectRatioLocked}
+          onClick={() => dispatch({
+            type: "UPDATE_CUTOUT", id: cutout.id,
+            patch: { aspectRatioLocked: !cutout.aspectRatioLocked },
+            historyLabel: cutout.aspectRatioLocked ? "Unlock pocket proportions" : "Lock pocket proportions",
+          })}
+        >
+          {cutout.aspectRatioLocked ? <Lock className="h-3 w-3" /> : <Unlock className="h-3 w-3" />}
+          Keep proportions
+        </Button>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        {(["x", "y"] as const).map((axis) => {
+          const extent = axis === "x" ? shape.bboxMm.maxX - shape.bboxMm.minX : shape.bboxMm.maxY - shape.bboxMm.minY;
+          const scale = axis === "x" ? cutout.scaleX : cutout.scaleY;
+          return (
+            <Label key={axis} className="flex min-w-0 items-center gap-1 text-xs">
+              {axis === "x" ? "W" : "L"}
+              <DraftNumberInput
+                className="h-8 min-w-0"
+                aria-label={`Pocket ${axis === "x" ? "width" : "length"} in millimetres`}
+                value={extent * scale + 2 * cutout.clearanceMm}
+                displayPrecision={2}
+                min={extent * 0.05 + 2 * cutout.clearanceMm}
+                max={extent * 20 + 2 * cutout.clearanceMm}
+                step={0.1}
+                onValueChange={(value) => setScale(axis, (value - 2 * cutout.clearanceMm) / extent * 100)}
+              />
+            </Label>
+          );
+        })}
+      </div>
+      <p className="text-[11px] text-muted-foreground">Before rotation, including extra clearance. Top rounding widens the opening further.</p>
+      <details className="text-[11px] text-muted-foreground">
+        <summary className="cursor-pointer">Clearance details</summary>
+        <p data-testid="pocket-margin-summary">{shape.traceMarginMm === undefined
+          ? `Original trace margin unknown (older project). Extra allowance: ${cutout.clearanceMm.toFixed(2)} mm per edge.`
+          : `Trace margin: ${shape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(shape.traceMarginMm * cutout.scaleX + cutout.clearanceMm).toFixed(2)} / ${(shape.traceMarginMm * cutout.scaleY + cutout.clearanceMm).toFixed(2)} mm per edge.`}</p>
+      </details>
+    </div>
+  );
 }

--- a/client/src/components/gridfinity/pocket-measurements.tsx
+++ b/client/src/components/gridfinity/pocket-measurements.tsx
@@ -1,10 +1,11 @@
 import { outlineBounds } from "@/lib/geometry/outline";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { ChevronDown, Lock, Unlock } from "lucide-react";
 import { placementFootprint, resolvePocketDepth, type CutoutPlacement, type TracedShape } from "@shared/gridfinity/cutout";
 import { binTotalHeightMm } from "@shared/gridfinity/standard";
 import { Button } from "@/components/ui/button";
 import { DraftNumberInput } from "@/components/ui/draft-number-input";
+import { HelpHint } from "@/components/ui/help-hint";
 import { Label } from "@/components/ui/label";
 import { useBin } from "@/state/bin-store";
 import { useShapeLibrary } from "@/state/shape-library";
@@ -16,29 +17,25 @@ export function PositionInputs({ position, onChange }: {
   onChange: (position: { x: number; y: number }, transient: boolean) => void;
 }): JSX.Element {
   return <div className="space-y-1.5">
-    <p className="text-xs font-medium">Position from bin centre (mm)</p>
+    <div className="flex items-center gap-1"><p className="text-xs font-medium">Position from bin centre (mm)</p><HelpHint label="pocket position">Positive X is right; positive Y is up.</HelpHint></div>
     <div className="grid grid-cols-2 gap-2">{(["x", "y"] as const).map((axis) => <Label key={axis} className="flex min-w-0 items-center gap-2 text-xs">
       {axis.toUpperCase()}
       <DraftNumberInput aria-label={`${axis.toUpperCase()} position in millimetres`} className="h-8 min-w-0" value={position[axis]} displayPrecision={2} step={0.5}
         onValueChange={(value) => onChange({ ...position, [axis]: value }, true)}
         onValueCommit={(value) => onChange({ ...position, [axis]: value }, false)} />
     </Label>)}</div>
-    <p className="text-[11px] text-muted-foreground">Positive X is right; positive Y is up.</p>
   </div>;
 }
 
-export function PocketMeasurements({ cutout, shape, section, inspect }: {
+export function PocketMeasurements({ cutout, shape, children }: {
   cutout: CutoutPlacement; shape: TracedShape;
-  section: BuildBinSection | null;
-  inspect: (section: BuildBinSection | null) => void;
+  children?: ReactNode;
 }): JSX.Element {
-  const { spec, cutouts, dispatch } = useBin();
+  const { cutouts, dispatch } = useBin();
   const { shapes } = useShapeLibrary();
   const [neighborId, setNeighborId] = useState("");
   const [side, setSide] = useState<"right" | "left" | "above" | "below">("right");
   const [gap, setGap] = useState(3);
-  const pocket = resolvePocketDepth(spec, cutout.depth);
-  const total = binTotalHeightMm(spec.heightUnits, spec.lip === "standard");
   const updatePosition = (position: CutoutPlacement["position"], transient = false) => dispatch({ type: "UPDATE_CUTOUT", id: cutout.id, patch: { position }, transient, historyLabel: "Position tool pocket" });
   const bounds = outlineBounds(placementFootprint(shape, cutout).outline)!;
   const neighbor = cutouts.find((item) => item.id === neighborId && item.id !== cutout.id);
@@ -53,19 +50,20 @@ export function PocketMeasurements({ cutout, shape, section, inspect }: {
     updatePosition({ x: cutout.position.x + dx, y: cutout.position.y + dy });
   };
   return <div className="space-y-2">
-    <details className="group/precision text-xs">
+    <details className="group/precision border-t pt-1 text-xs" data-testid="pocket-position-settings">
       <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded py-1.5 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-        Fine-tune position &amp; spacing
+        Position &amp; rotation
         <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/precision:rotate-180" />
       </summary>
       <div className="space-y-3 pb-2 pt-2">
+        {children}
         <PositionInputs position={cutout.position} onChange={updatePosition} />
         <div className="flex gap-2">
           <Button variant="outline" size="sm" onClick={() => updatePosition({ ...cutout.position, x: cutout.position.x - (bounds.minX + bounds.maxX) / 2 })}>Centre X</Button>
           <Button variant="outline" size="sm" onClick={() => updatePosition({ ...cutout.position, y: cutout.position.y - (bounds.minY + bounds.maxY) / 2 })}>Centre Y</Button>
         </div>
         {cutouts.length > 1 && <details className="space-y-2 text-xs">
-          <summary className="cursor-pointer">Space beside another pocket</summary>
+          <summary className="cursor-pointer">Space beside another pocket <HelpHint label="pocket spacing">Gap between opening bounds, including top rounding.</HelpHint></summary>
           <select className="h-8 w-full rounded border bg-background px-2" aria-label="Reference pocket" value={neighborId} onChange={(event) => setNeighborId(event.target.value)}>
             <option value="">Choose a pocket</option>
             {cutouts.filter((item) => item.id !== cutout.id).map((item) => <option key={item.id} value={item.id}>{shapes.find((shape) => shape.id === item.shapeId)?.name ?? "Pocket"}</option>)}
@@ -78,11 +76,24 @@ export function PocketMeasurements({ cutout, shape, section, inspect }: {
             <span>mm</span>
           </div>
           <Button size="sm" variant="outline" disabled={!neighbor} onClick={spaceFromNeighbor}>Apply gap</Button>
-          <p className="text-muted-foreground">Gap between opening bounds, including top rounding.</p>
         </details>}
 
       </div>
     </details>
+  </div>;
+}
+
+/** Depth feedback and inspection stay beside the primary depth controls. */
+export function PocketDepthSummary({ cutout, shape, section, inspect }: {
+  cutout: CutoutPlacement; shape: TracedShape;
+  section: BuildBinSection | null;
+  inspect: (section: BuildBinSection | null) => void;
+}): JSX.Element {
+  const { spec, dispatch } = useBin();
+  const pocket = resolvePocketDepth(spec, cutout.depth);
+  const total = binTotalHeightMm(spec.heightUnits, spec.lip === "standard");
+  const bounds = outlineBounds(placementFootprint(shape, cutout).outline)!;
+  return <div className="space-y-2">
     <details className="group/depth text-xs" data-testid="pocket-depth-summary">
       <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded py-1.5 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
         <span>Cut depth: {pocket.depthMm === null ? "through" : `${pocket.depthMm.toFixed(1)} mm`} · Floor: {(pocket.floorZ ?? 0).toFixed(1)} mm</span>
@@ -97,11 +108,11 @@ export function PocketMeasurements({ cutout, shape, section, inspect }: {
           <text x="230" y="57" textAnchor="end" fontSize="9" fill="currentColor">Floor</text>
         </svg>
       </div>
+      <Button className="mt-2 h-8 w-full text-xs" size="sm" variant="outline" data-testid="button-inspect-pocket" onClick={() => {
+        dispatch({ type: "SET_VIEW_MODE", viewMode: "3d" });
+        inspect(section ? null : { axis: "x", offsetMm: (bounds.minX + bounds.maxX) / 2 });
+      }}>{section ? "Show full bin" : "Inspect this pocket in 3D"}</Button>
     </details>
-    <Button className="h-8 w-full text-xs" size="sm" variant="outline" data-testid="button-inspect-pocket" onClick={() => {
-      dispatch({ type: "SET_VIEW_MODE", viewMode: "3d" });
-      inspect(section ? null : { axis: "x", offsetMm: (bounds.minX + bounds.maxX) / 2 });
-    }}>{section ? "Show full bin" : "Inspect this pocket in 3D"}</Button>
   </div>;
 }
 
@@ -115,7 +126,7 @@ export function PocketSizeInputs({ cutout, shape, setScale }: {
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between gap-2">
-        <p className="text-xs font-medium">Pocket size (mm)</p>
+        <div className="flex items-center gap-1"><p className="text-xs font-medium">Dimensions</p><HelpHint label="pocket size">Width and length in mm, before rotation. Includes extra clearance; top edge rounding widens the opening further.</HelpHint></div>
         <Button
           type="button"
           variant={cutout.aspectRatioLocked ? "secondary" : "outline"}
@@ -150,17 +161,33 @@ export function PocketSizeInputs({ cutout, shape, setScale }: {
                 step={0.1}
                 onValueChange={(value) => setScale(axis, (value - 2 * cutout.clearanceMm) / extent * 100)}
               />
+              <span className="text-[11px] text-muted-foreground">mm</span>
             </Label>
           );
         })}
       </div>
-      <p className="text-[11px] text-muted-foreground">Before rotation, including extra clearance. Top rounding widens the opening further.</p>
-      <details className="text-[11px] text-muted-foreground">
-        <summary className="cursor-pointer">Clearance details</summary>
-        <p data-testid="pocket-margin-summary">{shape.traceMarginMm === undefined
-          ? `Original trace margin unknown (older project). Extra allowance: ${cutout.clearanceMm.toFixed(2)} mm per edge.`
-          : `Trace margin: ${shape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(shape.traceMarginMm * cutout.scaleX + cutout.clearanceMm).toFixed(2)} / ${(shape.traceMarginMm * cutout.scaleY + cutout.clearanceMm).toFixed(2)} mm per edge.`}</p>
-      </details>
+      <div className="flex items-center justify-between gap-2 pt-1">
+        <div className="flex items-center gap-1"><p className="text-xs font-medium">Scale</p><HelpHint label="pocket scale">Drag layout edges or corners. Keep proportions links width and length.</HelpHint></div>
+        {(cutout.scaleX !== 1 || cutout.scaleY !== 1) && (
+          <Button type="button" variant="ghost" size="sm" className="h-5 px-1.5 text-[11px]" onClick={() => dispatch({ type: "UPDATE_CUTOUT", id: cutout.id, patch: { scaleX: 1, scaleY: 1 }, historyLabel: "Reset tool pocket scale" })}>Reset 100%</Button>
+        )}
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        {(["x", "y"] as const).map((axis) => (
+          <Label key={axis} className="flex min-w-0 items-center gap-1 text-xs">
+            {axis === "x" ? "W" : "L"}
+            <DraftNumberInput
+              className="h-8 min-w-0"
+              aria-label={`Pocket ${axis === "x" ? "width" : "length"} scale percent`}
+              data-testid={`input-pocket-scale-${axis}`}
+              value={Math.round((axis === "x" ? cutout.scaleX : cutout.scaleY) * 1000) / 10}
+              min={5} max={2000} step={1}
+              onValueChange={(percent) => setScale(axis, percent)}
+            />
+            <span className="text-[11px] text-muted-foreground">%</span>
+          </Label>
+        ))}
+      </div>
     </div>
   );
 }

--- a/client/src/components/gridfinity/pocket-measurements.tsx
+++ b/client/src/components/gridfinity/pocket-measurements.tsx
@@ -17,7 +17,7 @@ export function PositionInputs({ position, onChange }: {
   onChange: (position: { x: number; y: number }, transient: boolean) => void;
 }): JSX.Element {
   return <div className="space-y-1.5">
-    <div className="flex items-center gap-1"><p className="text-xs font-medium">Position from bin centre (mm)</p><HelpHint label="pocket position">Positive X is right; positive Y is up.</HelpHint></div>
+    <div className="flex items-center gap-1"><p className="text-xs font-medium">Position from bin center (mm)</p><HelpHint label="pocket position">Positive X is right; positive Y is up.</HelpHint></div>
     <div className="grid grid-cols-2 gap-2">{(["x", "y"] as const).map((axis) => <Label key={axis} className="flex min-w-0 items-center gap-2 text-xs">
       {axis.toUpperCase()}
       <DraftNumberInput aria-label={`${axis.toUpperCase()} position in millimetres`} className="h-8 min-w-0" value={position[axis]} displayPrecision={2} step={0.5}
@@ -59,8 +59,8 @@ export function PocketMeasurements({ cutout, shape, children }: {
         {children}
         <PositionInputs position={cutout.position} onChange={updatePosition} />
         <div className="flex gap-2">
-          <Button variant="outline" size="sm" onClick={() => updatePosition({ ...cutout.position, x: cutout.position.x - (bounds.minX + bounds.maxX) / 2 })}>Centre X</Button>
-          <Button variant="outline" size="sm" onClick={() => updatePosition({ ...cutout.position, y: cutout.position.y - (bounds.minY + bounds.maxY) / 2 })}>Centre Y</Button>
+          <Button variant="outline" size="sm" onClick={() => updatePosition({ ...cutout.position, x: cutout.position.x - (bounds.minX + bounds.maxX) / 2 })}>Center X</Button>
+          <Button variant="outline" size="sm" onClick={() => updatePosition({ ...cutout.position, y: cutout.position.y - (bounds.minY + bounds.maxY) / 2 })}>Center Y</Button>
         </div>
         {cutouts.length > 1 && <details className="space-y-2 text-xs">
           <summary className="cursor-pointer">Space beside another pocket <HelpHint label="pocket spacing">Gap between opening bounds, including top rounding.</HelpHint></summary>

--- a/client/src/components/gridfinity/pocket-measurements.tsx
+++ b/client/src/components/gridfinity/pocket-measurements.tsx
@@ -154,10 +154,10 @@ export function PocketSizeInputs({ cutout, shape, setScale }: {
               <DraftNumberInput
                 className="h-8 min-w-0"
                 aria-label={`Pocket ${axis === "x" ? "width" : "length"} in millimetres`}
-                value={extent * scale + 2 * cutout.clearanceMm}
+                value={Math.max(0, extent * scale + 2 * cutout.clearanceMm)}
                 displayPrecision={2}
-                min={extent * 0.05 + 2 * cutout.clearanceMm}
-                max={extent * 20 + 2 * cutout.clearanceMm}
+                min={Math.max(0, extent * 0.05 + 2 * cutout.clearanceMm)}
+                max={Math.max(0, extent * 20 + 2 * cutout.clearanceMm)}
                 step={0.1}
                 onValueChange={(value) => setScale(axis, (value - 2 * cutout.clearanceMm) / extent * 100)}
               />

--- a/client/src/components/help/help-dialog.tsx
+++ b/client/src/components/help/help-dialog.tsx
@@ -144,16 +144,17 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
               </li>
               <li>
                 Click a pocket in <strong>Layout</strong> or choose it in
-                <strong> Pockets</strong> to open its properties at the top of
-                the controls. Set its size, depth, and extra clearance there;
-                expand the position or rounding settings for finer adjustments.
+                <strong> Pockets</strong> to open its properties in that section.
+                Set depth first; expand <strong>Size &amp; scale</strong> for dimensions. Expand <strong>Edges &amp; corners</strong>
+                to soften the outline or pocket edges, or <strong>Extra pocket clearance</strong>
+                to add more room around the tool.
                 Extra clearance is added after the Margin chosen on Trace.
                 Use <strong>Finger access</strong> for straight or scoop holes.
                 Warnings appear at the bottom right of the canvas; click a message
                 to open the affected pocket or settings.
               </li>
               <li>
-                Click a selected tool's name to rename it. Use Layout to move,
+                Click the pencil on a pocket’s row to rename it. Use Layout to move,
                 rotate, or edit its contour; the ruler snaps to tool contours
                 and is most accurate in the 2D Layout view.
               </li>

--- a/client/src/components/help/help-dialog.tsx
+++ b/client/src/components/help/help-dialog.tsx
@@ -143,10 +143,12 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
                 Keep bin size fixed prevents new tools from enlarging the bin.
               </li>
               <li>
-                Open <strong>Arrange pockets</strong> and select a cutout to
-                set depth, extra clearance, corner rounds, bottom fillet, and
-                straight or scoop finger holes. Extra clearance is added after
-                the Margin chosen on Trace.
+                Click a pocket in <strong>Layout</strong> or choose it in
+                <strong> Pockets</strong> to open its properties at the top of
+                the controls. Set its size, depth, and extra clearance there;
+                expand the position or rounding settings for finer adjustments.
+                Extra clearance is added after the Margin chosen on Trace.
+                Use <strong>Finger access</strong> for straight or scoop holes.
               </li>
               <li>
                 Click a selected tool's name to rename it. Use Layout to move,

--- a/client/src/components/help/help-dialog.tsx
+++ b/client/src/components/help/help-dialog.tsx
@@ -149,6 +149,8 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
                 expand the position or rounding settings for finer adjustments.
                 Extra clearance is added after the Margin chosen on Trace.
                 Use <strong>Finger access</strong> for straight or scoop holes.
+                Warnings appear at the bottom right of the canvas; click a message
+                to open the affected pocket or settings.
               </li>
               <li>
                 Click a selected tool's name to rename it. Use Layout to move,

--- a/client/src/components/layout/panel-section.tsx
+++ b/client/src/components/layout/panel-section.tsx
@@ -193,7 +193,7 @@ export interface PanelSettingsIndexProps {
  * `scrollIntoView()` also scrolls a mobile drawer ancestor, which can carry the
  * map itself behind the drawer's clipped top edge.
  */
-export function revealPanelSection(id: string, items: readonly { id: string }[]): void {
+export function revealPanelSection(id: string, items: readonly { id: string }[], focusId?: string): void {
     const target = document.getElementById(id);
     if (!target) return;
     const scroller = target.parentElement;
@@ -222,6 +222,10 @@ export function revealPanelSection(id: string, items: readonly { id: string }[])
 
     const scroll = () => {
       if (!scroller) return;
+      // A selected item may have a long list above its controls. Resolve its
+      // editor after the section opens so small screens reach editable fields.
+      const focus = focusId ? document.getElementById(focusId) : null;
+      const scrollTarget = focus && target.contains(focus) ? focus : target;
       // Browsers otherwise clamp the final sections below the top because
       // there is not enough content beneath them. Add only the blank space
       // required for the selected heading to reach the scroller's top edge.
@@ -232,7 +236,7 @@ export function revealPanelSection(id: string, items: readonly { id: string }[])
       // top instead of disappearing behind the settings index.
       const targetTop =
         scroller.scrollTop +
-        target.getBoundingClientRect().top -
+        scrollTarget.getBoundingClientRect().top -
         scroller.getBoundingClientRect().top;
       // A full-pane reserve guarantees that even the final short section can
       // reach the top; calculated minimums are vulnerable to scroll anchoring
@@ -242,7 +246,7 @@ export function revealPanelSection(id: string, items: readonly { id: string }[])
       scroller?.scrollTo?.({ top: targetTop, behavior: "auto" });
       const alignSelectedHeading = () => {
         const remainingOffset =
-          target.getBoundingClientRect().top -
+          scrollTarget.getBoundingClientRect().top -
           scroller.getBoundingClientRect().top;
         if (Math.abs(remainingOffset) > 0.5) {
           scroller.scrollTop += remainingOffset;

--- a/client/src/components/layout/workspace-layout.tsx
+++ b/client/src/components/layout/workspace-layout.tsx
@@ -129,14 +129,15 @@ export function WorkspaceLayout({
           {/* aria-describedby={undefined} opts out of Radix's description
               warning: this drawer is a controls tray, not a prose dialog. */}
           <DrawerContent
-            className="max-h-[85dvh]"
+            className="h-[85dvh] max-h-[85dvh]"
             aria-describedby={undefined}
           >
             <DrawerHeader className="shrink-0 pb-2">
               <DrawerTitle>{panelTitle}</DrawerTitle>
             </DrawerHeader>
-            {/* The composed panel owns its scrolling through PanelBody. Keeping
-                this wrapper non-scrolling lets panel-level navigation and the
+            {/* The drawer has a definite height so the panel's h-full and
+                flex scroller can shrink within it. PanelBody owns scrolling;
+                this wrapper keeps panel-level navigation and the
                 PanelFooter remain pinned in the mobile drawer too. */}
             <div className="min-h-0 flex-1 overflow-hidden">{panel}</div>
           </DrawerContent>

--- a/client/src/components/ui/help-hint.test.tsx
+++ b/client/src/components/ui/help-hint.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { HelpHint } from "./help-hint";
+
+let host: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+  React.act(() => root.render(
+    <details><summary>Edges <HelpHint label="edges">A radius of 0 keeps the edge sharp.</HelpHint></summary><p>Settings</p></details>,
+  ));
+});
+afterEach(() => {
+  React.act(() => root.unmount());
+  host.remove();
+  vi.unstubAllGlobals();
+});
+
+it("reveals optional guidance on keyboard focus and dismisses it with Escape", async () => {
+  expect(document.querySelector('[role="tooltip"]')).toBeNull();
+  await React.act(async () => host.querySelector('button')!.focus());
+  expect(document.querySelector('[role="tooltip"]')!.textContent).toContain('0 keeps the edge sharp');
+  React.act(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })));
+  expect(document.querySelector('[role="tooltip"]')).toBeNull();
+  expect(host.querySelector('details')!.open).toBe(false);
+});
+
+it("toggles guidance by tapping without expanding the enclosing settings", async () => {
+  await React.act(async () => host.querySelector('button')!.click());
+  expect(document.querySelector('[role="tooltip"]')).not.toBeNull();
+  expect(host.querySelector('details')!.open).toBe(false);
+  React.act(() => host.querySelector('button')!.click());
+  expect(document.querySelector('[role="tooltip"]')).toBeNull();
+  expect(host.querySelector('details')!.open).toBe(false);
+});

--- a/client/src/components/ui/help-hint.tsx
+++ b/client/src/components/ui/help-hint.tsx
@@ -1,0 +1,39 @@
+import { Portal } from "@radix-ui/react-tooltip";
+import { CircleHelp } from "lucide-react";
+import { useState, type ReactNode } from "react";
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip";
+
+/** Optional field guidance, available on hover, keyboard focus, and touch. */
+export function HelpHint({ label, children }: { label: string; children: ReactNode }): JSX.Element {
+  const [open, setOpen] = useState(false);
+  return (
+    <TooltipProvider delayDuration={250}>
+      <Tooltip open={open} onOpenChange={setOpen}>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={`About ${label}`}
+            className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={(event) => {
+              // Radix closes tooltips on click by default. Keep a tap usable,
+              // and avoid toggling an enclosing details summary.
+              event.preventDefault();
+              setOpen((current) => !current);
+            }}
+          >
+            <CircleHelp className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <Portal>
+          <TooltipContent side="top" className="max-w-64 text-xs font-normal leading-relaxed" onEscapeKeyDown={(event) => {
+            event.stopPropagation();
+            setOpen(false);
+          }}>
+            {children}
+          </TooltipContent>
+        </Portal>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/client/src/components/ui/slider.tsx
+++ b/client/src/components/ui/slider.tsx
@@ -5,8 +5,17 @@ import { cn } from "@/lib/utils"
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+    /** Fill a signed horizontal control from zero, with a neutral-position tick. */
+    centerOrigin?: boolean;
+  }
+>(({ className, centerOrigin = false, ...props }, ref) => {
+  const min = props.min ?? 0;
+  const max = props.max ?? 100;
+  const position = (value: number) => Math.max(0, Math.min(100, (value - min) / (max - min) * 100));
+  const zero = position(0);
+  const current = position(props.value?.[0] ?? props.defaultValue?.[0] ?? 0);
+  return (
   <SliderPrimitive.Root
     ref={ref}
     className={cn(
@@ -16,11 +25,15 @@ const Slider = React.forwardRef<
     {...props}
   >
     <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      {centerOrigin ? <>
+        <span className="absolute h-full bg-primary" style={{ left: `${Math.min(zero, current)}%`, width: `${Math.abs(current - zero)}%` }} />
+        <span className="absolute h-full w-px bg-foreground/50" style={{ left: `${zero}%` }} />
+      </> : <SliderPrimitive.Range className="absolute h-full bg-primary" />}
     </SliderPrimitive.Track>
     <SliderPrimitive.Thumb aria-label={props["aria-label"]} aria-labelledby={props["aria-labelledby"]} className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
-))
+  )
+})
 Slider.displayName = SliderPrimitive.Root.displayName
 
 export { Slider }

--- a/client/src/lib/gridfinity/autoplace.test.ts
+++ b/client/src/lib/gridfinity/autoplace.test.ts
@@ -145,6 +145,31 @@ describe("autoPlaceFresh", () => {
     expect(errors).toEqual([]);
   });
 
+  it.each(["half", "quarter"] as const)("packs and fits long tools beyond 16 %s-pitch cells", (gridPitch) => {
+    const shape = rectShape("long", 400, 20);
+    const byId = new Map([[shape.id, shape]]);
+    const fresh = autoPlaceFresh([shape], "standard", gridPitch);
+    expect(fresh.overflow).toBe(false);
+    expect(fresh.gridX).toBeGreaterThan(16);
+    const fitted = fitLayoutToPlacements(fresh.cutouts, byId, "standard", gridPitch);
+    const arranged = autoArrangeLayout(fresh.cutouts, byId, "standard", gridPitch)!;
+    expect(arranged.overflow).toBe(false);
+    for (const result of [fresh, fitted, arranged]) {
+      const spec = parseBinSpec({ gridX: result.gridX, gridY: result.gridY, gridPitch, heightUnits: 6 });
+      expect(validateLayout(spec, result.cutouts, byId).filter((issue) => issue.severity === "error")).toEqual([]);
+    }
+
+    const added = rectShape("added", 20, 20);
+    byId.set(added.id, added);
+    const incremental = autoPlaceIncremental([added], {
+      gridX: fresh.gridX, gridY: fresh.gridY, gridPitch, lip: "standard",
+      existing: fresh.cutouts, shapesById: byId,
+    });
+    expect(incremental.overflow).toBe(false);
+    const grown = parseBinSpec({ gridX: incremental.gridX, gridY: incremental.gridY, gridPitch, heightUnits: 6 });
+    expect(validateLayout(grown, [...fresh.cutouts, ...incremental.cutouts], byId).filter((issue) => issue.severity === "error")).toEqual([]);
+  });
+
   it("property: fresh placements never produce validation errors", () => {
     for (const count of [1, 2, 4, 6]) {
       const shapes = Array.from({ length: count }, (_, i) =>

--- a/client/src/lib/gridfinity/autoplace.test.ts
+++ b/client/src/lib/gridfinity/autoplace.test.ts
@@ -1,4 +1,4 @@
-import type { TracedShape } from "@shared/gridfinity/cutout";
+import { parseCutoutPlacement, type TracedShape } from "@shared/gridfinity/cutout";
 import { parseBinSpec } from "@shared/gridfinity/types";
 import { validateLayout } from "@shared/gridfinity/validate";
 import { describe, expect, it } from "vitest";
@@ -44,6 +44,17 @@ describe("placementInsetMm", () => {
 });
 
 describe("autoPlaceFresh", () => {
+  it("preserves inward clearance and valid packing bounds for a very narrow pocket", () => {
+    const shape = rectShape("thin", 30, 0.8);
+    const cutout = parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 }, clearanceMm: -2 });
+    const byId = new Map([[shape.id, shape]]);
+    const result = autoArrangeLayout([cutout], byId, "none");
+    const unshrunk = autoArrangeLayout([{ ...cutout, clearanceMm: 0 }], byId, "none");
+    expect(result).not.toBeNull();
+    expect(result!.cutouts[0].clearanceMm).toBe(-2);
+    expect({ ...result, cutouts: result!.cutouts.map((item) => ({ ...item, clearanceMm: 0 })) }).toEqual(unshrunk);
+  });
+
   it("keeps a fixed bin and retains oversized arrivals for manual adjustment", () => {
     const shape = rectShape("large", 150, 100);
     const result = autoPlaceIncremental([shape], { lip: "standard", gridX: 2, gridY: 2,

--- a/client/src/lib/gridfinity/autoplace.ts
+++ b/client/src/lib/gridfinity/autoplace.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_TOP_EDGE_FILLET_MM,
   fingerHoleFootprintRing,
   placementFootprint,
+  pocketLayoutAllowanceMm,
   type CutoutPlacement,
   type FingerHole,
   type TracedShape,
@@ -264,7 +265,7 @@ function existingBounds(
     const shape = shapesById.get(cutout.shapeId);
     if (!shape) continue;
     const footprint = placementFootprint(shape, cutout);
-    const outlineAllowance = cutout.clearanceMm + cutout.topFilletMm;
+    const outlineAllowance = pocketLayoutAllowanceMm(cutout);
     for (const part of footprint.outline) {
       for (const point of part.outer) includePoint(point, outlineAllowance);
     }
@@ -644,10 +645,10 @@ export function autoArrangeLayout(
     key: item.cutout.id,
     widthMm:
       item.widthMm +
-      2 * (item.cutout.clearanceMm + item.cutout.topFilletMm),
+      2 * pocketLayoutAllowanceMm(item.cutout),
     heightMm:
       item.heightMm +
-      2 * (item.cutout.clearanceMm + item.cutout.topFilletMm),
+      2 * pocketLayoutAllowanceMm(item.cutout),
   }));
   const inset = placementInsetMm(lip);
   const fixedHoleBounds = existingBounds([], shapesById, fingerHoles);

--- a/client/src/lib/gridfinity/autoplace.ts
+++ b/client/src/lib/gridfinity/autoplace.ts
@@ -15,7 +15,7 @@ import {
   STACKING_LIP_DEPTH,
   type GridPitch,
 } from "@shared/gridfinity/standard";
-import { MAX_GRID, type BinSpec } from "@shared/gridfinity/types";
+import { maxGridCells, type BinSpec } from "@shared/gridfinity/types";
 import {
   canonicalCells,
   cellCenterMm,
@@ -139,10 +139,11 @@ function shapeTargets(shapes: readonly TracedShape[]): PackTarget[] {
 }
 
 /** Candidate grids ordered by cell count, then by squareness. */
-function gridCandidates(minX = 1, minY = 1): { gridX: number; gridY: number }[] {
+function gridCandidates(gridPitch: GridPitch = "full", minX = 1, minY = 1): { gridX: number; gridY: number }[] {
   const candidates: { gridX: number; gridY: number }[] = [];
-  for (let gx = minX; gx <= MAX_GRID; gx++) {
-    for (let gy = minY; gy <= MAX_GRID; gy++) {
+  const maximum = maxGridCells(gridPitch);
+  for (let gx = minX; gx <= maximum; gx++) {
+    for (let gy = minY; gy <= maximum; gy++) {
       candidates.push({ gridX: gx, gridY: gy });
     }
   }
@@ -190,7 +191,7 @@ export interface AutoPlaceResult {
   cutouts: CutoutPlacement[];
   gridX: number;
   gridY: number;
-  /** True when nothing fit even at MAX_GRID; placements are still returned. */
+  /** True when nothing fit at the maximum physical span; placements are still returned. */
   overflow: boolean;
 }
 
@@ -210,7 +211,7 @@ export function autoPlaceFresh(
   const byId = new Map(shapes.map((shape) => [shape.id, shape]));
   const targets = shapeTargets(shapes);
 
-  for (const grid of gridCandidates()) {
+  for (const grid of gridCandidates(gridPitch)) {
     const interior = interiorMm(grid, inset, gridPitch);
     if (interior.widthMm <= 0 || interior.heightMm <= 0) continue;
     const block = shelfPack(targets, interior.widthMm);
@@ -224,16 +225,17 @@ export function autoPlaceFresh(
     }
   }
 
-  // Nothing fits even at MAX_GRID: return the biggest bin and let the
+  // Nothing fits at the maximum span: return the biggest bin and let the
   // validation rules paint the problem rather than silently dropping shapes.
+  const maximum = maxGridCells(gridPitch);
   const block = shelfPack(
     targets,
-    interiorMm({ gridX: MAX_GRID, gridY: MAX_GRID }, inset, gridPitch).widthMm,
+    interiorMm({ gridX: maximum, gridY: maximum }, inset, gridPitch).widthMm,
   );
   return {
     cutouts: block.items.map((item) => toPlacement(item, byId, 0, 0)),
-    gridX: MAX_GRID,
-    gridY: MAX_GRID,
+    gridX: maximum,
+    gridY: maximum,
     overflow: true,
   };
 }
@@ -333,7 +335,7 @@ export function autoPlaceIncremental(
   const byId = new Map(shapes.map((shape) => [shape.id, shape]));
   const targets = shapeTargets(shapes);
 
-  for (const grid of options.keepBinSize ? [options] : gridCandidates(options.gridX, options.gridY)) {
+  for (const grid of options.keepBinSize ? [options] : gridCandidates(options.gridPitch, options.gridX, options.gridY)) {
     const interior = interiorMm(grid, inset, options.gridPitch);
     const halfW = interior.widthMm / 2;
     const halfH = interior.heightMm / 2;
@@ -375,7 +377,7 @@ export function autoPlaceIncremental(
   const cx = occupied.maxX + ITEM_GAP_MM + block.widthMm / 2;
   return {
     cutouts: block.items.map((item) => toPlacement(item, byId, cx, 0)),
-    gridX: options.keepBinSize ? options.gridX : MAX_GRID,
+    gridX: options.keepBinSize ? options.gridX : maxGridCells(options.gridPitch),
     gridY: Math.max(options.gridY, 1),
     overflow: true,
   };
@@ -417,11 +419,12 @@ export function fitLayoutToPlacements(
   const halfWNeeded = (bounds.maxX - bounds.minX) / 2 + inset;
   const halfHNeeded = (bounds.maxY - bounds.minY) / 2 + inset;
 
+  const maximum = maxGridCells(gridPitch);
   const fit = (halfNeeded: number): number => {
-    for (let cells = 1; cells <= MAX_GRID; cells++) {
+    for (let cells = 1; cells <= maximum; cells++) {
       if (binFootprintMm(cells, gridPitch) / 2 >= halfNeeded) return cells;
     }
-    return MAX_GRID;
+    return maximum;
   };
   return {
     cutouts: cutouts.map((cutout) => ({
@@ -676,7 +679,7 @@ export function autoArrangeLayout(
       };
     });
 
-  for (const grid of fixedGrid ? [fixedGrid] : gridCandidates()) {
+  for (const grid of fixedGrid ? [fixedGrid] : gridCandidates(gridPitch)) {
     const interior = interiorMm(grid, inset, gridPitch);
     if (interior.widthMm <= 0 || interior.heightMm <= 0) continue;
     if (!containsFixedHoles(interior.widthMm, interior.heightMm)) continue;
@@ -710,14 +713,15 @@ export function autoArrangeLayout(
     }
   }
 
+  const maximum = maxGridCells(gridPitch);
   const block = shelfPack(
     targets,
-    interiorMm(fixedGrid ?? { gridX: MAX_GRID, gridY: MAX_GRID }, inset, gridPitch).widthMm,
+    interiorMm(fixedGrid ?? { gridX: maximum, gridY: maximum }, inset, gridPitch).widthMm,
   );
   return {
     cutouts: placeBlock(block),
-    gridX: fixedGrid?.gridX ?? MAX_GRID,
-    gridY: fixedGrid?.gridY ?? MAX_GRID,
+    gridX: fixedGrid?.gridX ?? maximum,
+    gridY: fixedGrid?.gridY ?? maximum,
     overflow: true,
   };
 }

--- a/client/src/lib/gridfinity/bin-worker-handlers.test.ts
+++ b/client/src/lib/gridfinity/bin-worker-handlers.test.ts
@@ -425,6 +425,28 @@ describe("fit template worker handler", () => {
     expect(result.transfer).toContain(result.value.mesh.indices.buffer);
   });
 
+  it("exports an inward-offset fit template after placement scale", async () => {
+    const result = await getFitCheckHandler()({
+      shape,
+      cutout: { id: "fit-cutout", shapeId: shape.id, position: { x: 40, y: -20 },
+        scaleX: 1.5, scaleY: 0.5, clearanceMm: -0.5, cornerRoundMm: 0 },
+      depthMm: 2.5, quality: { circularSegments: 24, cutoutVertexBudget: 600 },
+    }, context());
+    const xs = Array.from(result.value.mesh.positions).filter((_, index) => index % 3 === 0);
+    expect(Math.min(...xs)).toBeCloseTo(-14.5, 5);
+    expect(Math.max(...xs)).toBeCloseTo(14.5, 5);
+    expect(result.value.stats.volumeMm3).toBeCloseTo(29 * 4 * 2.5, 4);
+  });
+
+  it("rejects a fit template erased by inward clearance", async () => {
+    await expect(getFitCheckHandler()({
+      shape,
+      cutout: { id: "fit-cutout", shapeId: shape.id, position: { x: 0, y: 0 },
+        scaleY: 0.05, clearanceMm: -0.5, cornerRoundMm: 0 },
+      depthMm: 2, quality: { circularSegments: 24 },
+    }, context())).rejects.toThrow("collapsed");
+  });
+
   it("rejects an out-of-range template depth", async () => {
     await expect(
       getFitCheckHandler()(

--- a/client/src/lib/gridfinity/bin.test.ts
+++ b/client/src/lib/gridfinity/bin.test.ts
@@ -209,6 +209,19 @@ describe("buildBin", () => {
     expect(box.max[2]).toBeCloseTo(42, 9);
   });
 
+  it("builds a 3 by 5 standard-cell bin with 12 by 20 quarter sockets", () => {
+    const { solid } = buildBin(kernel, spec({
+      gridX: 12, gridY: 20, gridPitch: "quarter", heightUnits: 5.5, fill: "solid",
+    }), PREVIEW_QUALITY);
+    expect(solid.status()).toBe("NoError");
+    expect(solid.genus()).toBe(0);
+    const box = solid.boundingBox();
+    expect(box.max[0] - box.min[0]).toBeCloseTo(125.5, 9);
+    expect(box.max[1] - box.min[1]).toBeCloseTo(209.5, 9);
+    expect(box.min[2]).toBeCloseTo(0, 9);
+    expect(box.max[2]).toBeCloseTo(38.5 + STACKING_LIP_HEIGHT_ACTUAL, 6);
+  });
+
   it("2×3×6 empty bin with lip: exact bbox and inclusion–exclusion volume", () => {
     const { parts, solid } = buildBin(kernel, spec(), QUALITY);
     expect(solid.status()).toBe("NoError");

--- a/client/src/lib/gridfinity/cutouts.test.ts
+++ b/client/src/lib/gridfinity/cutouts.test.ts
@@ -377,6 +377,30 @@ describe("buildBinWithCutouts", () => {
     expect(Math.abs(removed - area * 5) / (area * 5)).toBeLessThan(1e-4);
   });
 
+  it("negative clearance shrinks each edge after scaling, preserving the source outline", () => {
+    const shape = rectShape("s1", 30, 10);
+    const original = structuredClone(shape);
+    const plain = buildBin(kernel, SPEC, QUALITY);
+    const pocketed = buildBinWithCutouts(kernel, SPEC, layoutFor([shape], [cutout("c1", "s1", {
+      scaleX: 1.5, scaleY: 2, clearanceMm: -0.5, depth: { mode: "mm", value: 5 },
+    })]), QUALITY);
+    expect(pocketed.solid.status()).toBe("NoError");
+    expect(plain.solid.volume() - pocketed.solid.volume()).toBeCloseTo((45 - 1) * (20 - 1) * 5, 4);
+    expect(pocketed.cutoutReports).toEqual([{ id: "c1", emptied: false }]);
+    expect(shape).toEqual(original);
+  });
+
+  it("reports a pocket erased by negative clearance without producing an invalid solid", () => {
+    const sliver = rectShape("s1", 30, 0.8);
+    const plain = buildBin(kernel, SPEC, QUALITY);
+    const pocketed = buildBinWithCutouts(kernel, SPEC, layoutFor([sliver], [cutout("c1", "s1", {
+      clearanceMm: -0.5,
+    })]), QUALITY);
+    expect(pocketed.cutoutReports).toEqual([{ id: "c1", emptied: true }]);
+    expect(pocketed.solid.status()).toBe("NoError");
+    expect(pocketed.solid.volume()).toBeCloseTo(plain.solid.volume(), 6);
+  });
+
   it("outline corner rounding removes sharp plan-view corners", () => {
     const shape = rectShape("s1", 30, 10);
     const plain = buildBin(kernel, SPEC, QUALITY);

--- a/client/src/lib/gridfinity/cutouts.ts
+++ b/client/src/lib/gridfinity/cutouts.ts
@@ -36,7 +36,7 @@ import {
  *     ring down to the quality's budget (the count is surfaced in the UI so
  *     the trade-off stays legible, per the design doc);
  *  2. placement transform (mirror → rotate → translate, shared math);
- *  3. `+clearance` offset with round joins — clearance runs BEFORE corner
+ *  3. signed clearance offset with round joins — clearance runs BEFORE corner
  *     rounding on purpose: a 1 mm slot is 1.8 mm wide after clearance, but
  *     rounding first at r = 1 would erase it before clearance could save it;
  *  4. corner rounding as `−r` then `+r` round offsets (2D vertical-edge
@@ -421,7 +421,7 @@ export function buildCutoutCutters(
     const placed = transformOutlinePlacement(budgeted, cutout);
 
     let section = toCrossSection(kernel, placed);
-    if (cutout.clearanceMm > 0) {
+    if (cutout.clearanceMm !== 0) {
       section = arena.track(
         arena
           .track(section.offset(cutout.clearanceMm, "Round", 2, segments))

--- a/client/src/lib/gridfinity/fit-check.ts
+++ b/client/src/lib/gridfinity/fit-check.ts
@@ -74,7 +74,7 @@ export function buildFitCheckSolid(
   });
 
   let section = toCrossSection(kernel, normalized);
-  if (cutout.clearanceMm > 0) {
+  if (cutout.clearanceMm !== 0) {
     section = arena.track(
       arena
         .track(section.offset(cutout.clearanceMm, "Round", 2, segments))

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -222,13 +222,14 @@ beforeEach(() => {
   );
 });
 
-function renderPage() {
+function renderPage(options: { mobile?: boolean } = {}) {
   return render(
     <PanelProvider>
       <ShapeLibraryProvider>
         <BinDesignerPage />
       </ShapeLibraryProvider>
     </PanelProvider>,
+    options,
   );
 }
 
@@ -991,7 +992,79 @@ describe("BinDesignerPage", () => {
     unmount();
   });
 
-  it("warns about floor color on the underside in pocket controls, Materials, and 3MF export without blocking", async () => {
+  it("keeps error details on the canvas in both views, collapses them, and blocks export", async () => {
+    const shape = rectangularShape("tool", "Wrench");
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT, shapes: [shape],
+      spec: parseBinSpec({ gridX: 2, gridY: 2, heightUnits: 6, fill: "solid" }),
+      cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 70, y: 0 } })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    const warnings = container.querySelector<HTMLElement>('[data-testid="canvas-warnings"]')!;
+    expect(warnings.closest('[data-testid="bin-canvas"]')).not.toBeNull();
+    const issue = warnings.querySelector<HTMLButtonElement>('[data-issue-code="out-of-bounds"]')!;
+    expect(issue).not.toBeNull();
+    expect(container.querySelectorAll('[data-issue-code="out-of-bounds"]')).toHaveLength(1);
+    const toggle = warnings.querySelector<HTMLButtonElement>('button[aria-expanded]')!;
+    expect(toggle.textContent).toContain('error');
+    React.act(() => toggle.click());
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(warnings.querySelector('[data-issue-code]')).toBeNull();
+    React.act(() => toggle.click());
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="view-toggle-2d"]')!.click());
+    expect(container.querySelector('[data-testid="canvas-warnings"]')).toBe(warnings);
+    React.act(() => warnings.querySelector<HTMLButtonElement>('[data-issue-code="out-of-bounds"]')!.click());
+    expect(container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).toContain('Wrench');
+    openSettingsSection(container, 'export');
+    expect(container.querySelector<HTMLButtonElement>('[data-testid="button-export-stl"]')!.disabled).toBe(true);
+    expect(container.querySelector('#bin-settings-export [data-issue-code]')).toBeNull();
+    unmount();
+  });
+
+  it("cycles between overlapping pockets from their canvas warning", async () => {
+    const first = rectangularShape('first', 'Wrench');
+    const second = rectangularShape('second', 'Pliers');
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT, shapes: [first, second],
+      spec: parseBinSpec({ gridX: 2, gridY: 2, heightUnits: 6, fill: "solid" }),
+      cutouts: [
+        parseCutoutPlacement({ id: 'first-pocket', shapeId: first.id, position: { x: -3, y: 0 } }),
+        parseCutoutPlacement({ id: 'second-pocket', shapeId: second.id, position: { x: 3, y: 0 } }),
+      ],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    const issue = container.querySelector<HTMLButtonElement>('[data-testid="canvas-warnings"] [data-issue-code="cutout-overlap"]')!;
+    React.act(() => issue.click());
+    const firstName = container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent;
+    React.act(() => issue.click());
+    expect(container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).not.toBe(firstName);
+    expect(issue.getAttribute('data-selected')).toBe('true');
+    expect(container.querySelector('[data-testid="layout-canvas"]')).not.toBeNull();
+    expect(container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.disabled).toBe(true);
+    unmount();
+  });
+
+  it("starts mobile warnings as a compact count and expands the messages on request", async () => {
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT,
+      spec: parseBinSpec({ gridX: 7, gridY: 2, heightUnits: 6 }),
+    });
+    const { container, unmount } = renderPage({ mobile: true });
+    await flushHydration();
+    const warnings = container.querySelector<HTMLElement>('[data-testid="canvas-warnings"]')!;
+    const toggle = warnings.querySelector<HTMLButtonElement>('button[aria-expanded]')!;
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(toggle.getAttribute('aria-label')).toContain('Expand');
+    expect(warnings.querySelector('[data-issue-code]')).toBeNull();
+    React.act(() => toggle.click());
+    expect(warnings.querySelector('[data-issue-code="large-footprint"]')).not.toBeNull();
+    expect(toggle.getAttribute('aria-label')).toContain('Collapse');
+    unmount();
+  });
+
+  it("shows live floor-color warnings only on the canvas, with a reminder at export", async () => {
     const shape = rectangularShape("tool", "Air Duster");
     vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
       ...EMPTY_PROJECT,
@@ -1009,7 +1082,9 @@ describe("BinDesignerPage", () => {
     expect(issue.textContent).toContain("Floor color may show on the underside");
     React.act(() => issue.click());
     expect(container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).toContain("Air Duster");
-    expect(container.querySelector('[data-testid="selected-object-issues"]')!.textContent).toContain("Floor color may show on the underside");
+    expect(issue.closest('[data-testid="bin-canvas"]')).not.toBeNull();
+    expect(container.querySelectorAll(issueSelector)).toHaveLength(1);
+    expect(container.querySelector('[data-testid="selected-object-issues"]')).toBeNull();
 
     const setNumber = (input: HTMLInputElement, value: string) => React.act(() => {
       Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, value);
@@ -1022,7 +1097,8 @@ describe("BinDesignerPage", () => {
     expect(container.querySelector(issueSelector)).not.toBeNull();
 
     React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="bin-settings-jump-materials"]')!.click());
-    expect(container.querySelector('[aria-label="Pocket floor color warnings"]')!.textContent).toContain("Air Duster");
+    expect(container.querySelector('[aria-label="Pocket floor color warnings"]')).toBeNull();
+    expect(container.querySelector('[data-testid="canvas-warnings"]')!.textContent).toContain("Air Duster");
     const thicknessInput = container.querySelector<HTMLInputElement>('[data-testid="input-pocket-floor-thickness"]')!;
     setNumber(thicknessInput, "0.4");
     expect(container.querySelector(issueSelector)).toBeNull();

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -237,6 +237,7 @@ function openSettingsSection(
   container: HTMLElement,
   section:
     | "project"
+    | "size"
     | "construction"
     | "materials"
     | "tool-cutouts"
@@ -333,6 +334,62 @@ describe("BinDesignerPage", () => {
     expect(editor.querySelector<HTMLDetailsElement>('[data-testid="pocket-depth-summary"]')!.open).toBe(false);
     expect(container.querySelector('[data-testid="button-layout-edit-pocket"]')).toBeNull();
     expect(pockets.getAttribute('data-state')).toBe('open');
+    expect(container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.disabled).toBe(true);
+    unmount();
+  });
+
+  it("keeps bin guidance behind help buttons while retaining dimensions and save status", async () => {
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "size");
+    const before = [...container.querySelectorAll<HTMLInputElement>('input[type="number"]')].map((input) => input.value);
+    expect(container.textContent).not.toContain("Pitch changes preserve");
+    expect(container.textContent).not.toContain("Snaps to");
+    expect(container.textContent).not.toContain("Adding tools keeps these dimensions");
+    expect(container.textContent).toContain("Outer size");
+    expect(container.querySelector('[data-testid="project-status"] [role="status"]')!.textContent).toMatch(/Sav(?:ed|ing) in this browser/);
+    for (const [name, explanation] of [
+      ["grid pitch", "Pitch changes preserve the outer size"],
+      ["width outer size", "Snaps to 21 mm grid increments"],
+      ["length outer size", "Snaps to 21 mm grid increments"],
+      ["keep bin size fixed", "Adding tools keeps these dimensions"],
+    ]) {
+      const help = container.querySelector<HTMLButtonElement>(`[aria-label="About ${name}"]`)!;
+      React.act(() => help.click());
+      expect(document.querySelector('[role="tooltip"]')!.textContent).toContain(explanation);
+      React.act(() => help.click());
+    }
+    expect([...container.querySelectorAll<HTMLInputElement>('input[type="number"]')].map((input) => input.value)).toEqual(before);
+    expect(container.querySelector('[aria-label="Keep bin size fixed"]')!.getAttribute('aria-checked')).toBe('false');
+    unmount();
+  });
+
+  it("centers zero clearance and makes inward adjustments undoable without scaling the trace", async () => {
+    const shape = rectangularShape("tool", "Wrench");
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT, shapes: [shape],
+      cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 } })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    selectPocket(container, "pocket");
+    const control = container.querySelector('[data-testid="pocket-clearance-settings"]')!;
+    const slider = control.querySelector<HTMLElement>('[role="slider"]')!;
+    expect(slider.getAttribute('aria-valuemin')).toBe('-2');
+    expect(slider.getAttribute('aria-valuemax')).toBe('2');
+    expect(slider.getAttribute('aria-valuenow')).toBe('0');
+    const input = control.querySelector<HTMLInputElement>('input')!;
+    React.act(() => {
+      input.focus();
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(input, '-0.5');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    React.act(() => input.blur());
+    expect(slider.getAttribute('aria-valuenow')).toBe('-0.5');
+    expect(container.querySelector<HTMLInputElement>('[aria-label="Pocket width in millimetres"]')!.value).toBe('29');
+    expect(container.querySelector<HTMLInputElement>('[aria-label="Pocket width scale percent"]')!.value).toBe('100');
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.click());
+    expect(input.value).toBe('0');
     expect(container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.disabled).toBe(true);
     unmount();
   });
@@ -438,16 +495,22 @@ describe("BinDesignerPage", () => {
     openSettingsSection(container, "tool-cutouts");
     selectPocket(container, "pocket");
     const edit = container.querySelector<HTMLButtonElement>('[data-testid="button-layout-edit-contour"]')!;
-    expect(edit.textContent).toBe("Edit Contour");
+    expect(edit.closest('[data-testid="layout-tool-toolbar"]')).not.toBeNull();
+    expect(edit.previousElementSibling?.getAttribute('data-testid')).toBe('button-layout-ruler');
+    expect(container.querySelector('[data-testid="button-edit-contour"]')!.closest('[data-testid="pocket-properties-heading"]')).not.toBeNull();
+    expect(edit.textContent).toBe("");
+    expect(edit.getAttribute("aria-label")).toBe("Edit contour");
     React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-layout-ruler"]')!.click());
     expect(container.querySelector('[data-testid="layout-ruler-status"]')).not.toBeNull();
     React.act(() => edit.click());
-    expect(edit.textContent).toBe("Finish contour editing");
+    expect(edit.getAttribute("aria-label")).toBe("Finish contour editing");
+    expect(edit.getAttribute("aria-pressed")).toBe("true");
     expect(container.querySelector('[data-testid="layout-ruler-status"]')).toBeNull();
     expect(container.querySelectorAll('[data-testid="contour-vertex-handle"]')).toHaveLength(4);
-    expect(container.querySelector('[data-testid="button-edit-contour"]')!.textContent).toContain("Finish contour editing");
+    expect(container.querySelector('[data-testid="button-edit-contour"]')!.getAttribute("aria-label")).toBe("Finish contour editing");
     React.act(() => edit.click());
-    expect(edit.textContent).toBe("Edit Contour");
+    expect(edit.textContent).toBe("");
+    expect(edit.getAttribute("aria-label")).toBe("Edit contour");
     expect(container.querySelector('[data-testid="contour-vertex-handle"]')).toBeNull();
     expect(container.querySelector('[data-testid="pocket-resize-handle-ne"]')).not.toBeNull();
     unmount();
@@ -1197,7 +1260,11 @@ describe("BinDesignerPage", () => {
     expect(floorThickness.max).toBe("3");
     expect(rimThickness.max).toBe("7.35");
     expect(container.textContent).toContain("mm down");
-    expect(container.textContent).toContain("never adds height to the bin");
+    expect(container.textContent).not.toContain("never adds height to the bin");
+    const thicknessHelp = container.querySelector<HTMLButtonElement>('[data-testid="view-color-row-floor"] [aria-label="About color thickness"]')!;
+    React.act(() => thicknessHelp.click());
+    expect(document.querySelector('[role="tooltip"]')!.textContent).toContain("never adds height to the bin");
+    React.act(() => thicknessHelp.click());
 
     React.act(() => {
       Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(
@@ -1287,7 +1354,11 @@ describe("BinDesignerPage", () => {
     await flushHydration();
 
     expect(status.textContent).toContain("Untitled project");
-    expect(status.textContent).toContain("draft resumes automatically");
+    expect(status.textContent).not.toContain("draft resumes automatically");
+    const autosaveHelp = status.querySelector<HTMLButtonElement>('[aria-label="About project autosave"]')!;
+    React.act(() => autosaveHelp.click());
+    expect(document.querySelector('[role="tooltip"]')!.textContent).toContain("draft resumes automatically");
+    React.act(() => autosaveHelp.click());
     expect(save.textContent).toContain("Save to library");
     expect(open.textContent).toContain("Open library");
     expect(fresh.textContent).toContain("New project");
@@ -1562,13 +1633,16 @@ describe("BinDesignerPage", () => {
     expect(text).toContain("Extra pocket clearance");
     expect(text).not.toContain("Added after the Trace margin");
     expect(container.querySelector('[aria-label="About extra pocket clearance"]')).not.toBeNull();
-    expect(text).toContain("Outline corners");
-    expect(text).toContain("Top edge");
-    expect(text).toContain("Bottom edge");
+    expect(text).toContain("Outline corner rounding");
+    expect(text).toContain("Top edge rounding");
+    expect(text).toContain("Bottom edge fillet");
     expect(text).toContain("Finger access");
     const pocketTopRound = container.querySelector(
-      '#pocket-properties [aria-label="Top edge"] [role="slider"]',
+      '#pocket-properties [aria-label="Top edge rounding"] [role="slider"]',
     );
+    expect([...container.querySelectorAll('[data-testid="pocket-edge-settings"] input')].map((input) => input.getAttribute('aria-label'))).toEqual([
+      'Top edge rounding in millimetres', 'Bottom edge fillet in millimetres', 'Outline corner rounding in millimetres',
+    ]);
     expect(pocketTopRound?.getAttribute("aria-valuemax")).toBe("5");
     expect(pocketTopRound?.getAttribute("aria-valuenow")).toBe("1");
     const renameButton = container.querySelector(
@@ -1700,7 +1774,7 @@ describe("BinDesignerPage", () => {
       '[data-testid="button-edit-contour"]',
     ) as HTMLButtonElement;
     React.act(() => editContour.click());
-    expect(editContour.textContent).toContain("Finish contour editing");
+    expect(editContour.getAttribute("aria-label")).toBe("Finish contour editing");
     expect(container.querySelector('[data-testid="layout-canvas"]')).not.toBeNull();
     expect(
       (container.querySelector(
@@ -1821,7 +1895,8 @@ describe("BinDesignerPage", () => {
     expect(text).toContain("8,400 triangles");
     expect(text).toContain("82.4 cm³ model volume");
     expect(text).not.toContain("g solid PLA");
-    expect(text).toContain("Estimate filament weight in your slicer");
+    expect(text).not.toContain("Estimate filament weight in your slicer");
+    expect(container.querySelector('[aria-label="About model validation"]')).not.toBeNull();
     expect(
       container.querySelector("#bin-settings-export [data-panel-section-trigger]")
         ?.textContent,

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { PanelProvider } from "@/components/layout/panel-context";
+import { PanelProvider, usePanelState } from "@/components/layout/panel-context";
 import { WORKSPACES } from "@/components/layout/workspaces";
 import * as ShapeLibraryModule from "@/state/shape-library";
 import { ShapeLibraryProvider } from "@/state/shape-library";
@@ -237,6 +237,7 @@ function openSettingsSection(
   section:
     | "project"
     | "construction"
+    | "materials"
     | "tool-cutouts"
     | "finger-holes"
     | "export"
@@ -245,7 +246,7 @@ function openSettingsSection(
   React.act(() => {
     (
       container.querySelector(
-        `[data-testid="bin-settings-jump-${section === "tool-cutouts" ? "arrange" : section === "finger-holes" ? "finger-access" : section}"]`,
+        `[data-testid="bin-settings-jump-${section === "tool-cutouts" ? "pockets" : section === "finger-holes" ? "finger-access" : section}"]`,
       ) as HTMLButtonElement
     ).click();
   });
@@ -272,7 +273,7 @@ describe("BinDesignerPage", () => {
     expect(secondButton.textContent).toContain("Edit properties");
     React.act(() => secondButton.querySelector("span")!.click());
     expect(secondButton.getAttribute("aria-pressed")).toBe("true");
-    expect(secondButton.textContent).toContain("Properties shown below");
+    expect(secondButton.textContent).toContain("Editing this pocket");
     expect(container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).toContain("Pliers");
     expect(container.querySelector<HTMLInputElement>('[aria-label="Pocket cut depth in millimetres"]')!.value).toBe("20");
     React.act(() => firstButton.click());
@@ -287,6 +288,112 @@ describe("BinDesignerPage", () => {
     expect(container.querySelector<HTMLInputElement>('[data-testid="input-shape-name"]')!.value).toBe("Wrench");
     unmount();
   });
+
+  it("keeps everyday properties outside the pocket list and returns to them from Layout", async () => {
+    const shape = rectangularShape("tool", "Wrench");
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT, shapes: [shape],
+      cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 } })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "tool-cutouts");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click());
+    const editor = container.querySelector<HTMLElement>('#pocket-properties')!;
+    const scroller = editor.parentElement!;
+    expect(scroller.firstElementChild).toBe(editor);
+    expect(editor.closest('#bin-settings-pockets')).toBeNull();
+    for (const label of ["Pocket width in millimetres", "Pocket length in millimetres", "Pocket depth mode"]) {
+      expect(editor.querySelector(`[aria-label="${label}"]`)!.closest("details")).toBeNull();
+    }
+    expect(editor.querySelector<HTMLDetailsElement>('[data-testid="pocket-more-settings"]')!.open).toBe(false);
+    openSettingsSection(container, "materials");
+    expect(container.querySelector('#bin-settings-pockets')!.getAttribute('data-state')).toBe('closed');
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="view-toggle-2d"]')!.click());
+    scroller.scrollTop = 700;
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-layout-edit-pocket"]')!.click());
+    await React.act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+    expect(scroller.scrollTop).toBe(0);
+    expect(editor.textContent).toContain('Wrench');
+    expect(container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.disabled).toBe(true);
+    unmount();
+  });
+
+  it("edits physical dimensions with linked proportions and undoes the committed value once", async () => {
+    const shape = rectangularShape("tool", "Wrench");
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT, shapes: [shape],
+      cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 } })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "tool-cutouts");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click());
+    const width = container.querySelector<HTMLInputElement>('[aria-label="Pocket width in millimetres"]')!;
+    const length = container.querySelector<HTMLInputElement>('[aria-label="Pocket length in millimetres"]')!;
+    React.act(() => {
+      width.focus();
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(width, '40');
+      width.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    React.act(() => width.blur());
+    expect(width.value).toBe('40');
+    expect(length.value).toBe('26.67');
+    const undo = container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!;
+    React.act(() => undo.click());
+    expect(width.value).toBe('30');
+    expect(length.value).toBe('20');
+    expect(undo.disabled).toBe(true);
+    unmount();
+  });
+
+  it.each(["tap", "jitter", "drag", "cancel"] as const)(
+    "%s on a pocket distinguishes editing from placement and leaves meaningful undo history",
+    async (gesture) => {
+      const shape = rectangularShape("tool", "Wrench");
+      vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+        ...EMPTY_PROJECT, shapes: [shape],
+        cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 1.25, y: 0 } })],
+      });
+      let controls: ReturnType<typeof usePanelState>;
+      function PanelProbe() { controls = usePanelState(); return null; }
+      const { container, unmount } = render(
+        <PanelProvider><PanelProbe /><ShapeLibraryProvider><BinDesignerPage /></ShapeLibraryProvider></PanelProvider>,
+      );
+      await flushHydration();
+      React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="view-toggle-2d"]')!.click());
+      React.act(() => controls.setPanelOpen(false));
+      const svg = container.querySelector<SVGSVGElement>('[data-testid="layout-canvas"]')!;
+      const scene = svg.querySelector('g')!;
+      const pocket = svg.querySelector('[data-cutout-id="pocket"]')!;
+      const before = pocket.getAttribute('d');
+      // jsdom lacks SVG coordinate mapping and pointer capture. Identity mapping
+      // gives a 1 px/mm canvas, with the 83.5 mm bin centred at (41.75, 41.75).
+      Object.defineProperty(scene, 'getScreenCTM', { value: () => ({ inverse: () => ({}) }) });
+      Object.defineProperties(svg, {
+        createSVGPoint: { value: () => ({ x: 0, y: 0, matrixTransform() { return { x: this.x, y: this.y }; } }) },
+        setPointerCapture: { value: () => {} },
+      });
+      const pointer = (type: string, x: number) => React.act(() => {
+        const event = new MouseEvent(type, { bubbles: true, button: 0, clientX: x, clientY: 41.75, altKey: true });
+        Object.defineProperty(event, 'pointerId', { value: 1 });
+        pocket.dispatchEvent(event);
+      });
+      pointer('pointerdown', 43);
+      if (gesture === 'drag') pointer('pointermove', 55);
+      if (gesture === 'jitter') pointer('pointermove', 44);
+      pointer(gesture === 'cancel' ? 'pointercancel' : 'pointerup', gesture === 'drag' ? 55 : gesture === 'jitter' ? 44 : 43);
+      expect(controls!.panelOpen).toBe(gesture === 'tap' || gesture === 'jitter');
+      const undo = container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!;
+      expect(undo.disabled).toBe(gesture !== 'drag');
+      if (gesture === 'drag') {
+        expect(pocket.getAttribute('d')).not.toBe(before);
+        React.act(() => undo.click());
+      }
+      expect(pocket.getAttribute('d')).toBe(before);
+      unmount();
+    },
+  );
 
   it("edits and finishes a selected contour directly in Layout, including after using the ruler", async () => {
     const shape = rectangularShape("tool", "Wrench");
@@ -771,7 +878,7 @@ describe("BinDesignerPage", () => {
     const { container, unmount } = renderPage();
     const index = container.querySelector('[data-testid="bin-settings-index"]');
     expect(index?.textContent).toContain("Find a setting");
-    expect(index?.textContent).toContain("Arrange");
+    expect(index?.textContent).toContain("Pockets");
     expect(index?.textContent).not.toContain("Color by purpose");
 
     const expectedSections = [
@@ -1296,7 +1403,7 @@ describe("BinDesignerPage", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("test wrench");
     expect(text).toContain("Fit bin to contents");
-    expect(text).toContain("Choose a pocket below to edit its size, depth, and shape.");
+    expect(text).toContain("Click a pocket in Layout or choose one below to edit its properties.");
     expect(text).toContain("Pocket properties");
     // Selected-pocket controls appear for the auto-selected cutout.
     expect(text).not.toContain("Editing selected tool");
@@ -1358,7 +1465,7 @@ describe("BinDesignerPage", () => {
       '[data-testid="button-edit-shape-name"]',
     ) as HTMLButtonElement;
     expect(renameButton.closest('[data-testid="pocket-properties-heading"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid^="button-select-"][aria-pressed="true"]')?.textContent).toContain("Properties shown below");
+    expect(container.querySelector('[data-testid^="button-select-"][aria-pressed="true"]')?.textContent).toContain("Editing this pocket");
     React.act(() => renameButton.click());
     const shapeName = container.querySelector(
       '[data-testid="input-shape-name"]',

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -707,6 +707,41 @@ describe("BinDesignerPage", () => {
     unmount();
   });
 
+  it("switches a 3 by 5 bin to quarter pitch and edits beyond 16 small cells", async () => {
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT,
+      spec: parseBinSpec({ gridX: 6, gridY: 10, gridPitch: "half", heightUnits: 5.5 }),
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    try {
+      const trigger = container.querySelector<HTMLButtonElement>('[data-testid="select-grid-pitch"]')!;
+      React.act(() => trigger.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true })));
+      const option = Array.from(document.querySelectorAll<HTMLElement>('[role="option"]')).find((node) => node.textContent === "Quarter · 10.5 mm")!;
+      expect(option).toBeDefined();
+      expect(option.getAttribute("aria-disabled")).not.toBe("true");
+      React.act(() => option.click());
+      const size = container.querySelector("#bin-settings-size")!;
+      expect(size.textContent).toContain("3 × 5 × 5.5u");
+      expect(size.textContent).toContain("240 of 240 quarter-pitch cells occupied");
+      const input = (label: string) => container.querySelector<HTMLInputElement>(`[aria-label="${label}"]`)!;
+      expect(input("Width outer size in millimetres").value).toBe("125.5");
+      expect(input("Length outer size in millimetres").value).toBe("209.5");
+
+      const length = input("Length in standard cells");
+      React.act(() => {
+        Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(length, "5.25");
+        length.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      React.act(() => length.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+      expect(size.textContent).toContain("3 × 5.25 × 5.5u");
+      expect(size.textContent).toContain("252 of 252 quarter-pitch cells occupied");
+      expect(input("Length outer size in millimetres").value).toBe("220");
+    } finally {
+      unmount();
+    }
+  });
+
   it("sets width, length, and height in half-unit increments", async () => {
     const { container, unmount } = renderPage();
     await flushHydration();

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -253,13 +253,17 @@ function openSettingsSection(
   });
 }
 
+/** Use the compact pocket list without entering rename or changing geometry. */
+function selectPocket(container: HTMLElement, id: string): void {
+  React.act(() => container.querySelector<HTMLButtonElement>(`[data-testid="button-select-${id}"]`)!.click());
+}
+
 describe("BinDesignerPage", () => {
-  it("opens the requested pocket's properties from its row and keeps selection separate from renaming", async () => {
+  it("switches pockets in their fixed section without changing section order or entering rename", async () => {
     const first = rectangularShape("first-shape", "Wrench");
     const second = rectangularShape("second-shape", "Pliers");
     vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
-      ...EMPTY_PROJECT,
-      shapes: [first, second],
+      ...EMPTY_PROJECT, shapes: [first, second],
       cutouts: [
         parseCutoutPlacement({ id: "first-pocket", shapeId: first.id, position: { x: -20, y: 0 }, depth: { mode: "mm", value: 10 } }),
         parseCutoutPlacement({ id: "second-pocket", shapeId: second.id, position: { x: 20, y: 0 }, depth: { mode: "mm", value: 20 } }),
@@ -267,55 +271,68 @@ describe("BinDesignerPage", () => {
     });
     const { container, unmount } = renderPage();
     await flushHydration();
-    openSettingsSection(container, "tool-cutouts");
-    const firstButton = container.querySelector<HTMLButtonElement>('[data-testid="button-select-first-pocket"]')!;
-    const secondButton = container.querySelector<HTMLButtonElement>('[data-testid="button-select-second-pocket"]')!;
-    expect(firstButton.getAttribute("aria-pressed")).toBe("false");
-    expect(secondButton.textContent).toContain("Edit properties");
-    React.act(() => secondButton.querySelector("span")!.click());
-    expect(secondButton.getAttribute("aria-pressed")).toBe("true");
-    expect(secondButton.textContent).toContain("Editing this pocket");
+    const pockets = container.querySelector<HTMLElement>('#bin-settings-pockets')!;
+    const scroller = pockets.parentElement!;
+    const sections = Array.from(scroller.children);
+    expect(pockets.querySelector('[data-testid="pocket-selection-help"]')!.textContent).toContain('Select a pocket');
+    scroller.scrollTop = 240;
+    selectPocket(container, "second-pocket");
     expect(container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).toContain("Pliers");
     expect(container.querySelector<HTMLInputElement>('[aria-label="Pocket cut depth in millimetres"]')!.value).toBe("20");
-    React.act(() => firstButton.click());
-    expect(firstButton.getAttribute("aria-pressed")).toBe("true");
-    expect(secondButton.getAttribute("aria-pressed")).toBe("false");
+    const editor = container.querySelector<HTMLElement>('#pocket-properties')!;
+    const edges = editor.querySelector<HTMLDetailsElement>('[data-testid="pocket-edge-settings"]')!;
+    React.act(() => edges.querySelector('summary')!.click());
+    selectPocket(container, "first-pocket");
+    await React.act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+    expect(Array.from(scroller.children)).toEqual(sections);
+    expect(container.querySelector('#pocket-properties')).toBe(editor);
+    expect(edges.open).toBe(true);
     expect(container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).toContain("Wrench");
     expect(container.querySelector<HTMLInputElement>('[aria-label="Pocket cut depth in millimetres"]')!.value).toBe("10");
-    React.act(() => firstButton.click());
     expect(container.querySelector('[data-testid="input-shape-name"]')).toBeNull();
     expect(container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.disabled).toBe(true);
-    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-edit-shape-name"]')!.click());
-    expect(container.querySelector<HTMLInputElement>('[data-testid="input-shape-name"]')!.value).toBe("Wrench");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-rename-second-pocket"]')!.click());
+    const name = container.querySelector<HTMLInputElement>('[data-testid="input-shape-name"]')!;
+    expect(name.value).toBe("Pliers");
+    expect(document.activeElement).toBe(name);
+    expect(container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).toContain("Pliers");
+    React.act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(name, 'Discard this name');
+      name.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    React.act(() => name.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })));
+    expect(container.querySelector('[data-testid="input-shape-name"]')).toBeNull();
+    expect(container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).toContain("Pliers");
     unmount();
   });
 
-  it("keeps everyday properties outside the pocket list and returns to them from Layout", async () => {
+  it("keeps depth first and the size, scale, and other optional settings collapsed, and opens Pockets on selection", async () => {
     const shape = rectangularShape("tool", "Wrench");
     vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
       ...EMPTY_PROJECT, shapes: [shape],
-      cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 } })],
+      cutouts: [parseCutoutPlacement({ id: "pocket", shapeId: shape.id, position: { x: 0, y: 0 }, depth: { mode: "mm", value: 12 } })],
     });
     const { container, unmount } = renderPage();
     await flushHydration();
-    openSettingsSection(container, "tool-cutouts");
-    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click());
+    selectPocket(container, "pocket");
     const editor = container.querySelector<HTMLElement>('#pocket-properties')!;
-    const scroller = editor.parentElement!;
-    expect(scroller.firstElementChild).toBe(editor);
-    expect(editor.closest('#bin-settings-pockets')).toBeNull();
-    for (const label of ["Pocket width in millimetres", "Pocket length in millimetres", "Pocket depth mode"]) {
-      expect(editor.querySelector(`[aria-label="${label}"]`)!.closest("details")).toBeNull();
+    const pockets = container.querySelector<HTMLElement>('#bin-settings-pockets')!;
+    const scroller = pockets.parentElement!;
+    expect(editor.closest('#bin-settings-pockets')).toBe(pockets);
+    const primaryFields = editor.querySelectorAll<HTMLInputElement>('input[type="number"]');
+    expect(primaryFields[0].getAttribute('aria-label')).toBe('Pocket cut depth in millimetres');
+    const size = editor.querySelector('[aria-label="Pocket size and scale"]')!;
+    for (const label of ["Pocket width in millimetres", "Pocket length in millimetres", "Pocket width scale percent", "Pocket length scale percent"]) {
+      expect(size.querySelector(`[aria-label="${label}"]`)!.closest('details')).toBe(size);
     }
-    expect(editor.querySelector<HTMLDetailsElement>('[data-testid="pocket-more-settings"]')!.open).toBe(false);
-    openSettingsSection(container, "materials");
-    expect(container.querySelector('#bin-settings-pockets')!.getAttribute('data-state')).toBe('closed');
-    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="view-toggle-2d"]')!.click());
-    scroller.scrollTop = 700;
-    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-layout-edit-pocket"]')!.click());
-    await React.act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
-    expect(scroller.scrollTop).toBe(0);
-    expect(editor.textContent).toContain('Wrench');
+    for (const id of ['pocket-size-settings', 'pocket-clearance-settings', 'pocket-edge-settings', 'pocket-position-settings']) {
+      expect(editor.querySelector<HTMLDetailsElement>(`[data-testid="${id}"]`)!.open).toBe(false);
+    }
+    expect(editor.querySelector('[aria-label="Extra pocket clearance in millimetres"]')!.closest('details')!.dataset.testid).toBe('pocket-clearance-settings');
+    expect(editor.querySelector('[data-testid="button-inspect-pocket"]')!.closest('details')!.dataset.testid).toBe('pocket-depth-summary');
+    expect(editor.querySelector<HTMLDetailsElement>('[data-testid="pocket-depth-summary"]')!.open).toBe(false);
+    expect(container.querySelector('[data-testid="button-layout-edit-pocket"]')).toBeNull();
+    expect(pockets.getAttribute('data-state')).toBe('open');
     expect(container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.disabled).toBe(true);
     unmount();
   });
@@ -329,7 +346,7 @@ describe("BinDesignerPage", () => {
     const { container, unmount } = renderPage();
     await flushHydration();
     openSettingsSection(container, "tool-cutouts");
-    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click());
+    selectPocket(container, "pocket");
     const width = container.querySelector<HTMLInputElement>('[aria-label="Pocket width in millimetres"]')!;
     const length = container.querySelector<HTMLInputElement>('[aria-label="Pocket length in millimetres"]')!;
     React.act(() => {
@@ -349,7 +366,7 @@ describe("BinDesignerPage", () => {
   });
 
   it.each(["tap", "jitter", "drag", "cancel"] as const)(
-    "%s on a pocket distinguishes editing from placement and leaves meaningful undo history",
+    "%s on a pocket opens its fixed settings only for a click and leaves meaningful undo history",
     async (gesture) => {
       const shape = rectangularShape("tool", "Wrench");
       vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
@@ -360,8 +377,15 @@ describe("BinDesignerPage", () => {
       function PanelProbe() { controls = usePanelState(); return null; }
       const { container, unmount } = render(
         <PanelProvider><PanelProbe /><ShapeLibraryProvider><BinDesignerPage /></ShapeLibraryProvider></PanelProvider>,
+        { mobile: gesture === 'tap' },
       );
       await flushHydration();
+      // Start from another section with this pocket already selected: clicking
+      // it again must still return to its settings.
+      if (gesture !== 'tap') {
+        selectPocket(container, "pocket");
+        openSettingsSection(container, "materials");
+      }
       React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="view-toggle-2d"]')!.click());
       React.act(() => controls.setPanelOpen(false));
       const svg = container.querySelector<SVGSVGElement>('[data-testid="layout-canvas"]')!;
@@ -385,6 +409,11 @@ describe("BinDesignerPage", () => {
       if (gesture === 'jitter') pointer('pointermove', 44);
       pointer(gesture === 'cancel' ? 'pointercancel' : 'pointerup', gesture === 'drag' ? 55 : gesture === 'jitter' ? 44 : 43);
       expect(controls!.panelOpen).toBe(gesture === 'tap' || gesture === 'jitter');
+      if (gesture === 'tap' || gesture === 'jitter') {
+        expect(document.querySelector('#bin-settings-pockets')!.getAttribute('data-state')).toBe('open');
+        expect(document.querySelector('[data-testid="pocket-properties-heading"]')!.textContent).toContain('Wrench');
+      }
+      expect(container.querySelector('[data-testid="button-layout-edit-pocket"]')).toBeNull();
       const undo = container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!;
       expect(undo.disabled).toBe(gesture !== 'drag');
       if (gesture === 'drag') {
@@ -407,7 +436,7 @@ describe("BinDesignerPage", () => {
     React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="view-toggle-2d"]')!.click());
     expect(container.querySelector('[data-testid="button-layout-edit-contour"]')).toBeNull();
     openSettingsSection(container, "tool-cutouts");
-    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click());
+    selectPocket(container, "pocket");
     const edit = container.querySelector<HTMLButtonElement>('[data-testid="button-layout-edit-contour"]')!;
     expect(edit.textContent).toBe("Edit Contour");
     React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-layout-ruler"]')!.click());
@@ -456,7 +485,7 @@ describe("BinDesignerPage", () => {
       await flushHydration();
       openSettingsSection(container, "tool-cutouts");
       React.act(() => {
-        container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click();
+        selectPocket(container, "pocket");
         container.querySelector<HTMLButtonElement>('[data-testid="view-toggle-2d"]')!.click();
       });
       const precision = container.querySelector<HTMLDetailsElement>('[aria-label="X position in millimetres"]')!.closest("details")!;
@@ -518,7 +547,7 @@ describe("BinDesignerPage", () => {
       if (kind === "fit-check") {
         openSettingsSection(container, "tool-cutouts");
         React.act(() => {
-          container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click();
+          selectPocket(container, "pocket");
         });
       }
       openSettingsSection(container, kind === "surface-fit-test" || kind === "fit-check" || kind.startsWith("layout-") ? "check-fit" : "export");
@@ -982,7 +1011,7 @@ describe("BinDesignerPage", () => {
     const { container, unmount } = renderPage();
     await flushHydration();
     openSettingsSection(container, "tool-cutouts");
-    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-pocket"]')!.click());
+    selectPocket(container, "pocket");
     const trigger = container.querySelector<HTMLButtonElement>('[aria-label="Pocket depth mode"]')!;
     React.act(() => trigger.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true })));
     const option = Array.from(document.querySelectorAll<HTMLElement>('[role="option"]')).find((node) => node.textContent?.includes("Keep floor thickness"))!;
@@ -1405,6 +1434,7 @@ describe("BinDesignerPage", () => {
     );
     expect(container.textContent).toContain("saved wrench");
 
+    openSettingsSection(container, "project");
     React.act(() => {
       (
         container.querySelector(
@@ -1416,7 +1446,7 @@ describe("BinDesignerPage", () => {
       '[data-testid="button-confirm-new-project"]',
     ) as HTMLButtonElement | null;
     expect(confirm).not.toBeNull();
-    expect(container.textContent).toContain("saved wrench");
+    expect(libraryHandle!.shapes.some((shape) => shape.name === "saved wrench")).toBe(true);
 
     await React.act(async () => {
       confirm!.click();
@@ -1482,9 +1512,8 @@ describe("BinDesignerPage", () => {
 
     const text = container.textContent ?? "";
     expect(text).toContain("test wrench");
-    expect(text).toContain("Fit bin to contents");
-    expect(text).toContain("Click a pocket in Layout or choose one below to edit its properties.");
-    expect(text).toContain("Pocket properties");
+    expect(container.querySelector('[aria-label="Choose a pocket to edit"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Selected pocket properties"]')).not.toBeNull();
     // Selected-pocket controls appear for the auto-selected cutout.
     expect(text).not.toContain("Editing selected tool");
     expect(text).toContain("Rotation");
@@ -1531,21 +1560,22 @@ describe("BinDesignerPage", () => {
     expect(widthScale.value).toBe("100");
     expect(heightScale.value).toBe("100");
     expect(text).toContain("Extra pocket clearance");
-    expect(text).toContain("Added after the Trace margin");
-    expect(text).toContain("Outline corner round");
-    expect(text).toContain("Top edge round");
-    expect(text).toContain("Bottom fillet");
+    expect(text).not.toContain("Added after the Trace margin");
+    expect(container.querySelector('[aria-label="About extra pocket clearance"]')).not.toBeNull();
+    expect(text).toContain("Outline corners");
+    expect(text).toContain("Top edge");
+    expect(text).toContain("Bottom edge");
     expect(text).toContain("Finger access");
     const pocketTopRound = container.querySelector(
-      '[aria-label="Top edge round"] [role="slider"]',
+      '#pocket-properties [aria-label="Top edge"] [role="slider"]',
     );
     expect(pocketTopRound?.getAttribute("aria-valuemax")).toBe("5");
     expect(pocketTopRound?.getAttribute("aria-valuenow")).toBe("1");
     const renameButton = container.querySelector(
-      '[data-testid="button-edit-shape-name"]',
+      '[data-testid^="button-rename-"]',
     ) as HTMLButtonElement;
-    expect(renameButton.closest('[data-testid="pocket-properties-heading"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid^="button-select-"][aria-pressed="true"]')?.textContent).toContain("Editing this pocket");
+    expect(renameButton.closest('[data-testid^="cutout-row-"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid^="button-select-"][aria-pressed="true"]')!.textContent).toContain("test wrench");
     React.act(() => renameButton.click());
     const shapeName = container.querySelector(
       '[data-testid="input-shape-name"]',
@@ -1647,11 +1677,7 @@ describe("BinDesignerPage", () => {
 
     // Selecting the pocket again is independent and exposes contour editing.
     openSettingsSection(container, "tool-cutouts");
-    React.act(() => {
-      (
-        container.querySelector('[data-testid^="button-select-"]') as HTMLButtonElement
-      ).click();
-    });
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid^="button-select-"]')!.click());
     expect(
       container.querySelectorAll('[data-testid^="pocket-resize-handle-"]'),
     ).toHaveLength(8);
@@ -1765,12 +1791,7 @@ describe("BinDesignerPage", () => {
         twoCellSize.includes(label),
       ),
     ).toBe(true);
-    const removeButtons = container.querySelectorAll<HTMLButtonElement>(
-      '[data-testid^="button-remove-"]',
-    );
-    expect(removeButtons).toHaveLength(2);
-
-    React.act(() => removeButtons[0].click());
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid^="button-remove-"]')!.click());
     expect(document.body.textContent).toContain(
       "Resize the bin after removing “first part”?",
     );

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -1003,10 +1003,12 @@ describe("BinDesignerPage", () => {
     await flushHydration();
     const warnings = container.querySelector<HTMLElement>('[data-testid="canvas-warnings"]')!;
     expect(warnings.closest('[data-testid="bin-canvas"]')).not.toBeNull();
+    const toggle = warnings.querySelector<HTMLButtonElement>('button[aria-expanded]')!;
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    React.act(() => toggle.click());
     const issue = warnings.querySelector<HTMLButtonElement>('[data-issue-code="out-of-bounds"]')!;
     expect(issue).not.toBeNull();
     expect(container.querySelectorAll('[data-issue-code="out-of-bounds"]')).toHaveLength(1);
-    const toggle = warnings.querySelector<HTMLButtonElement>('button[aria-expanded]')!;
     expect(toggle.textContent).toContain('error');
     React.act(() => toggle.click());
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
@@ -1035,6 +1037,7 @@ describe("BinDesignerPage", () => {
     });
     const { container, unmount } = renderPage();
     await flushHydration();
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="canvas-warnings"] button[aria-expanded]')!.click());
     const issue = container.querySelector<HTMLButtonElement>('[data-testid="canvas-warnings"] [data-issue-code="cutout-overlap"]')!;
     React.act(() => issue.click());
     const firstName = container.querySelector('[data-testid="pocket-properties-heading"]')!.textContent;
@@ -1046,12 +1049,12 @@ describe("BinDesignerPage", () => {
     unmount();
   });
 
-  it("starts mobile warnings as a compact count and expands the messages on request", async () => {
+  it.each([false, true])("starts warnings as a compact count and expands the messages on request (mobile: %s)", async (mobile) => {
     vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
       ...EMPTY_PROJECT,
       spec: parseBinSpec({ gridX: 7, gridY: 2, heightUnits: 6 }),
     });
-    const { container, unmount } = renderPage({ mobile: true });
+    const { container, unmount } = renderPage({ mobile });
     await flushHydration();
     const warnings = container.querySelector<HTMLElement>('[data-testid="canvas-warnings"]')!;
     const toggle = warnings.querySelector<HTMLButtonElement>('button[aria-expanded]')!;
@@ -1076,6 +1079,7 @@ describe("BinDesignerPage", () => {
     const { container, unmount } = renderPage();
     await flushHydration();
     openSettingsSection(container, "export");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="canvas-warnings"] button[aria-expanded]')!.click());
     const issueSelector = '[data-issue-code="floor-color-on-underside"]';
     const issue = container.querySelector<HTMLButtonElement>(issueSelector)!;
     expect(issue.textContent).toContain("Air Duster");

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -350,8 +350,8 @@ describe("BinDesignerPage", () => {
     expect(container.querySelector('[data-testid="project-status"] [role="status"]')!.textContent).toMatch(/Sav(?:ed|ing) in this browser/);
     for (const [name, explanation] of [
       ["grid pitch", "Pitch changes preserve the outer size"],
-      ["width outer size", "Snaps to 21 mm grid increments"],
-      ["length outer size", "Snaps to 21 mm grid increments"],
+      ["width", "Snaps to 21 mm grid increments"],
+      ["length", "Snaps to 21 mm grid increments"],
       ["keep bin size fixed", "Adding tools keeps these dimensions"],
     ]) {
       const help = container.querySelector<HTMLButtonElement>(`[aria-label="About ${name}"]`)!;
@@ -723,19 +723,20 @@ describe("BinDesignerPage", () => {
       React.act(() => option.click());
       const size = container.querySelector("#bin-settings-size")!;
       expect(size.textContent).toContain("3 × 5 × 5.5u");
-      expect(size.textContent).toContain("240 of 240 quarter-pitch cells occupied");
+      expect(vi.mocked(useBinGeometry).mock.lastCall![0]).toMatchObject({ gridX: 12, gridY: 20, gridPitch: "quarter" });
       const input = (label: string) => container.querySelector<HTMLInputElement>(`[aria-label="${label}"]`)!;
       expect(input("Width outer size in millimetres").value).toBe("125.5");
       expect(input("Length outer size in millimetres").value).toBe("209.5");
 
       const length = input("Length in standard cells");
+      React.act(() => length.focus());
       React.act(() => {
         Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(length, "5.25");
         length.dispatchEvent(new Event("input", { bubbles: true }));
       });
       React.act(() => length.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
       expect(size.textContent).toContain("3 × 5.25 × 5.5u");
-      expect(size.textContent).toContain("252 of 252 quarter-pitch cells occupied");
+      expect(vi.mocked(useBinGeometry).mock.lastCall![0]).toMatchObject({ gridX: 12, gridY: 21, gridPitch: "quarter" });
       expect(input("Length outer size in millimetres").value).toBe("220");
     } finally {
       unmount();
@@ -814,8 +815,8 @@ describe("BinDesignerPage", () => {
     });
     const { container, unmount } = renderPage();
     await flushHydration();
-    expect(container.querySelector('[data-testid="bin-footprint-summary"]')?.textContent)
-      .toContain("3 of 4 full-pitch cells occupied · custom footprint");
+    expect(container.querySelector("#bin-settings-size")?.textContent)
+      .toContain("Custom footprint. Add or remove cells in the Layout view");
     const edit = container.querySelector('[data-testid="button-edit-footprint"]') as HTMLButtonElement;
     React.act(() => edit.click());
     expect(container.querySelector('[data-testid="layout-canvas"]')).not.toBeNull();

--- a/client/src/pages/bin-designer.tsx
+++ b/client/src/pages/bin-designer.tsx
@@ -87,6 +87,11 @@ export default function BinDesignerPage(): JSX.Element {
 
 function BinDesignerWorkspace(): JSX.Element {
   const { panelOpen, setPanelOpen } = usePanelState();
+  const [pocketEditorRequest, setPocketEditorRequest] = useState(0);
+  const editSelectedPocket = () => {
+    setPanelOpen(true);
+    setPocketEditorRequest((request) => request + 1);
+  };
   const { toast } = useToast();
   const bin = useBin();
   const { spec, cutouts, fingerHoles, viewMode, dispatch } = bin;
@@ -828,6 +833,7 @@ function BinDesignerWorkspace(): JSX.Element {
       panelTitle="Bin designer"
       panel={
         <BinControlsPanel
+          pocketEditorRequest={pocketEditorRequest}
           saveStatus={saveStatus}
           keepBinSize={keepBinSize}
           onKeepBinSizeChange={setKeepBinSize}
@@ -895,7 +901,7 @@ function BinDesignerWorkspace(): JSX.Element {
               measurementPlaneZMm={builtDimensions.heightToRimMm}
             />
           ) : (
-            <LayoutCanvas />
+            <LayoutCanvas onEditPocket={editSelectedPocket} />
           )}
           <ViewToggle
             viewMode={viewMode}

--- a/client/src/pages/bin-designer.tsx
+++ b/client/src/pages/bin-designer.tsx
@@ -362,7 +362,7 @@ function BinDesignerWorkspace(): JSX.Element {
         );
         toast({
           title: "Pocket vanished",
-          description: `“${shape?.name ?? "A pocket"}” collapsed under its clearance/corner settings — reduce corner rounding.`,
+          description: `“${shape?.name ?? "A pocket"}” collapsed under its clearance/corner settings — increase clearance toward zero or reduce outline corner rounding.`,
           variant: "destructive",
         });
       }

--- a/client/src/pages/bin-designer.tsx
+++ b/client/src/pages/bin-designer.tsx
@@ -1,6 +1,8 @@
 import { Box, History, Redo2, Undo2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { CanvasWarnings } from "@/components/gridfinity/canvas-warnings";
+import { validateBinSpec, validateLayout, validatePocketFloorMaterials, type ValidationIssue } from "@shared/gridfinity/validate";
 import { BinControlsPanel } from "@/components/gridfinity/bin-controls-panel";
 import { BinViewport } from "@/components/gridfinity/bin-viewport";
 import { LayoutCanvas } from "@/components/gridfinity/layout-canvas";
@@ -88,7 +90,9 @@ export default function BinDesignerPage(): JSX.Element {
 function BinDesignerWorkspace(): JSX.Element {
   const { panelOpen, setPanelOpen } = usePanelState();
   const [pocketEditorRequest, setPocketEditorRequest] = useState(0);
+  const [settingsSectionRequest, setSettingsSectionRequest] = useState<{ id: string }>();
   const editSelectedPocket = () => {
+    setSettingsSectionRequest(undefined);
     setPanelOpen(true);
     setPocketEditorRequest((request) => request + 1);
   };
@@ -126,6 +130,33 @@ function BinDesignerWorkspace(): JSX.Element {
   const [saveStatus, setSaveStatus] = useState<"saving" | "saved" | "error">("saving");
   const [draftName, setDraftName] = useState<string | null>(null);
   const [keepBinSize, setKeepBinSize] = useState(false);
+
+  // One validation result drives both the canvas feedback and export gates,
+  // including when the controls are collapsed or the mobile drawer is closed.
+  const issues = useMemo(() => {
+    const shapesById = new Map(library.shapes.map((shape) => [shape.id, shape]));
+    return [
+      ...validateBinSpec(spec).issues,
+      ...validateLayout(spec, cutouts, shapesById, fingerHoles),
+      ...validatePocketFloorMaterials(spec, cutouts, shapesById, colorPocketFloors ? pocketFloorThicknessMm : 0),
+    ];
+  }, [spec, cutouts, fingerHoles, library.shapes, colorPocketFloors, pocketFloorThicknessMm]);
+  const revealIssue = (issue: ValidationIssue) => {
+    dispatch({ type: "SET_VIEW_MODE", viewMode: "2d" });
+    if (issue.cutoutIds?.length) {
+      const next = issue.cutoutIds.find((id) => id !== bin.selectedCutoutId) ?? issue.cutoutIds[0];
+      dispatch({ type: "SELECT_CUTOUT", id: next });
+      editSelectedPocket();
+    } else {
+      setPanelOpen(true);
+      if (issue.fingerHoleIds?.length) {
+        dispatch({ type: "SELECT_FINGER_HOLE", id: issue.fingerHoleIds[0] });
+        setSettingsSectionRequest({ id: "bin-settings-finger-holes" });
+      } else {
+        setSettingsSectionRequest({ id: "bin-settings-size" });
+      }
+    }
+  };
 
   // Restore the saved project before anything else touches state; pending
   // consumption below is gated on `hydrated` so an arrival from the trace
@@ -833,6 +864,8 @@ function BinDesignerWorkspace(): JSX.Element {
       panelTitle="Bin designer"
       panel={
         <BinControlsPanel
+          issues={issues}
+          settingsSectionRequest={settingsSectionRequest}
           pocketEditorRequest={pocketEditorRequest}
           saveStatus={saveStatus}
           keepBinSize={keepBinSize}
@@ -880,7 +913,13 @@ function BinDesignerWorkspace(): JSX.Element {
         />
       }
       canvas={
-        <div className="absolute inset-0">
+        <div className="absolute inset-0" data-testid="bin-canvas">
+          <CanvasWarnings
+            issues={issues}
+            selectedCutoutId={bin.selectedCutoutId}
+            selectedFingerHoleId={bin.selectedFingerHoleId}
+            onRevealIssue={revealIssue}
+          />
           {viewMode === "3d" ? (
             <BinViewport
               geometry={geometry}

--- a/docs/gridfinity-plan.md
+++ b/docs/gridfinity-plan.md
@@ -343,7 +343,7 @@ interface CutoutPlacement {
   scaleX: number; scaleY: number; aspectRatioLocked: boolean;
   depth: { mode: 'through' } | { mode: 'mm'; value: number }
        | { mode: 'remaining'; floorThicknessMm: number };
-  clearanceMm: number;      // 0.0 — optional extra after Trace margin
+  clearanceMm: number;      // 0.0 — signed adjustment after scale/Trace margin, -5..5 mm
   cornerRoundMm: number;    // 1.0 — 2D vertical edge round
   topFilletMm: number;      // 0.0 — top-surface pocket-edge round-over
   bottomFilletMm: number;   // 2.8 (r_f2), clamped to depth/2

--- a/docs/gridfinity-plan.md
+++ b/docs/gridfinity-plan.md
@@ -159,7 +159,9 @@ actual underside, so flat pockets can cut into the former feet area. Base magnet
 return when switched off. Existing projects retain the Gridfinity base.
 **Half/quarter grid**
 landed as explicit 21/10.5 mm pitch modes while retaining the upstream 0.5 mm
-gap; fractional magnet/screw patterns are disabled until the corner-only hole
+gap. The maximum physical span is shared across pitches: 16 full, 32 half, or
+64 quarter cells per axis, including footprint editing and automatic sizing.
+Fractional magnet/screw patterns are disabled until the corner-only hole
 layout is ported. Baseplate generation was intentionally removed from
 Pocketry; dedicated Gridfinity tools cover that workflow. The only remaining
 G5 item is optional server persistence.

--- a/shared/gridfinity/cutout.test.ts
+++ b/shared/gridfinity/cutout.test.ts
@@ -78,6 +78,16 @@ describe("cutout schemas", () => {
     });
   });
 
+  it("accepts signed clearance but rejects adjustments outside the supported range", () => {
+    const base = { id: "c1", shapeId: "s1", position: { x: 0, y: 0 } };
+    for (const clearanceMm of [-5, -0.5, 0, 0.5, 5]) {
+      expect(parseCutoutPlacement({ ...base, clearanceMm }).clearanceMm).toBe(clearanceMm);
+    }
+    for (const clearanceMm of [-5.1, 5.1, NaN, Infinity, -Infinity]) {
+      expect(() => parseCutoutPlacement({ ...base, clearanceMm })).toThrow();
+    }
+  });
+
   it("rejects unknown keys and malformed outlines", () => {
     expect(() =>
       cutoutPlacementSchema.parse({

--- a/shared/gridfinity/cutout.ts
+++ b/shared/gridfinity/cutout.ts
@@ -345,8 +345,8 @@ const cutoutPlacementInputSchema = z
       mode: "remaining",
       floorThicknessMm: BASE_HEIGHT,
     }),
-    /** Fit clearance grown around the outline before cutting. */
-    clearanceMm: z.number().min(0).max(5).default(0),
+    /** Signed per-edge fit adjustment after scaling: negative shrinks, positive grows. */
+    clearanceMm: z.number().min(-5).max(5).default(0),
     /** 2D rounding of vertical pocket edges (offset −r then +r). */
     cornerRoundMm: z.number().min(0).max(5).default(1),
     /** Round-over radius where the pocket wall meets the top surface. */
@@ -680,6 +680,18 @@ export interface PlacementFootprint {
    * only — features are cut at their exact diameter.
    */
   features: Point[][];
+}
+
+/**
+ * Conservative allowance for synchronous layout checks and packing. These
+ * operate on the traced rings without kernel offsets, so inward clearance
+ * cannot be credited as extra room (it can split or erase thin features).
+ * The actual cutter and fit template apply the full signed clearance.
+ */
+export function pocketLayoutAllowanceMm(
+  cutout: Pick<CutoutPlacement, "clearanceMm" | "topFilletMm">,
+): number {
+  return Math.max(0, cutout.clearanceMm) + cutout.topFilletMm;
 }
 
 /**

--- a/shared/gridfinity/project.test.ts
+++ b/shared/gridfinity/project.test.ts
@@ -65,6 +65,13 @@ describe("parseProjectDoc", () => {
     expect(parseProjectDoc(JSON.parse(JSON.stringify(doc)))).toEqual(doc);
     expect(doc!.shapes[0].traceMarginMm).toBe(0.5);
   });
+  it("round-trips negative pocket clearance without changing the saved trace", () => {
+    const doc = parseProjectDoc({ ...VALID, cutouts: [{ ...VALID.cutouts[0], clearanceMm: -0.7 }] });
+    expect(doc?.cutouts[0].clearanceMm).toBe(-0.7);
+    expect(doc?.shapes[0].outlineMm).toEqual(VALID.shapes[0].outlineMm);
+    expect(parseProjectDoc(JSON.parse(JSON.stringify(doc)))).toEqual(doc);
+  });
+
   it("round-trips a valid document", () => {
     const doc = parseProjectDoc(VALID);
     expect(doc).not.toBeNull();

--- a/shared/gridfinity/project.test.ts
+++ b/shared/gridfinity/project.test.ts
@@ -44,6 +44,12 @@ const VALID = {
 };
 
 describe("parseProjectDoc", () => {
+  it("round-trips a 3 by 5 standard-cell bin at quarter pitch", () => {
+    const doc = parseProjectDoc({ ...VALID, spec: { ...VALID.spec, gridX: 12, gridY: 20, gridPitch: "quarter" } });
+    expect(doc?.spec).toMatchObject({ gridX: 12, gridY: 20, gridPitch: "quarter" });
+    expect(parseProjectDoc(JSON.parse(JSON.stringify(doc)))).toEqual(doc);
+  });
+
   it("migrates the complete New Airduster Layout without changing any saved geometry or settings", () => {
     const original = JSON.stringify(airdusterV9);
     const doc = parseProjectDoc(airdusterV9);

--- a/shared/gridfinity/types.ts
+++ b/shared/gridfinity/types.ts
@@ -6,6 +6,7 @@ import {
   type BoundaryEdge,
   type GridCell,
 } from "./footprint";
+import { GRID_PITCH_DIVISOR, type GridPitch } from "./standard";
 
 /**
  * The Gridfinity bin specification — what the user asks for, not how it is
@@ -18,9 +19,14 @@ import {
  * `ProjectDoc` when saved.
  */
 
-/** Hard ceilings, so a typo cannot ask manifold for a metre of bin. */
+/** Maximum span per axis in standard 42 mm cells, independent of grid pitch. */
 export const MAX_GRID = 16;
 export const MAX_HEIGHT_UNITS = 42;
+
+/** Selected-pitch cell ceiling for the same maximum physical bin size. */
+export function maxGridCells(pitch: GridPitch = "full"): number {
+  return MAX_GRID * GRID_PITCH_DIVISOR[pitch];
+}
 
 const gridCellSchema = z
   .object({ x: z.number().int(), y: z.number().int() })
@@ -41,9 +47,9 @@ const boundaryEdgeSchema = z.object({
 export const binSpecSchema = z
   .object({
     /** Number of selected-pitch grid cells along x. */
-    gridX: z.number().int().min(1).max(MAX_GRID),
+    gridX: z.number().int().min(1).max(maxGridCells("quarter")),
     /** Number of selected-pitch grid cells along y. */
-    gridY: z.number().int().min(1).max(MAX_GRID),
+    gridY: z.number().int().min(1).max(maxGridCells("quarter")),
     /** Standard 42 mm cells, or equal half/quarter-pitch subdivisions. */
     gridPitch: z.enum(["full", "half", "quarter"]).default("full"),
     /** Rectangular legacy footprint or a canonical connected cell mask. */
@@ -89,6 +95,20 @@ export const binSpecSchema = z
   })
   .strict()
   .superRefine((spec, context) => {
+    const maximum = maxGridCells(spec.gridPitch);
+    for (const axis of ["gridX", "gridY"] as const) {
+      if (spec[axis] > maximum) {
+        context.addIssue({
+          code: z.ZodIssueCode.too_big,
+          type: "number",
+          maximum,
+          inclusive: true,
+          path: [axis],
+          message: `Bin dimensions cannot exceed ${MAX_GRID} standard 42 mm cells per axis.`,
+        });
+      }
+    }
+    if (spec.gridX > maximum || spec.gridY > maximum) return;
     if (spec.footprint.kind !== "custom") return;
     const error = footprintTopologyError(
       spec.gridX,

--- a/shared/gridfinity/validate-layout.test.ts
+++ b/shared/gridfinity/validate-layout.test.ts
@@ -76,6 +76,13 @@ function codes(
 // 2×2 bin: footprint 83.5, interior half-width 40.8.
 
 describe("validateLayout", () => {
+  it("keeps layout checks conservative for inward clearance instead of treating erosion as scaled geometry", () => {
+    const shape = makeShape("s1", 20, 20);
+    const placements = [makeCutout("a", "s1", -8, 0), makeCutout("b", "s1", 8, 0)];
+    expect(codes(spec(), placements.map((cutout) => ({ ...cutout, clearanceMm: -5 })), [shape])).toEqual(codes(spec(), placements, [shape]));
+    expect(codes(spec(), placements, [shape])).toContain('cutout-overlap');
+  });
+
   it("rejects a pocket placed in a custom footprint's missing corner", () => {
     const shaped = spec({
       footprint: {

--- a/shared/gridfinity/validate.test.ts
+++ b/shared/gridfinity/validate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { parseBinSpec, binSpecSchema, type BinSpecInput } from "./types";
 import { validateBinSpec } from "./validate";
+import { binFootprintMm } from "./standard";
 
 function spec(partial: Partial<BinSpecInput> = {}) {
   return parseBinSpec({ gridX: 2, gridY: 3, heightUnits: 6, ...partial });
@@ -20,6 +21,22 @@ describe("binSpecSchema", () => {
     expect(spec({ gridPitch: "half" }).gridPitch).toBe("half");
     expect(spec({ gridPitch: "quarter" }).gridPitch).toBe("quarter");
     expect(() => spec({ gridPitch: "eighth" as never })).toThrow();
+  });
+
+  it.each([
+    ["full", 16], ["half", 32], ["quarter", 64],
+  ] as const)("keeps the same physical ceiling at %s pitch", (gridPitch, maximum) => {
+    const parsed = spec({ gridPitch, gridX: maximum, gridY: maximum });
+    expect(binFootprintMm(parsed.gridX, gridPitch)).toBe(671.5);
+    for (const axis of ["gridX", "gridY"] as const) {
+      expect(() => spec({ gridPitch, [axis]: maximum + 1 })).toThrow();
+    }
+  });
+
+  it("accepts a quarter-pitch custom footprint longer than 16 cells", () => {
+    const cells = Array.from({ length: 20 }, (_, y) => ({ x: 0, y }));
+    expect(spec({ gridX: 1, gridY: 20, gridPitch: "quarter", footprint: { kind: "custom", cells } }).footprint)
+      .toEqual({ kind: "custom", cells });
   });
 
   it("accepts half-unit heights and rejects unsupported or out-of-range sizes", () => {

--- a/shared/gridfinity/validate.ts
+++ b/shared/gridfinity/validate.ts
@@ -17,6 +17,7 @@ import {
   effectiveScoopDepthMm,
   fingerHoleFootprintRing,
   placementFootprint,
+  pocketLayoutAllowanceMm,
   resolvePocketDepth,
   signedDistanceToInterior,
   type CutoutPlacement,
@@ -422,7 +423,7 @@ function validateAgainstBin(spec: BinSpec, p: PlacedCutout): ValidationIssue[] {
       : Math.min(...feature.map((point) => signedDistanceToInterior(point, spec)));
     if (d < minDistFeature) minDistFeature = d;
   }
-  const outlineAllowance = cutout.clearanceMm + cutout.topFilletMm;
+  const outlineAllowance = pocketLayoutAllowanceMm(cutout);
   const wallMargin = Math.min(minDistOutline - outlineAllowance, minDistFeature);
 
   if (wallMargin < 0) {
@@ -628,10 +629,7 @@ function segmentsIntersect(a1: Point, a2: Point, b1: Point, b2: Point): boolean 
 
 function validatePair(a: PlacedCutout, b: PlacedCutout): ValidationIssue | null {
   const edgeAllowance =
-    a.cutout.clearanceMm +
-    a.cutout.topFilletMm +
-    b.cutout.clearanceMm +
-    b.cutout.topFilletMm;
+    pocketLayoutAllowanceMm(a.cutout) + pocketLayoutAllowanceMm(b.cutout);
   const warnGap = edgeAllowance + D_DIV;
 
   // Cheap reject: bboxes further apart than the warning threshold.

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -63,6 +63,14 @@ export default {
         },
       },
       keyframes: {
+        "warning-attention": {
+          "0%, 50%, 100%": {
+            boxShadow: "0 1px 4px rgb(0 0 0 / 0.1), 0 0 0 0 rgb(var(--warning-pulse-color) / 0)",
+          },
+          "25%": {
+            boxShadow: "0 1px 4px rgb(0 0 0 / 0.1), 0 0 0 4px rgb(var(--warning-pulse-color) / 0.2)",
+          },
+        },
         "accordion-down": {
           from: {
             height: "0",
@@ -81,6 +89,7 @@ export default {
         },
       },
       animation: {
+        "warning-attention": "warning-attention 4s ease-in-out infinite",
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },


### PR DESCRIPTION
Various UI cleanups and improvements.

Selecting a pocket now opens a stable properties area below the compact pocket list, with Depth first. The panel stays in the same workflow position, canvas taps reveal it on phones, and dragging keeps the canvas available.

- Keep every pocket on its own row with working rename, duplicate, and remove actions. Put contour editing beside the canvas ruler and at the right of the properties header.
- Collapse Size & scale, Edges & corners, Position & rotation, and Extra pocket clearance by default. Move 3D inspection into the depth profile, order rounding controls from top edge to bottom edge to outline corners, and put Flat bottom directly below Screw holes in Construction.
- Move optional explanations into help hints accessible by hover, keyboard focus, or tap. Keep dimensions, save status, warnings, and active editing guidance visible. The clearance slider and number field share one row, with its hint in the section title.
- Show model warnings at the canvas bottom right in both Layout and 3D. Start collapsed, pulse gently every four seconds with reduced-motion support, and let warning clicks open the affected settings. Errors still block export.
- Allow signed pocket clearance after scaling and Trace margin. The slider runs from −2 to +2 mm with zero centered; project validation accepts −5 to +5 mm. Negative values shrink the cutter and fit templates without changing the saved trace, and adjustments remain undoable.

- Condense Bin size into labeled slider rows with numeric fields alongside them. Keep both standard-cell and millimeter entry, put sizing guidance in label hints, and remove the occupied-cell count.
- Keep the same 671.5 mm maximum outer size per axis at every pitch (16 full, 32 half, or 64 quarter cells). A 3 × 5 standard-cell bin can switch from Half to Quarter without changing its dimensions. Apply the same allowance to numeric sizing, footprint editing, packing, and fit-to-contents.

Negative clearance can erase narrow features; collapsed pockets are reported. The synchronous 2D placement checks and automatic packing conservatively retain the original outline for inward clearance. Generated 3D geometry and fit templates apply the signed offset.

Validation: `npm run check`, `npm test` (73 files, 1,066 tests), `npm run build`, and `git diff --check` pass. Browser checks covered desktop and mobile selection, inline rename, contour editing, help hints, centered negative clearance and Undo, collapsed sections, and warning navigation. Follow-up browser checks verified Half → Quarter on a 3 × 5 bin, editing its length to 5.25 standard cells, and the Construction order. Compact size rows were checked on desktop and at 375- and 320-pixel widths, including numeric entry and keyboard slider changes. Regression coverage includes persistence, packing and fitting beyond 16 fractional cells, and a real-kernel 12 × 20 quarter-cell bin with the expected dimensions and valid closed geometry. The build retains the existing large-chunk advisory.
