### PR TITLE
Simplify bin dimensions and clarify cross-section controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ processing, project storage, and model generation kept on the user's device.
   It starts as a compact count with a gentle pulse every four seconds until expanded
   (unless reduced motion is enabled). Errors still block export.
 - Configure full-, half-, and quarter-pitch bins and export STL or 3MF models.
-  Bin size places numeric inputs alongside each slider, with optional sizing guidance in hover hints.
+  Bin size places bin-unit inputs alongside each slider, with a combined outer-size
+  readout in millimeters below and optional sizing guidance in hover hints.
   All pitches support the same maximum outer size of 671.5 mm per axis
   (16 full, 32 half, or 64 quarter cells), so finer pitch does not shrink the size allowance.
 - Model, fit-test, and outline export dialogs include an optional, unchecked

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -189,7 +189,7 @@ const BIN_SETTINGS_SECTIONS = [
   { id: "bin-settings-pockets", label: "Pockets", tone: "violet" },
   { id: "bin-settings-finger-holes", label: "Finger access", tone: "cyan" },
   { id: "bin-settings-materials", label: "Materials", tone: "amber" },
-  { id: "bin-settings-view", label: "View", tone: "amber" },
+  { id: "bin-settings-view", label: "Cross-section View", tone: "amber" },
   { id: "bin-settings-fit", label: "Check fit", tone: "emerald" },
   { id: "bin-settings-export", label: "Export", tone: "emerald" },
 ] as const;
@@ -575,7 +575,7 @@ export function BinControlsPanel({
                 aria-label="Height in 0.5u increments"
               />
               <span className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs tabular-nums text-muted-foreground">
-                <DraftNumberInput className="h-8 w-16" aria-label="Bin height in units" value={spec.heightUnits} min={1} max={MAX_HEIGHT_UNITS_UI} step={0.5} normalize={(value) => Math.round(value * 2) / 2} onValueChange={(heightUnits) => patchSpec({ heightUnits }, true)} onValueCommit={(heightUnits) => patchSpec({ heightUnits })} /> u · {spec.heightUnits * 7} mm
+                <DraftNumberInput className="h-8 w-20" aria-label="Bin height in units" value={spec.heightUnits} min={1} max={MAX_HEIGHT_UNITS_UI} step={0.5} normalize={(value) => Math.round(value * 2) / 2} onValueChange={(heightUnits) => patchSpec({ heightUnits }, true)} onValueCommit={(heightUnits) => patchSpec({ heightUnits })} /> units
               </span>
             </div>
           </div>
@@ -1592,7 +1592,7 @@ export function BinControlsPanel({
             </div>
           </div>
         </PanelSection>
-        <PanelSection id="bin-settings-view" title="View" icon={Eye} tone="amber" defaultOpen={section !== null} summary={section ? "Cut open" : "Whole bin"}>
+        <PanelSection id="bin-settings-view" title="Cross-section View" icon={Eye} tone="amber" defaultOpen={section !== null} summary={section ? "Cut open" : "Whole bin"}>
           <FeatureSwitch
             label="Cut the preview open"
             description="Slice the 3D view to inspect pockets. These controls only change the preview; exports always contain the complete bin."
@@ -2370,10 +2370,7 @@ function CellSlider({
           aria-label={`${label} in standard Gridfinity cells`}
         />
         <span className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs tabular-nums text-muted-foreground">
-          <DraftNumberInput className="h-8 w-16" aria-label={`${label} in standard cells`} value={standardCells} min={step} max={MAX_GRID} step={step} normalize={(value) => Math.round(value / step) * step} onValueChange={(value) => onChange(value, true)} onValueCommit={(value) => onChange(value, false)} /> × 42 mm
-        </span>
-        <span className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs tabular-nums">
-          <DraftNumberInput className="h-8 w-20" aria-label={`${label} outer size in millimetres`} value={Number(binFootprintMm(cells, pitch).toFixed(1))} min={step * 42 - 0.5} max={MAX_GRID * 42 - 0.5} step={step * 42} normalize={(value) => Math.round((value + 0.5) / (42 * step)) * 42 * step - 0.5} onValueChange={(value) => onChange((value + 0.5) / 42, true)} onValueCommit={(value) => onChange((value + 0.5) / 42, false)} /> mm
+          <DraftNumberInput className="h-8 w-20" aria-label={`${label} in standard cells`} value={standardCells} min={step} max={MAX_GRID} step={step} normalize={(value) => Math.round(value / step) * step} onValueChange={(value) => onChange(value, true)} onValueCommit={(value) => onChange(value, false)} /> units
         </span>
       </div>
     </div>

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -725,8 +725,9 @@ describe("BinDesignerPage", () => {
       expect(size.textContent).toContain("3 × 5 × 5.5u");
       expect(vi.mocked(useBinGeometry).mock.lastCall![0]).toMatchObject({ gridX: 12, gridY: 20, gridPitch: "quarter" });
       const input = (label: string) => container.querySelector<HTMLInputElement>(`[aria-label="${label}"]`)!;
-      expect(input("Width outer size in millimetres").value).toBe("125.5");
-      expect(input("Length outer size in millimetres").value).toBe("209.5");
+      expect(input("Width in standard cells").value).toBe("3");
+      expect(input("Length in standard cells").value).toBe("5");
+      expect(size.textContent).toContain("Outer size 125.5 × 209.5 × 42.1 mm");
 
       const length = input("Length in standard cells");
       React.act(() => length.focus());
@@ -737,7 +738,7 @@ describe("BinDesignerPage", () => {
       React.act(() => length.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
       expect(size.textContent).toContain("3 × 5.25 × 5.5u");
       expect(vi.mocked(useBinGeometry).mock.lastCall![0]).toMatchObject({ gridX: 12, gridY: 21, gridPitch: "quarter" });
-      expect(input("Length outer size in millimetres").value).toBe("220");
+      expect(size.textContent).toContain("Outer size 125.5 × 220.0 × 42.1 mm");
     } finally {
       unmount();
     }
@@ -761,8 +762,7 @@ describe("BinDesignerPage", () => {
     });
 
     const sizeSection = container.querySelector("#bin-settings-size");
-    expect(container.querySelector<HTMLInputElement>('[aria-label="Width outer size in millimetres"]')?.value).toBe("62.5");
-    expect(container.querySelector<HTMLInputElement>('[aria-label="Length outer size in millimetres"]')?.value).toBe("83.5");
+    expect(sizeSection?.textContent).toContain("Outer size 62.5 × 83.5 × 45.6 mm");
     expect(sizeSection?.textContent).toContain("1.5 × 2 × 6u");
     expect(
       container.querySelector('[data-testid="select-grid-pitch"]')?.textContent,


### PR DESCRIPTION
Bin size now accepts dimensions only in bin units beside the sliders. Remove individual millimeter readouts and retain the combined Outer size measurement below. Widen the unit fields to show fractional values clearly, and rename View to Cross-section View in both the section and its navigation shortcut.

Validation: `npm run check`, `npm test` (73 files, 1,066 tests), `npm run build`, and `git diff --check` pass. Browser verification confirmed the simplified dimension rows, complete fractional values, and working Cross-section View navigation. The build retains its existing large-chunk advisory.
