### PR TITLE
Add JSON library export and import with automatic upgrades

### DIFF
--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -22,6 +22,7 @@ import {
   Scissors,
   Spline,
   Trash2,
+  Upload,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from "react";
 import { useLocation } from "wouter";
@@ -225,6 +226,8 @@ export interface BinControlsPanelProps {
   onOpenProject: (projectId: string) => Promise<boolean>;
   onDeleteProject: (projectId: string) => Promise<boolean>;
   onRefreshProjects: () => void;
+  onExportLibrary: () => void;
+  onImportLibrary: (file: File) => void;
   onNewProject: () => void;
   section: BuildBinSection | null;
   onSectionChange: (section: BuildBinSection | null) => void;
@@ -272,6 +275,8 @@ export function BinControlsPanel({
   onOpenProject,
   onDeleteProject,
   onRefreshProjects,
+  onExportLibrary,
+  onImportLibrary,
   onNewProject,
   section,
   onSectionChange,
@@ -490,6 +495,8 @@ export function BinControlsPanel({
             onOpenProject={onOpenProject}
             onDeleteProject={onDeleteProject}
             onRefreshProjects={onRefreshProjects}
+            onExportLibrary={onExportLibrary}
+            onImportLibrary={onImportLibrary}
             onNewProject={onNewProject}
             onExportProject={onExportProject}
             onImportProject={onImportProject}
@@ -2049,6 +2056,8 @@ interface ProjectControlsProps {
   onOpenProject: (projectId: string) => Promise<boolean>;
   onDeleteProject: (projectId: string) => Promise<boolean>;
   onRefreshProjects: () => void;
+  onExportLibrary: () => void;
+  onImportLibrary: (file: File) => void;
   onNewProject: () => void;
   onExportProject: () => void;
   onImportProject: (file: File) => void;
@@ -2065,6 +2074,8 @@ function ProjectControls({
   onOpenProject,
   onDeleteProject,
   onRefreshProjects,
+  onExportLibrary,
+  onImportLibrary,
   onNewProject,
   onExportProject,
   onImportProject,
@@ -2075,6 +2086,7 @@ function ProjectControls({
   const [libraryOpen, setLibraryOpen] = useState(false);
   const [projectName, setProjectName] = useState("");
   const importInputRef = useRef<HTMLInputElement | null>(null);
+  const libraryImportInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleSave = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -2179,7 +2191,7 @@ function ProjectControls({
               Open library
             </Button>
           </DialogTrigger>
-          <DialogContent>
+          <DialogContent className="max-h-[85dvh] overflow-y-auto">
             <DialogHeader>
               <DialogTitle>Project Library</DialogTitle>
               <DialogDescription>
@@ -2187,6 +2199,30 @@ function ProjectControls({
                 current working draft.
               </DialogDescription>
             </DialogHeader>
+            <div className="space-y-2">
+              <div className="flex flex-wrap gap-2">
+                <Button size="sm" variant="outline" disabled={!ready || busy}
+                  onClick={onExportLibrary} data-testid="button-export-library">
+                  <Download className="mr-1.5 h-3.5 w-3.5" />Export library
+                </Button>
+                <Button size="sm" variant="outline" disabled={!ready || busy}
+                  onClick={() => libraryImportInputRef.current?.click()} data-testid="button-import-library">
+                  <Upload className="mr-1.5 h-3.5 w-3.5" />Import library
+                </Button>
+                <input ref={libraryImportInputRef} type="file" accept=".json,application/json"
+                  className="hidden" aria-label="Import library JSON" data-testid="input-import-library"
+                  onChange={(event) => {
+                    const file = event.currentTarget.files?.[0];
+                    event.currentTarget.value = "";
+                    if (file) onImportLibrary(file);
+                  }} />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Export all named designs as JSON. Save an unnamed draft to the library first.
+                Import adds designs and upgrades older versions. Existing designs stay intact;
+                duplicate names get an “imported” suffix.
+              </p>
+            </div>
             <div className="max-h-80 space-y-2 overflow-y-auto" data-testid="project-list">
               {projects.length === 0 ? (
                 <div className="rounded-md border border-dashed p-5 text-center text-sm text-muted-foreground">

--- a/client/src/components/help/help-dialog.tsx
+++ b/client/src/components/help/help-dialog.tsx
@@ -192,6 +192,13 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
                 filename and location.
               </li>
               <li>
+                In <strong>Project → Open library</strong>, use <strong>Export library</strong>
+                {" "}to back up every named design in one JSON file, or <strong>Import library</strong>
+                {" "}to add designs from a backup. Supported older designs upgrade automatically.
+                Duplicate names get an “imported” suffix; existing designs and the open draft
+                stay intact. Save an unnamed draft to the library before exporting it.
+              </li>
+              <li>
                 <strong>New project</strong> clears the active design after
                 confirmation. An unsaved working draft is retained while you
                 switch between Trace and Bin.

--- a/client/src/lib/project/library.test.ts
+++ b/client/src/lib/project/library.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { set } from "idb-keyval";
+import { PROJECT_SCHEMA_VERSION, parseProjectDoc } from "@shared/gridfinity/project";
+import { type LibraryBackup } from "@shared/gridfinity/library";
+import airdusterV9 from "@shared/gridfinity/fixtures/airduster-v9.pocketry.json";
+import {
+  exportProjectLibrary, importProjectLibrary, loadProjectDoc,
+  loadProjectLibrary, openProjectFromLibrary, saveProjectDoc, saveProjectToLibrary,
+} from "./persist";
+
+const memory = new Map<string, unknown>();
+vi.mock("idb-keyval", () => ({
+  get: vi.fn(async (key: string) => memory.get(key)),
+  set: vi.fn(async (key: string, value: unknown) => { memory.set(key, value); }),
+}));
+const DOC = parseProjectDoc(airdusterV9)!;
+const LIBRARY_KEY = "tooltrace:project-library:v1";
+const backup = (docs: Record<string, unknown>[] = [DOC]): LibraryBackup => ({
+  format: "pocketry-library", schemaVersion: 1,
+  projects: docs.map((doc, index) => ({
+    id: `design-${index}`, name: `Design ${index}`, updatedAt: "2026-09-12T12:00:00.000Z", doc,
+  })),
+});
+
+beforeEach(() => { memory.clear(); vi.clearAllMocks(); });
+
+describe("library JSON transfer", () => {
+  it("round-trips all named designs, shapes, materials and metadata into an empty library", async () => {
+    await saveProjectToLibrary(DOC, "Tools", null);
+    await saveProjectToLibrary({ ...DOC, keepBinSize: true }, "Fixed tools", null);
+    const exported = JSON.parse(JSON.stringify(await exportProjectLibrary()));
+    memory.clear();
+    const result = await importProjectLibrary(exported);
+    expect(result).toMatchObject({ imported: 2, upgraded: 0, renamed: 0 });
+    expect(result.library.activeProjectId).toBeNull();
+    expect(await loadProjectDoc()).toBeNull();
+    expect(await exportProjectLibrary()).toEqual(exported);
+    const opened = await openProjectFromLibrary(result.library.projects.find(p => p.name === "Fixed tools")!.id);
+    expect(opened.doc).toEqual({ ...DOC, name: "Fixed tools", keepBinSize: true });
+  });
+
+  it("exports the latest active edits before debounce and excludes unnamed drafts", async () => {
+    const library = await saveProjectToLibrary(DOC, "Tools", null);
+    const updated = { ...DOC, keepBinSize: true };
+    const exported = await exportProjectLibrary(updated);
+    expect(exported.projects[0]).toMatchObject({ id: library.activeProjectId, doc: { ...updated, name: "Tools" } });
+    expect((await loadProjectDoc())!.keepBinSize).toBeUndefined();
+    memory.clear();
+    await saveProjectDoc(updated);
+    expect((await exportProjectLibrary(updated)).projects).toEqual([]);
+  });
+
+  it("upgrades mixed historical versions through the existing design migration path", async () => {
+    const old: Record<string, unknown>[] = Array.from(
+      { length: PROJECT_SCHEMA_VERSION - 1 },
+      (_, index) => {
+        // The removed liteBase flag belongs only to versions 1–10.
+        const source = index < 10 ? airdusterV9 : DOC;
+        const doc: Record<string, unknown> = { ...source, schemaVersion: index + 1 };
+        // Versions 1–6 predate the project-level finger-hole array.
+        if (index < 6) delete doc.fingerHoles;
+        return doc;
+      },
+    );
+    old.push(DOC);
+    const result = await importProjectLibrary(backup(old));
+    expect(result).toMatchObject({ imported: PROJECT_SCHEMA_VERSION, upgraded: PROJECT_SCHEMA_VERSION - 1 });
+    const exported = await exportProjectLibrary();
+    exported.projects.forEach((project, index) => {
+      expect(project.doc).toEqual({ ...parseProjectDoc(old[index]), name: `Design ${index}` });
+      expect(project.doc.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
+    });
+  });
+
+  it("preserves active work and creates distinct copies for repeated IDs and names", async () => {
+    const saved = await saveProjectToLibrary(DOC, "Design 0", null);
+    const before = await loadProjectDoc();
+    const input = backup();
+    input.projects[0].id = saved.activeProjectId!;
+    await importProjectLibrary(input);
+    const result = await importProjectLibrary(input);
+    expect(result.renamed).toBe(1);
+    expect(result.library.activeProjectId).toBe(saved.activeProjectId);
+    expect(await loadProjectDoc()).toEqual(before);
+    const exported = await exportProjectLibrary();
+    expect(exported.projects.map(p => p.name)).toEqual(["Design 0", "Design 0 (imported)", "Design 0 (imported 2)"]);
+    expect(new Set(exported.projects.map(p => p.id)).size).toBe(3);
+    expect(exported.projects[0].doc).toEqual(before);
+  });
+
+  it("resolves conflicts within the file and keeps suffixed names within the length limit", async () => {
+    const input = backup([DOC, DOC]);
+    input.projects.forEach(p => { p.id = "same"; p.name = "A".repeat(80); });
+    await importProjectLibrary(input);
+    const exported = await exportProjectLibrary();
+    expect(new Set(exported.projects.map(p => p.id)).size).toBe(2);
+    expect(exported.projects[1].name).toHaveLength(80);
+    expect(exported.projects[1].name).toMatch(/ \(imported\)$/);
+  });
+
+  it.each([
+    null, { ...backup(), schemaVersion: 999 }, { ...backup(), format: "other" },
+    backup([DOC, { ...DOC, schemaVersion: 999 }]),
+    backup([DOC, { ...DOC, shapes: "broken" }]),
+  ])("rejects invalid or future files without writing any designs (%#)", async input => {
+    await saveProjectToLibrary(DOC, "Existing", null);
+    const before = structuredClone([...memory]);
+    vi.mocked(set).mockClear();
+    await expect(importProjectLibrary(input)).rejects.toThrow();
+    expect(set).not.toHaveBeenCalled();
+    expect([...memory]).toEqual(before);
+  });
+
+  it("reports storage failure without changing the library or working copy", async () => {
+    await saveProjectToLibrary(DOC, "Existing", null);
+    const before = structuredClone([...memory]);
+    vi.mocked(set).mockRejectedValueOnce(new Error("Storage is full"));
+    await expect(importProjectLibrary(backup())).rejects.toThrow("Storage is full");
+    expect([...memory]).toEqual(before);
+    expect((await loadProjectLibrary()).projects).toHaveLength(1);
+  });
+
+  it("preserves unreadable stored designs in exports and on merge", async () => {
+    const future = { schemaVersion: 999, important: [1, 2, 3] };
+    memory.set(LIBRARY_KEY, { schemaVersion: 1, activeProjectId: null, projects: backup([future]).projects });
+    expect((await exportProjectLibrary()).projects[0].doc).toEqual(future);
+    await importProjectLibrary(backup());
+    expect((await exportProjectLibrary()).projects[0].doc).toEqual(future);
+    expect((await exportProjectLibrary()).projects).toHaveLength(2);
+  });
+
+  it("rejects an unreadable destination library and supports empty backups", async () => {
+    expect(await exportProjectLibrary()).toEqual(backup([]));
+    expect((await importProjectLibrary(backup([]))).imported).toBe(0);
+    memory.set(LIBRARY_KEY, { schemaVersion: 999 });
+    await expect(exportProjectLibrary()).rejects.toThrow("kept intact");
+    await expect(importProjectLibrary(backup())).rejects.toThrow("kept intact");
+    expect(memory.get(LIBRARY_KEY)).toEqual({ schemaVersion: 999 });
+  });
+
+  it("serializes import and autosave so neither loses the other's designs", async () => {
+    await saveProjectToLibrary(DOC, "Existing", null);
+    await Promise.all([importProjectLibrary(backup()), saveProjectDoc({ ...DOC, keepBinSize: true })]);
+    const exported = await exportProjectLibrary();
+    expect(exported.projects).toHaveLength(2);
+    expect(exported.projects[0].doc.keepBinSize).toBe(true);
+  });
+});

--- a/client/src/lib/project/persist.ts
+++ b/client/src/lib/project/persist.ts
@@ -1,5 +1,13 @@
 import { get, set } from "idb-keyval";
-import { z } from "zod";
+import {
+  libraryBackupSchema,
+  projectLibrarySchema,
+  PROJECT_LIBRARY_VERSION,
+  PROJECT_NAME_MAX_LENGTH,
+  type LibraryBackup,
+  type StoredProject,
+  type StoredProjectLibrary,
+} from "@shared/gridfinity/library";
 
 import {
   parseProjectDoc,
@@ -20,32 +28,6 @@ import {
 // browser-local projects or silently starts users from an empty library.
 const CURRENT_PROJECT_KEY = "tooltrace:project:v1";
 const PROJECT_LIBRARY_KEY = "tooltrace:project-library:v1";
-const PROJECT_LIBRARY_VERSION = 1 as const;
-const PROJECT_NAME_MAX_LENGTH = 80;
-
-const storedProjectSchema = z
-  .object({
-    id: z.string().min(1).max(128),
-    name: z.string().min(1).max(PROJECT_NAME_MAX_LENGTH),
-    updatedAt: z.string().datetime(),
-    // Validate and migrate documents separately so a project-schema bump does
-    // not make the entire named library appear empty. Unreadable/future docs
-    // remain in storage instead of being discarded by the next library write.
-    doc: z.record(z.unknown()),
-  })
-  .strict();
-
-const projectLibrarySchema = z
-  .object({
-    schemaVersion: z.literal(PROJECT_LIBRARY_VERSION),
-    activeProjectId: z.string().min(1).max(128).nullable(),
-    projects: z.array(storedProjectSchema),
-  })
-  .strict();
-
-type StoredProject = z.infer<typeof storedProjectSchema>;
-type StoredProjectLibrary = z.infer<typeof projectLibrarySchema>;
-
 export interface ProjectLibraryItem {
   id: string;
   name: string;
@@ -151,6 +133,71 @@ export async function loadProjectLibrary(): Promise<ProjectLibrarySnapshot> {
   await libraryMutationQueue;
   try { return toSnapshot(await readStoredLibrary()); }
   catch { return toSnapshot(EMPTY_LIBRARY); }
+}
+
+/** Include pending edits to the active named project without waiting for autosave.
+ * Unsupported stored documents are included verbatim, never silently omitted.
+ */
+export async function exportProjectLibrary(currentDoc?: ProjectDoc): Promise<LibraryBackup> {
+  return mutateLibrary(async (library) => ({
+    format: "pocketry-library",
+    schemaVersion: PROJECT_LIBRARY_VERSION,
+    projects: library.projects.map((project) =>
+      currentDoc && project.id === library.activeProjectId
+        ? { ...project, doc: { ...currentDoc, name: project.name }, updatedAt: new Date().toISOString() }
+        : project,
+    ),
+  }));
+}
+
+export interface LibraryImportResult {
+  library: ProjectLibrarySnapshot;
+  imported: number;
+  upgraded: number;
+  renamed: number;
+}
+
+/** Validate and migrate the entire backup before one atomic library write.
+ * Conflicting entries become independent copies; the current design stays open.
+ */
+export async function importProjectLibrary(input: unknown): Promise<LibraryImportResult> {
+  const backup = libraryBackupSchema.safeParse(input);
+  if (!backup.success) {
+    throw new Error("Not a supported Pocketry library JSON file. No designs were imported.");
+  }
+  let upgraded = 0;
+  const importedProjects = backup.data.projects.map((project) => {
+    const doc = parseProjectDoc(project.doc);
+    if (!doc) {
+      throw new Error(`“${project.name}” is invalid or uses a newer Pocketry version. No designs were imported.`);
+    }
+    if (project.doc.schemaVersion !== doc.schemaVersion) upgraded++;
+    return { ...project, name: cleanProjectName(project.name), doc };
+  });
+  return mutateLibrary(async (library) => {
+    const projects = [...library.projects];
+    const ids = new Set(projects.map((project) => project.id));
+    let renamed = 0;
+    for (const project of importedProjects) {
+      let name = project.name;
+      let suffix = 1;
+      while (projects.some((existing) =>
+        existing.name.localeCompare(name, undefined, { sensitivity: "accent" }) === 0,
+      )) {
+        const ending = suffix === 1 ? " (imported)" : ` (imported ${suffix})`;
+        name = `${project.name.slice(0, PROJECT_NAME_MAX_LENGTH - ending.length).trimEnd()}${ending}`;
+        suffix++;
+      }
+      if (name !== project.name) renamed++;
+      let id = project.id;
+      while (ids.has(id)) id = makeProjectId();
+      ids.add(id);
+      projects.push({ ...project, id, name, doc: { ...project.doc, name } });
+    }
+    const next = { ...library, projects };
+    if (importedProjects.length > 0) await set(PROJECT_LIBRARY_KEY, next);
+    return { library: toSnapshot(next), imported: importedProjects.length, upgraded, renamed };
+  });
 }
 
 /** Best-effort working-copy autosave, also updating the active named project. */

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -106,6 +106,8 @@ vi.mock("@/lib/project/persist", () => ({
   saveProjectToLibrary: vi.fn(),
   openProjectFromLibrary: vi.fn(),
   deleteProjectFromLibrary: vi.fn(),
+  exportProjectLibrary: vi.fn(),
+  importProjectLibrary: vi.fn(),
   startNewProject: vi.fn(async () => ({ activeProjectId: null, projects: [] })),
   createDebouncedProjectSaver: () => Object.assign(vi.fn(), { cancel: vi.fn() }),
 }));
@@ -1504,6 +1506,69 @@ describe("BinDesignerPage", () => {
     expect(
       container.querySelector('[data-testid="project-autosave-status"]')?.textContent,
     ).toContain("Pliers tray");
+    unmount();
+  });
+
+  it("exports the full library from its dialog with the latest design snapshot", async () => {
+    const backup = { format: "pocketry-library" as const, schemaVersion: 1 as const, projects: [] };
+    vi.mocked(ProjectPersistence.exportProjectLibrary).mockResolvedValue(backup);
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    React.act(() => { (container.querySelector('[data-testid="button-open-library"]') as HTMLButtonElement).click(); });
+    await React.act(async () => { (document.querySelector('[data-testid="button-export-library"]') as HTMLButtonElement).click(); });
+    expect(ProjectPersistence.exportProjectLibrary).toHaveBeenCalledWith(expect.objectContaining({ schemaVersion: PROJECT_SCHEMA_VERSION }));
+    expect(downloadBlob).toHaveBeenCalledWith(expect.any(Blob), expect.stringMatching(/^pocketry-library-.*\.json$/));
+    const [blob] = vi.mocked(downloadBlob).mock.calls[0];
+    const json = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result));
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(blob);
+    });
+    expect(JSON.parse(json)).toEqual(backup);
+    unmount();
+  });
+
+  it("imports library JSON, refreshes the list, and allows selecting the same file again", async () => {
+    const project = { id: "imported", name: "Imported tray", updatedAt: "2026-09-12T12:00:00.000Z" };
+    vi.mocked(ProjectPersistence.importProjectLibrary).mockResolvedValue({
+      library: { activeProjectId: null, projects: [project] }, imported: 1, upgraded: 1, renamed: 0,
+    });
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    React.act(() => { (container.querySelector('[data-testid="button-open-library"]') as HTMLButtonElement).click(); });
+    await flushHydration();
+    const input = document.querySelector('[data-testid="input-import-library"]') as HTMLInputElement;
+    const click = vi.spyOn(input, "click");
+    React.act(() => { (document.querySelector('[data-testid="button-import-library"]') as HTMLButtonElement).click(); });
+    expect(click).toHaveBeenCalledOnce();
+    const data = { format: "pocketry-library", schemaVersion: 1, projects: [] };
+    const file = new File([JSON.stringify(data)], "library.json", { type: "application/json" });
+    Object.defineProperty(file, "text", { value: async () => JSON.stringify(data) });
+    Object.defineProperty(input, "files", { value: [file] });
+    await React.act(async () => { input.dispatchEvent(new Event("change", { bubbles: true })); });
+    expect(ProjectPersistence.importProjectLibrary).toHaveBeenCalledWith(data);
+    expect(input.value).toBe("");
+    expect(document.querySelector('[data-testid="project-list"]')?.textContent).toContain("Imported tray");
+    expect(ProjectPersistence.startNewProject).not.toHaveBeenCalled();
+    expect(ProjectPersistence.openProjectFromLibrary).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("rejects malformed library JSON before persistence", async () => {
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    React.act(() => { (container.querySelector('[data-testid="button-open-library"]') as HTMLButtonElement).click(); });
+    const input = document.querySelector('[data-testid="input-import-library"]') as HTMLInputElement;
+    const file = new File(["{"], "broken.json");
+    Object.defineProperty(file, "text", { value: async () => "{" });
+    Object.defineProperty(input, "files", { value: [file] });
+    await React.act(async () => { input.dispatchEvent(new Event("change", { bubbles: true })); });
+    expect(ProjectPersistence.importProjectLibrary).not.toHaveBeenCalled();
+    expect((document.querySelector('[data-testid="button-import-library"]') as HTMLButtonElement).disabled).toBe(false);
     unmount();
   });
 

--- a/client/src/pages/bin-designer.tsx
+++ b/client/src/pages/bin-designer.tsx
@@ -50,6 +50,8 @@ import {
 import {
   createDebouncedProjectSaver,
   deleteProjectFromLibrary,
+  exportProjectLibrary,
+  importProjectLibrary,
   loadProjectDoc,
   loadProjectLibrary,
   openProjectFromLibrary,
@@ -425,6 +427,44 @@ function BinDesignerWorkspace(): JSX.Element {
       description: "Created a portable Pocketry JSON backup.",
     });
   }, [currentProjectDoc, currentProjectName, toast]);
+
+  const handleExportLibrary = useCallback(async () => {
+    setProjectBusy(true);
+    try {
+      const backup = await exportProjectLibrary(currentProjectDoc);
+      downloadBlob(
+        new Blob([JSON.stringify(backup, null, 2)], { type: "application/json" }),
+        `pocketry-library-${new Date().toISOString().replace(/[:.]/g, "-")}.json`,
+      );
+      toast({ title: "Library exported", description: `${backup.projects.length} named designs exported as JSON.` });
+    } catch (cause) {
+      toast({ title: "Could not export library", description: cause instanceof Error ? cause.message : "The library could not be read.", variant: "destructive" });
+    } finally {
+      setProjectBusy(false);
+    }
+  }, [currentProjectDoc, toast]);
+
+  const handleImportLibrary = useCallback(async (file: File) => {
+    setProjectBusy(true);
+    try {
+      let input: unknown;
+      try {
+        input = JSON.parse(await file.text());
+      } catch {
+        throw new Error("The file could not be read as JSON. No designs were imported.");
+      }
+      const result = await importProjectLibrary(input);
+      setProjectLibrary(result.library);
+      toast({
+        title: "Library imported",
+        description: `${result.imported} designs added, ${result.upgraded} upgraded, ${result.renamed} renamed.`,
+      });
+    } catch (cause) {
+      toast({ title: "Could not import library", description: cause instanceof Error ? cause.message : "No designs were imported.", variant: "destructive" });
+    } finally {
+      setProjectBusy(false);
+    }
+  }, [toast]);
 
   const handleImportProject = useCallback(
     async (file: File) => {
@@ -893,6 +933,8 @@ function BinDesignerWorkspace(): JSX.Element {
           onOpenProject={handleOpenProject}
           onDeleteProject={handleDeleteProject}
           onRefreshProjects={handleRefreshProjects}
+          onExportLibrary={() => void handleExportLibrary()}
+          onImportLibrary={(file) => void handleImportLibrary(file)}
           onNewProject={() => void handleNewProject()}
           section={section}
           onSectionChange={setSection}

--- a/shared/gridfinity/library.ts
+++ b/shared/gridfinity/library.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const PROJECT_LIBRARY_VERSION = 1 as const;
+export const PROJECT_NAME_MAX_LENGTH = 80;
+
+/** Documents are migrated separately so unsupported saved designs stay intact. */
+export const storedProjectSchema = z.object({
+  id: z.string().min(1).max(128),
+  name: z.string().min(1).max(PROJECT_NAME_MAX_LENGTH),
+  updatedAt: z.string().datetime(),
+  doc: z.record(z.unknown()),
+}).strict();
+
+export const projectLibrarySchema = z.object({
+  schemaVersion: z.literal(PROJECT_LIBRARY_VERSION),
+  activeProjectId: z.string().min(1).max(128).nullable(),
+  projects: z.array(storedProjectSchema),
+}).strict();
+
+/** Portable named-library backup; importing never changes the working draft. */
+export const libraryBackupSchema = z.object({
+  format: z.literal("pocketry-library"),
+  schemaVersion: z.literal(PROJECT_LIBRARY_VERSION),
+  projects: z.array(storedProjectSchema),
+}).strict();
+
+export type StoredProject = z.infer<typeof storedProjectSchema>;
+export type StoredProjectLibrary = z.infer<typeof projectLibrarySchema>;
+export type LibraryBackup = z.infer<typeof libraryBackupSchema>;


### PR DESCRIPTION
The Project Library can now be backed up and restored as one JSON file from **Project → Open library**. Exports contain every named design, including pending edits to the active design, and use an obvious `pocketry-library-<timestamp>.json` filename plus a `pocketry-library` format marker.

Import validates every entry and upgrades supported older designs through the existing project migrations before saving the entire batch in one library write. Existing projects and the open draft are preserved; ID conflicts become independent copies and duplicate names receive an “imported” suffix. Invalid or future-version designs reject the whole import without partial writes. Unnamed drafts must be saved to the library before export.

Validation:
- Type checking, all 1,166 tests, production build, and `git diff --check` pass on the isolated branch based on current main.
- Regression coverage includes library round trips, design versions 1–12 upgrading to v13, duplicate names/IDs, pending edits, malformed files, storage failures, and concurrent autosave.
- Browser verification during implementation covered legacy import, duplicate import, invalid-file rejection, opening the imported design, and inspection of the actual downloaded JSON. The library controls were also checked against the current-main build.
