### PR TITLE
Simplify finger access controls and add bin-aware limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ processing, project storage, and model generation kept on the user's device.
   at the bottom. Rename finger access from its list row; names save with the project
   and support undo/redo. All finger access styles support depths down to 1 mm;
   shallow curved scoops preserve their opening width as depth changes.
+  Choose Round or Slot, a Curved or Flat bottom, and (for slots) Rounded or Flat
+  ends. A top/section preview follows the choices. Shape changes retain dimensions,
+  rotation, edge radii, and the slot-end preference. Short slots retain their requested
+  length while rounded ends temporarily require a longer opening. Opening dimensions support
+  up to 80 mm in both the panel and Layout. Rounding fields show the actual radius
+  and retain larger requested values for deeper cuts. Existing spherical scoops
+  retain their saved geometry until their dimensions or shape choices are edited.
+  Finger-access depth stops at the bin underside. Mouth-size controls follow the
+  bin dimensions with a 5% allowance, including rotated slots and Layout resize
+  handles. Resizing the bin limits oversized openings in the same undo step. Existing oversized saves
+  remain unchanged on opening and are flagged until edited; wall/floor print
+  validation still applies, and mouth-size limits are before edge rounding.
 - Pocket properties stay in the Pockets section. Click a pocket on the canvas
   or choose its row in the compact list to open its settings there. On phones, tapping opens
   the controls drawer; dragging keeps the layout available.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ processing, project storage, and model generation kept on the user's device.
   shallow curved scoops preserve their opening width as depth changes.
   Choose Round or Slot, a Curved or Flat bottom, and (for slots) Rounded or Flat
   ends. A top/section preview follows the choices. Shape changes retain dimensions,
-  rotation, edge radii, and the slot-end preference. Short slots retain their requested
+  rotation, edge and corner radii, and the slot-end preference.
+  Flat-ended slots offer a separate Corner round
+  control under Edges & corners for either bottom style; it rounds the four plan-view
+  corners inside the opening dimensions, limited to half the smaller width or length.
+  Existing slots keep sharp corners until changed. Short slots retain their requested
   length while rounded ends temporarily require a longer opening. Opening dimensions support
   up to 80 mm in both the panel and Layout. Rounding fields show the actual radius
   and retain larger requested values for deeper cuts. Existing spherical scoops

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ processing, project storage, and model generation kept on the user's device.
 - Refine exterior contours and interior holes.
 - Export traced geometry as SVG, DXF, DWG-compatible DXF, or STL.
 - Arrange traced tools as pockets in Gridfinity bins.
+  Pocket and finger access properties share compact grouped controls, with position
+  at the bottom. Rename finger access from its list row; names save with the project
+  and support undo/redo. All finger access styles support depths down to 1 mm;
+  shallow curved scoops preserve their opening width as depth changes.
 - Pocket properties stay in the Pockets section. Click a pocket on the canvas
   or choose its row in the compact list to open its settings there. On phones, tapping opens
   the controls drawer; dragging keeps the layout available.

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -37,7 +37,10 @@ import {
   effectiveFingerHoleBottomFilletMm,
   minimumFingerHoleLengthMm,
   maximumFingerHoleBottomFilletMm,
+  maximumFingerHoleCornerRoundMm,
+  effectiveFingerHoleCornerRoundMm,
   hasFlatFingerHoleBottom,
+  hasFlatFingerHoleEnds,
   fingerAccessOptionsPatch,
   fingerHoleSizeLimits,
   resolvePocketDepth,
@@ -1284,6 +1287,30 @@ export function BinControlsPanel({
                     <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/edge:rotate-180" />
                   </summary>
                   <div className="space-y-3 pb-2 pt-2" key={selectedFingerHole.id}>
+                {hasFlatFingerHoleEnds(selectedFingerHole) && (
+                  <>
+                  <MmSlider
+                    label="Corner round"
+                    value={effectiveFingerHoleCornerRoundMm(selectedFingerHole)}
+                    min={0}
+                    max={maximumFingerHoleCornerRoundMm(selectedFingerHole)}
+                    step={0.1}
+                    onChange={(cornerRoundMm, transient) => dispatch({
+                      type: "UPDATE_FINGER_HOLE",
+                      id: selectedFingerHole.id,
+                      patch: { cornerRoundMm },
+                      historyLabel: "Change finger hole corner round",
+                      transient,
+                    })}
+                    hint="Rounds the four corners in the top view, inside the slot's width and length."
+                  />
+                  {(selectedFingerHole.cornerRoundMm ?? 0) > effectiveFingerHoleCornerRoundMm(selectedFingerHole) && (
+                    <p className="text-xs text-muted-foreground" role="status">
+                      Requested {selectedFingerHole.cornerRoundMm} mm; limited by width or length.
+                    </p>
+                  )}
+                  </>
+                )}
                 <MmSlider
                   label="Top edge round"
                   value={effectiveFingerHoleTopFilletMm(selectedFingerHole)}

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -152,15 +152,16 @@ function MaterialColorSwatch({
   );
 }
 
-function EditableShapeName({ shape, onRename, onDone }: {
-  shape: TracedShape;
+function EditableObjectName({ name, kind, onRename, onDone }: {
+  name: string;
+  kind: "shape" | "finger-hole";
   onRename: (name: string) => void;
   onDone: () => void;
 }): JSX.Element {
-  const [draft, setDraft] = useState(shape.name);
+  const [draft, setDraft] = useState(name);
   const commit = () => {
-    const name = draft.trim();
-    if (name.length > 0 && name !== shape.name) onRename(name);
+    const trimmedName = draft.trim();
+    if (trimmedName.length > 0 && trimmedName !== name) onRename(trimmedName);
     onDone();
   };
   return (
@@ -179,8 +180,8 @@ function EditableShapeName({ shape, onRename, onDone }: {
         }
       }}
       className="h-8 min-w-0 flex-1 text-xs font-medium"
-      aria-label="Pocket name"
-      data-testid="input-shape-name"
+      aria-label={kind === "shape" ? "Pocket name" : "Finger access name"}
+      data-testid={`input-${kind}-name`}
     />
   );
 }
@@ -307,6 +308,7 @@ export function BinControlsPanel({
   } = useBin();
   const [, navigate] = useLocation();
   const { shapes, storeShape } = useShapeLibrary();
+  const [renamingFingerId, setRenamingFingerId] = useState<string | null>(null);
   const [renamingPocketId, setRenamingPocketId] = useState<string | null>(null);
   useEffect(() => {
     if (!selectedCutoutId || renamingPocketId === selectedCutoutId) return;
@@ -799,7 +801,7 @@ export function BinControlsPanel({
                     isSelected ? "border-violet-500/50 bg-violet-500/10" : "border-transparent hover:bg-accent",
                   )}>
                     {renamingPocketId === cutout.id && shape ? (
-                      <EditableShapeName key={cutout.id} shape={shape} onRename={(name) => storeShape({ ...shape, name })} onDone={() => setRenamingPocketId(null)} />
+                      <EditableObjectName key={cutout.id} name={shape.name} kind="shape" onRename={(name) => storeShape({ ...shape, name })} onDone={() => setRenamingPocketId(null)} />
                     ) : (
                     <button
                       type="button"
@@ -995,6 +997,40 @@ export function BinControlsPanel({
 
                 </div>
               </details>
+              <details className="group/clearance border-t pt-1 text-xs" data-testid="pocket-clearance-settings">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2 font-medium [&::-webkit-details-marker]:hidden">
+                  <span className="flex items-center gap-1">Extra pocket clearance
+                    <HelpHint label="extra pocket clearance">
+                      Adjusts each edge after the Trace margin and scaling. Negative values shrink the pocket to reduce excess padding; positive values enlarge it. Zero keeps the traced size. Narrow features can disappear when shrunk.
+                      <span className="mt-1 block">{selectedShape.traceMarginMm === undefined
+                        ? `Original trace margin unknown (older project). Extra allowance: ${selectedCutout.clearanceMm.toFixed(2)} mm per edge.`
+                        : `Trace margin: ${selectedShape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(selectedShape.traceMarginMm * selectedCutout.scaleX + selectedCutout.clearanceMm).toFixed(2)} / ${(selectedShape.traceMarginMm * selectedCutout.scaleY + selectedCutout.clearanceMm).toFixed(2)} mm per edge.`}</span>
+                    </HelpHint>
+                  </span>
+                  <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/clearance:rotate-180" />
+                </summary>
+                <div className="space-y-2 pb-2" key={selectedCutout.id}>
+                  <MmSlider
+                    label="Extra pocket clearance"
+                    value={selectedCutout.clearanceMm}
+                    centered
+                    inline
+                    min={-2}
+                    max={2}
+                    step={0.1}
+                    onChange={(clearanceMm, transient) =>
+                      dispatch({
+                        type: "UPDATE_CUTOUT",
+                        id: selectedCutout.id,
+                        patch: { clearanceMm },
+                        historyLabel: "Change pocket clearance",
+                        transient,
+                      })
+                    }
+                  />
+                </div>
+              </details>
+
               <PocketMeasurements cutout={selectedCutout} shape={selectedShape}>
                 <div className="flex items-center gap-2">
                   <Label className="w-16 shrink-0 text-xs">Rotation</Label>
@@ -1029,39 +1065,6 @@ export function BinControlsPanel({
                 </div>
 
               </PocketMeasurements>
-              <details className="group/clearance border-t pt-1 text-xs" data-testid="pocket-clearance-settings">
-                <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2 font-medium [&::-webkit-details-marker]:hidden">
-                  <span className="flex items-center gap-1">Extra pocket clearance
-                    <HelpHint label="extra pocket clearance">
-                      Adjusts each edge after the Trace margin and scaling. Negative values shrink the pocket to reduce excess padding; positive values enlarge it. Zero keeps the traced size. Narrow features can disappear when shrunk.
-                      <span className="mt-1 block">{selectedShape.traceMarginMm === undefined
-                        ? `Original trace margin unknown (older project). Extra allowance: ${selectedCutout.clearanceMm.toFixed(2)} mm per edge.`
-                        : `Trace margin: ${selectedShape.traceMarginMm.toFixed(2)} mm per edge before scaling. Nominal total allowance X/Y: ${(selectedShape.traceMarginMm * selectedCutout.scaleX + selectedCutout.clearanceMm).toFixed(2)} / ${(selectedShape.traceMarginMm * selectedCutout.scaleY + selectedCutout.clearanceMm).toFixed(2)} mm per edge.`}</span>
-                    </HelpHint>
-                  </span>
-                  <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/clearance:rotate-180" />
-                </summary>
-                <div className="space-y-2 pb-2" key={selectedCutout.id}>
-                  <MmSlider
-                    label="Extra pocket clearance"
-                    value={selectedCutout.clearanceMm}
-                    centered
-                    inline
-                    min={-2}
-                    max={2}
-                    step={0.1}
-                    onChange={(clearanceMm, transient) =>
-                      dispatch({
-                        type: "UPDATE_CUTOUT",
-                        id: selectedCutout.id,
-                        patch: { clearanceMm },
-                        historyLabel: "Change pocket clearance",
-                        transient,
-                      })
-                    }
-                  />
-                </div>
-              </details>
 
               {editorMode === "contour" && (
                 <p className="rounded-md bg-violet-500/10 px-2.5 py-2 text-[11px] text-violet-800 dark:text-violet-200">
@@ -1120,49 +1123,35 @@ export function BinControlsPanel({
             </div>
 
             {fingerHoles.length > 0 && (
-              <div className="space-y-1">
+              <div className="space-y-1" aria-label="Choose finger access to edit">
                 {fingerHoles.map((hole, index) => {
                   const isSelected = hole.id === selectedFingerHoleId;
+                  const name = hole.name ?? `Hole ${index + 1}`;
                   return (
-                    <div
-                      key={hole.id}
-                      className={cn(
-                        "flex items-center gap-1 rounded border px-1 py-1 text-xs",
-                        isSelected
-                          ? "border-violet-500/40 bg-violet-500/10"
-                          : "border-transparent hover:border-violet-500/20 hover:bg-accent/50",
+                    <div key={hole.id} data-testid={`finger-hole-row-${hole.id}`} className={cn(
+                      "flex items-center rounded-md border text-xs",
+                      isSelected ? "border-cyan-500/50 bg-cyan-500/10" : "border-transparent hover:bg-accent",
+                    )}>
+                      {renamingFingerId === hole.id ? (
+                        <EditableObjectName key={hole.id} name={name} kind="finger-hole"
+                          onRename={(name) => dispatch({ type: "UPDATE_FINGER_HOLE", id: hole.id, patch: { name }, historyLabel: "Rename finger access" })}
+                          onDone={() => setRenamingFingerId(null)} />
+                      ) : (
+                        <button type="button"
+                          className="flex min-h-8 min-w-0 flex-1 items-center gap-2 rounded px-2 py-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          aria-label={`${name} — edit finger access properties`} aria-pressed={isSelected} aria-controls="finger-access-properties"
+                          data-testid={`button-select-finger-hole-${hole.id}`}
+                          onClick={() => dispatch({ type: "SELECT_FINGER_HOLE", id: hole.id })}>
+                          <span className={cn("min-w-0 flex-1 truncate", isSelected && "font-medium text-cyan-700 dark:text-cyan-300")}>{name}</span>
+                        </button>
                       )}
-                      data-testid={`finger-hole-row-${hole.id}`}
-                    >
-                      <button
-                        type="button"
-                        className="min-w-0 flex-1 rounded px-1 py-0.5 text-left font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        onClick={() =>
-                          dispatch({ type: "SELECT_FINGER_HOLE", id: hole.id })
-                        }
-                        data-testid={`button-select-finger-hole-${hole.id}`}
-                      >
-                        Hole {index + 1} · {hole.kind === "scoop"
-                          ? "Round scoop"
-                          : hole.kind === "deep-scoop"
-                            ? "Deep scoop"
-                            : hole.kind === "oblong-deep-scoop"
-                              ? "Oblong deep scoop"
-                              : hole.kind === "flat-ended-scoop"
-                                ? "Flat-ended cylindrical scoop"
-                                : "Straight"}
+                      <button type="button" className="flex h-8 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        aria-label={`Rename ${name}`} data-testid={`button-rename-finger-hole-${hole.id}`}
+                        onClick={() => { dispatch({ type: "SELECT_FINGER_HOLE", id: hole.id }); setRenamingFingerId(hole.id); }}>
+                        <Pencil className="h-3.5 w-3.5" />
                       </button>
-                      <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                        {isSelected ? "Selected" : "Select to edit"}
-                      </span>
-                      <button
-                        type="button"
-                        className="shrink-0 text-muted-foreground hover:text-destructive"
-                        aria-label={`Remove finger hole ${index + 1}`}
-                        onClick={() =>
-                          dispatch({ type: "REMOVE_FINGER_HOLE", id: hole.id })
-                        }
-                      >
+                      <button type="button" className="flex h-8 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        aria-label={`Remove finger hole ${hole.name ?? index + 1}`} onClick={() => dispatch({ type: "REMOVE_FINGER_HOLE", id: hole.id })}>
                         <Trash2 className="h-3.5 w-3.5" />
                       </button>
                     </div>
@@ -1172,8 +1161,13 @@ export function BinControlsPanel({
             )}
 
             {selectedFingerHole && (
-              <div className="space-y-2 border-t pt-3">
-                <PositionInputs position={selectedFingerHole.center} onChange={(center, transient) => dispatch({ type: "UPDATE_FINGER_HOLE", id: selectedFingerHole.id, patch: { center }, transient, historyLabel: "Position finger access" })} />
+              <div className="space-y-3 rounded-md border border-cyan-500/30 bg-cyan-500/[0.025] p-2.5" id="finger-access-properties" role="region" aria-label="Selected finger access properties">
+                <div className="flex min-w-0 flex-wrap items-center gap-2 border-b border-cyan-500/20 pb-2" data-testid="finger-access-properties-heading">
+                  <h3 className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-cyan-700 dark:text-cyan-300">Finger access properties</h3>
+                  <span className="min-w-[5rem] flex-1 truncate text-xs font-medium">{selectedFingerHole.name ?? `Hole ${fingerHoles.indexOf(selectedFingerHole) + 1}`}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="finger-hole-style" className="shrink-0 text-xs">Style</Label>
                 <Select
                   value={selectedFingerHole.kind}
                   onValueChange={(kind) => {
@@ -1187,9 +1181,7 @@ export function BinControlsPanel({
                         depthMm:
                           kind === "scoop"
                             ? Math.min(selectedFingerHole.depthMm, diameterMm / 2)
-                            : kind === "deep-scoop" || kind === "oblong-deep-scoop"
-                              ? Math.max(selectedFingerHole.depthMm, diameterMm / 2)
-                              : selectedFingerHole.depthMm,
+                            : selectedFingerHole.depthMm,
                         lengthMm:
                           isElongatedFingerHole(nextHole)
                             ? Math.max(
@@ -1208,14 +1200,15 @@ export function BinControlsPanel({
                   }}
                 >
                   <SelectTrigger
-                    className="h-8"
+                    id="finger-hole-style"
+                    className="h-8 min-w-0 flex-1"
                     aria-label="Selected finger hole type"
                     data-testid="selected-finger-hole-kind"
                   >
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="straight">Straight</SelectItem>
+                    <SelectItem value="straight">Vertical Cylinder</SelectItem>
                     <SelectItem value="scoop">Round scoop</SelectItem>
                     <SelectItem value="deep-scoop">Deep scoop</SelectItem>
                     <SelectItem value="oblong-deep-scoop">
@@ -1224,42 +1217,9 @@ export function BinControlsPanel({
                     <SelectItem value="flat-ended-scoop">Flat-ended cylindrical scoop</SelectItem>
                   </SelectContent>
                 </Select>
+                </div>
 
-                <MmSlider
-                  label="Diameter"
-                  value={selectedFingerHole.diameterMm}
-                  min={6}
-                  max={40}
-                  step={1}
-                  onChange={(diameterMm, transient) =>
-                    dispatch({
-                      type: "UPDATE_FINGER_HOLE",
-                      id: selectedFingerHole.id,
-                      patch: {
-                        diameterMm,
-                        depthMm:
-                          selectedFingerHole.kind === "scoop"
-                            ? Math.min(selectedFingerHole.depthMm, diameterMm / 2)
-                            : selectedFingerHole.kind === "deep-scoop" ||
-                                selectedFingerHole.kind === "oblong-deep-scoop"
-                              ? Math.max(selectedFingerHole.depthMm, diameterMm / 2)
-                              : selectedFingerHole.depthMm,
-                        lengthMm:
-                          isElongatedFingerHole(selectedFingerHole)
-                            ? Math.max(
-                                selectedFingerHole.lengthMm ??
-                                  DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
-                                minimumFingerHoleLengthMm({ ...selectedFingerHole, diameterMm }),
-                              )
-                            : selectedFingerHole.lengthMm,
-                      },
-                      historyLabel: "Resize finger hole",
-                      transient,
-                    })
-                  }
-                  hint="You can also drag the white size handle in Layout."
-                />
-
+                <section className="space-y-2" aria-label="Finger access depth">
                 {selectedFingerHole.kind === "straight" && (
                   <MmSlider
                     label="Depth"
@@ -1307,7 +1267,7 @@ export function BinControlsPanel({
                     <MmSlider
                       label="Total depth"
                       value={effectiveFingerHoleDepthMm(selectedFingerHole)}
-                      min={selectedFingerHole.kind === "flat-ended-scoop" ? 1 : selectedFingerHole.diameterMm / 2}
+                      min={1}
                       max={120}
                       step={0.5}
                       onChange={(depthMm, transient) =>
@@ -1326,9 +1286,7 @@ export function BinControlsPanel({
                         selectedFingerHole.depthMm -
                           selectedFingerHole.diameterMm / 2,
                       ).toFixed(1)} mm · rounded bottom radius: {(
-                        selectedFingerHole.kind === "flat-ended-scoop"
-                          ? flatEndedScoopRadiusMm(selectedFingerHole)
-                          : selectedFingerHole.diameterMm / 2
+                        flatEndedScoopRadiusMm(selectedFingerHole)
                       ).toFixed(1)} mm
                     </p>
                   </div>
@@ -1339,6 +1297,45 @@ export function BinControlsPanel({
                     Cylindrical bottom with flat ends. Shallow depths keep the opening width. Length is measured between the end faces.
                   </p>
                 )}
+
+                </section>
+                <details className="group/size border-t pt-1 text-xs" data-testid="finger-size-settings">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2 font-medium [&::-webkit-details-marker]:hidden">
+                    Size
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/size:rotate-180" />
+                  </summary>
+                  <div className="space-y-3 pb-2 pt-2" key={selectedFingerHole.id}>
+                <MmSlider
+                  label="Diameter"
+                  value={selectedFingerHole.diameterMm}
+                  min={6}
+                  max={40}
+                  step={1}
+                  onChange={(diameterMm, transient) =>
+                    dispatch({
+                      type: "UPDATE_FINGER_HOLE",
+                      id: selectedFingerHole.id,
+                      patch: {
+                        diameterMm,
+                        depthMm:
+                          selectedFingerHole.kind === "scoop"
+                            ? Math.min(selectedFingerHole.depthMm, diameterMm / 2)
+                            : selectedFingerHole.depthMm,
+                        lengthMm:
+                          isElongatedFingerHole(selectedFingerHole)
+                            ? Math.max(
+                                selectedFingerHole.lengthMm ??
+                                  DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
+                                minimumFingerHoleLengthMm({ ...selectedFingerHole, diameterMm }),
+                              )
+                            : selectedFingerHole.lengthMm,
+                      },
+                      historyLabel: "Resize finger hole",
+                      transient,
+                    })
+                  }
+                  hint="You can also drag the white size handle in Layout."
+                />
 
                 {isElongatedFingerHole(selectedFingerHole) && (
                   <div className="space-y-2">
@@ -1362,6 +1359,66 @@ export function BinControlsPanel({
                         })
                       }
                     />
+
+                  </div>
+                )}
+
+
+                  </div>
+                </details>
+                <details className="group/edge border-t pt-1 text-xs" data-testid="finger-edge-settings">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2 font-medium [&::-webkit-details-marker]:hidden">
+                    Edges &amp; corners
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/edge:rotate-180" />
+                  </summary>
+                  <div className="space-y-3 pb-2 pt-2" key={selectedFingerHole.id}>
+                <MmSlider
+                  label="Top edge round"
+                  value={selectedFingerHole.topFilletMm}
+                  min={0}
+                  max={5}
+                  step={0.2}
+                  onChange={(topFilletMm, transient) =>
+                    dispatch({
+                      type: "UPDATE_FINGER_HOLE",
+                      id: selectedFingerHole.id,
+                      patch: { topFilletMm },
+                      historyLabel: "Change finger hole top edge round",
+                      transient,
+                    })
+                  }
+                  hint="Rounds the opening into the bin's top surface."
+                />
+
+                {selectedFingerHole.kind === "straight" && (
+                  <MmSlider
+                    label="Bottom edge fillet"
+                    value={selectedFingerHole.bottomFilletMm}
+                    min={0}
+                    max={Math.min(4, selectedFingerHole.diameterMm / 2)}
+                    step={0.2}
+                    onChange={(bottomFilletMm, transient) =>
+                      dispatch({
+                        type: "UPDATE_FINGER_HOLE",
+                        id: selectedFingerHole.id,
+                        patch: { bottomFilletMm },
+                        historyLabel: "Change finger hole bottom fillet",
+                        transient,
+                      })
+                    }
+                    hint="Rounds the straight wall into its flat floor."
+                  />
+                )}
+
+                  </div>
+                </details>
+                <details className="group/position border-t pt-1 text-xs" data-testid="finger-position-settings">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2 font-medium [&::-webkit-details-marker]:hidden">
+                    Position &amp; rotation
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open/position:rotate-180" />
+                  </summary>
+                  <div className="space-y-3 pb-2 pt-2" key={selectedFingerHole.id}>
+                {isElongatedFingerHole(selectedFingerHole) && (
                     <div className="flex items-center gap-1.5">
                       <Label className="w-16 shrink-0 text-xs">Rotation</Label>
                       <Button
@@ -1428,46 +1485,10 @@ export function BinControlsPanel({
                       />
                       <span className="text-xs text-muted-foreground">°</span>
                     </div>
+                )}
+                <PositionInputs position={selectedFingerHole.center} onChange={(center, transient) => dispatch({ type: "UPDATE_FINGER_HOLE", id: selectedFingerHole.id, patch: { center }, transient, historyLabel: "Position finger access" })} />
                   </div>
-                )}
-
-                <MmSlider
-                  label="Top edge round"
-                  value={selectedFingerHole.topFilletMm}
-                  min={0}
-                  max={5}
-                  step={0.2}
-                  onChange={(topFilletMm, transient) =>
-                    dispatch({
-                      type: "UPDATE_FINGER_HOLE",
-                      id: selectedFingerHole.id,
-                      patch: { topFilletMm },
-                      historyLabel: "Change finger hole top edge round",
-                      transient,
-                    })
-                  }
-                  hint="Rounds the opening into the bin's top surface."
-                />
-
-                {selectedFingerHole.kind === "straight" && (
-                  <MmSlider
-                    label="Bottom edge fillet"
-                    value={selectedFingerHole.bottomFilletMm}
-                    min={0}
-                    max={Math.min(4, selectedFingerHole.diameterMm / 2)}
-                    step={0.2}
-                    onChange={(bottomFilletMm, transient) =>
-                      dispatch({
-                        type: "UPDATE_FINGER_HOLE",
-                        id: selectedFingerHole.id,
-                        patch: { bottomFilletMm },
-                        historyLabel: "Change finger hole bottom fillet",
-                        transient,
-                      })
-                    }
-                    hint="Rounds the straight wall into its flat floor."
-                  />
-                )}
+                </details>
               </div>
             )}
           </div>

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -29,14 +29,17 @@ import { useLocation } from "wouter";
 import {
   DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
   DEFAULT_TOP_EDGE_FILLET_MM,
-  MAX_OBLONG_DEEP_SCOOP_LENGTH_MM,
   defaultPocketFloorThicknessMm,
   isElongatedFingerHole,
   effectiveFingerHoleDepthMm,
-  flatEndedScoopRadiusMm,
+  effectiveFingerHoleTopFilletMm,
+  effectiveFingerHoleBottomFilletMm,
   minimumFingerHoleLengthMm,
+  maximumFingerHoleBottomFilletMm,
+  hasFlatFingerHoleBottom,
+  fingerAccessOptionsPatch,
+  fingerHoleSizeLimits,
   resolvePocketDepth,
-  type FingerHole,
   type TracedShape,
 } from "@shared/gridfinity/cutout";
 import {
@@ -109,6 +112,7 @@ import type { ProjectLibraryItem } from "@/lib/project/persist";
 import { cn } from "@/lib/utils";
 import { PocketDepthSummary, PocketMeasurements, PocketSizeInputs, PositionInputs } from "./pocket-measurements";
 import { ExportConfirmationDialog, ProjectBackupOption } from "./export-confirmation-dialog";
+import { FingerAccessShapeControls } from "./finger-access-shape-controls";
 import { useBin } from "@/state/bin-store";
 import { useShapeLibrary } from "@/state/shape-library";
 
@@ -179,7 +183,7 @@ function EditableObjectName({ name, kind, onRename, onDone }: {
           onDone();
         }
       }}
-      className="h-8 min-w-0 flex-1 text-xs font-medium"
+      className={cn("min-w-0 flex-1 text-xs font-medium", kind === "finger-hole" ? "h-11" : "h-8")}
       aria-label={kind === "shape" ? "Pocket name" : "Finger access name"}
       data-testid={`input-${kind}-name`}
     />
@@ -192,7 +196,7 @@ const BIN_SETTINGS_SECTIONS = [
   { id: "bin-settings-construction", label: "Construction", tone: "rose" },
   { id: "bin-settings-pockets", label: "Pockets", tone: "violet" },
   { id: "bin-settings-finger-holes", label: "Finger access", tone: "cyan" },
-  { id: "bin-settings-materials", label: "Materials", tone: "amber" },
+  { id: "bin-settings-materials", label: "Materials & Colors", tone: "amber" },
   { id: "bin-settings-view", label: "Cross-section View", tone: "amber" },
   { id: "bin-settings-fit", label: "Check fit", tone: "emerald" },
   { id: "bin-settings-export", label: "Export", tone: "emerald" },
@@ -393,6 +397,7 @@ export function BinControlsPanel({
   const selectedCutout = cutouts.find((cutout) => cutout.id === selectedCutoutId) ?? null;
   const selectedFingerHole =
     fingerHoles.find((hole) => hole.id === selectedFingerHoleId) ?? null;
+  const fingerSizeLimits = selectedFingerHole ? fingerHoleSizeLimits(selectedFingerHole, spec) : null;
   const selectedShape = selectedCutout
     ? (shapesById.get(selectedCutout.shapeId) ?? null)
     : null;
@@ -1096,11 +1101,11 @@ export function BinControlsPanel({
         >
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-3">
-              <SettingLabel label="Finger holes" hint="Finger holes are independent layout objects. Select, move, resize, or remove one without changing a tool pocket. Drag a hole to move it and its white size handle to resize it; elongated scoops also have two end handles for length and angle." />
+              <SettingLabel label="Openings" hint="Allow room beside the tool at the depth where you will grip it. Wider slots can accommodate more fingers or gloves. Check the fit with the actual tool and hand before printing the full bin." />
               <Button
                 variant="outline"
                 size="sm"
-                className="h-7 shrink-0 px-2 text-xs"
+                className="h-11 shrink-0 px-2 text-xs"
                 data-testid="button-add-finger-hole"
                 onClick={() =>
                   dispatch({
@@ -1138,19 +1143,21 @@ export function BinControlsPanel({
                           onDone={() => setRenamingFingerId(null)} />
                       ) : (
                         <button type="button"
-                          className="flex min-h-8 min-w-0 flex-1 items-center gap-2 rounded px-2 py-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          className="flex min-h-11 min-w-0 flex-1 items-center gap-2 rounded px-2 py-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                           aria-label={`${name} — edit finger access properties`} aria-pressed={isSelected} aria-controls="finger-access-properties"
                           data-testid={`button-select-finger-hole-${hole.id}`}
                           onClick={() => dispatch({ type: "SELECT_FINGER_HOLE", id: hole.id })}>
                           <span className={cn("min-w-0 flex-1 truncate", isSelected && "font-medium text-cyan-700 dark:text-cyan-300")}>{name}</span>
                         </button>
                       )}
-                      <button type="button" className="flex h-8 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      <button type="button" className="flex h-11 w-11 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                         aria-label={`Rename ${name}`} data-testid={`button-rename-finger-hole-${hole.id}`}
+                        title={`Rename ${name}`}
                         onClick={() => { dispatch({ type: "SELECT_FINGER_HOLE", id: hole.id }); setRenamingFingerId(hole.id); }}>
                         <Pencil className="h-3.5 w-3.5" />
                       </button>
-                      <button type="button" className="flex h-8 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      <button type="button" className="flex h-11 w-11 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        title={`Remove ${name}`}
                         aria-label={`Remove finger hole ${hole.name ?? index + 1}`} onClick={() => dispatch({ type: "REMOVE_FINGER_HOLE", id: hole.id })}>
                         <Trash2 className="h-3.5 w-3.5" />
                       </button>
@@ -1160,143 +1167,47 @@ export function BinControlsPanel({
               </div>
             )}
 
-            {selectedFingerHole && (
-              <div className="space-y-3 rounded-md border border-cyan-500/30 bg-cyan-500/[0.025] p-2.5" id="finger-access-properties" role="region" aria-label="Selected finger access properties">
+            {selectedFingerHole && fingerSizeLimits && (
+              <div className="space-y-3 rounded-md border border-cyan-500/30 bg-cyan-500/[0.025] p-2.5 [&_input]:min-h-11 [&_[data-mm-slider-track]]:min-h-11 [&_[role=slider]]:relative [&_[role=slider]]:before:absolute [&_[role=slider]]:before:-inset-3 [&_summary]:min-h-11" id="finger-access-properties" role="region" aria-label="Selected finger access properties">
                 <div className="flex min-w-0 flex-wrap items-center gap-2 border-b border-cyan-500/20 pb-2" data-testid="finger-access-properties-heading">
                   <h3 className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-cyan-700 dark:text-cyan-300">Finger access properties</h3>
                   <span className="min-w-[5rem] flex-1 truncate text-xs font-medium">{selectedFingerHole.name ?? `Hole ${fingerHoles.indexOf(selectedFingerHole) + 1}`}</span>
                 </div>
-                <div className="flex items-center gap-2">
-                  <Label htmlFor="finger-hole-style" className="shrink-0 text-xs">Style</Label>
-                <Select
-                  value={selectedFingerHole.kind}
-                  onValueChange={(kind) => {
-                    const diameterMm = selectedFingerHole.diameterMm;
-                    const nextHole = { ...selectedFingerHole, kind: kind as FingerHole["kind"] };
+                <FingerAccessShapeControls
+                  hole={selectedFingerHole}
+                  onChange={(change) => {
                     dispatch({
                       type: "UPDATE_FINGER_HOLE",
                       id: selectedFingerHole.id,
-                      patch: {
-                        kind: kind as FingerHole["kind"],
-                        depthMm:
-                          kind === "scoop"
-                            ? Math.min(selectedFingerHole.depthMm, diameterMm / 2)
-                            : selectedFingerHole.depthMm,
-                        lengthMm:
-                          isElongatedFingerHole(nextHole)
-                            ? Math.max(
-                                selectedFingerHole.lengthMm ??
-                                  DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
-                                minimumFingerHoleLengthMm(nextHole),
-                              )
-                            : selectedFingerHole.lengthMm,
-                        rotationDeg:
-                          isElongatedFingerHole(nextHole)
-                            ? (selectedFingerHole.rotationDeg ?? 0)
-                            : selectedFingerHole.rotationDeg,
-                      },
-                      historyLabel: "Change finger hole type",
+                      patch: fingerAccessOptionsPatch(selectedFingerHole, change),
+                      historyLabel: "Change finger access shape",
                     });
                   }}
-                >
-                  <SelectTrigger
-                    id="finger-hole-style"
-                    className="h-8 min-w-0 flex-1"
-                    aria-label="Selected finger hole type"
-                    data-testid="selected-finger-hole-kind"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="straight">Vertical Cylinder</SelectItem>
-                    <SelectItem value="scoop">Round scoop</SelectItem>
-                    <SelectItem value="deep-scoop">Deep scoop</SelectItem>
-                    <SelectItem value="oblong-deep-scoop">
-                      Oblong deep scoop
-                    </SelectItem>
-                    <SelectItem value="flat-ended-scoop">Flat-ended cylindrical scoop</SelectItem>
-                  </SelectContent>
-                </Select>
-                </div>
+                />
+                {(effectiveFingerHoleDepthMm(selectedFingerHole) > fingerSizeLimits.depthMm ||
+                  selectedFingerHole.diameterMm > fingerSizeLimits.diameterMm ||
+                  (isElongatedFingerHole(selectedFingerHole) && Math.max(selectedFingerHole.lengthMm ?? DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
+                    minimumFingerHoleLengthMm(selectedFingerHole)) > fingerSizeLimits.lengthMm)) && (
+                  <p className="text-xs text-amber-700 dark:text-amber-300" role="status">Opening exceeds this bin's size limits.</p>
+                )}
 
                 <section className="space-y-2" aria-label="Finger access depth">
-                {selectedFingerHole.kind === "straight" && (
                   <MmSlider
                     label="Depth"
-                    value={selectedFingerHole.depthMm}
+                    value={effectiveFingerHoleDepthMm(selectedFingerHole)}
                     min={1}
-                    max={120}
+                    max={fingerSizeLimits.depthMm}
                     step={0.5}
                     onChange={(depthMm, transient) =>
                       dispatch({
                         type: "UPDATE_FINGER_HOLE",
                         id: selectedFingerHole.id,
-                        patch: { depthMm },
+                        patch: { depthMm, kind: selectedFingerHole.kind === "scoop" ? "deep-scoop" : selectedFingerHole.kind },
                         historyLabel: "Change finger hole depth",
                         transient,
                       })
                     }
                   />
-                )}
-
-                {selectedFingerHole.kind === "scoop" && (
-                  <MmSlider
-                    label="Depth"
-                    value={Math.min(
-                      selectedFingerHole.depthMm,
-                      selectedFingerHole.diameterMm / 2,
-                    )}
-                    min={1}
-                    max={Math.min(30, selectedFingerHole.diameterMm / 2)}
-                    step={0.5}
-                    onChange={(depthMm, transient) =>
-                      dispatch({
-                        type: "UPDATE_FINGER_HOLE",
-                        id: selectedFingerHole.id,
-                        patch: { depthMm },
-                        historyLabel: "Change finger scoop depth",
-                        transient,
-                      })
-                    }
-                  />
-                )}
-
-                {(selectedFingerHole.kind === "deep-scoop" ||
-                  isElongatedFingerHole(selectedFingerHole)) && (
-                  <div className="space-y-1">
-                    <MmSlider
-                      label="Total depth"
-                      value={effectiveFingerHoleDepthMm(selectedFingerHole)}
-                      min={1}
-                      max={120}
-                      step={0.5}
-                      onChange={(depthMm, transient) =>
-                        dispatch({
-                          type: "UPDATE_FINGER_HOLE",
-                          id: selectedFingerHole.id,
-                          patch: { depthMm },
-                          historyLabel: "Change deep scoop depth",
-                          transient,
-                        })
-                      }
-                    />
-                    <p className="pl-16 text-[11px] text-muted-foreground">
-                      Vertical walls: {Math.max(
-                        0,
-                        selectedFingerHole.depthMm -
-                          selectedFingerHole.diameterMm / 2,
-                      ).toFixed(1)} mm · rounded bottom radius: {(
-                        flatEndedScoopRadiusMm(selectedFingerHole)
-                      ).toFixed(1)} mm
-                    </p>
-                  </div>
-                )}
-
-                {selectedFingerHole.kind === "flat-ended-scoop" && (
-                  <p className="text-[11px] text-muted-foreground">
-                    Cylindrical bottom with flat ends. Shallow depths keep the opening width. Length is measured between the end faces.
-                  </p>
-                )}
 
                 </section>
                 <details className="group/size border-t pt-1 text-xs" data-testid="finger-size-settings">
@@ -1306,10 +1217,10 @@ export function BinControlsPanel({
                   </summary>
                   <div className="space-y-3 pb-2 pt-2" key={selectedFingerHole.id}>
                 <MmSlider
-                  label="Diameter"
+                  label={isElongatedFingerHole(selectedFingerHole) ? "Width" : "Diameter"}
                   value={selectedFingerHole.diameterMm}
                   min={6}
-                  max={40}
+                  max={fingerSizeLimits.diameterMm}
                   step={1}
                   onChange={(diameterMm, transient) =>
                     dispatch({
@@ -1317,24 +1228,14 @@ export function BinControlsPanel({
                       id: selectedFingerHole.id,
                       patch: {
                         diameterMm,
-                        depthMm:
-                          selectedFingerHole.kind === "scoop"
-                            ? Math.min(selectedFingerHole.depthMm, diameterMm / 2)
-                            : selectedFingerHole.depthMm,
-                        lengthMm:
-                          isElongatedFingerHole(selectedFingerHole)
-                            ? Math.max(
-                                selectedFingerHole.lengthMm ??
-                                  DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
-                                minimumFingerHoleLengthMm({ ...selectedFingerHole, diameterMm }),
-                              )
-                            : selectedFingerHole.lengthMm,
+                        depthMm: effectiveFingerHoleDepthMm(selectedFingerHole),
+                        kind: selectedFingerHole.kind === "scoop" ? "deep-scoop" : selectedFingerHole.kind,
                       },
                       historyLabel: "Resize finger hole",
                       transient,
                     })
                   }
-                  hint="You can also drag the white size handle in Layout."
+                  hint="Opening size before top-edge rounding. Curved bottoms become narrower below the opening."
                 />
 
                 {isElongatedFingerHole(selectedFingerHole) && (
@@ -1346,8 +1247,8 @@ export function BinControlsPanel({
                           DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM,
                         minimumFingerHoleLengthMm(selectedFingerHole),
                       )}
-                      min={minimumFingerHoleLengthMm(selectedFingerHole)}
-                      max={MAX_OBLONG_DEEP_SCOOP_LENGTH_MM}
+                      min={Math.min(minimumFingerHoleLengthMm(selectedFingerHole), fingerSizeLimits.lengthMm)}
+                      max={fingerSizeLimits.lengthMm}
                       step={1}
                       onChange={(lengthMm, transient) =>
                         dispatch({
@@ -1359,7 +1260,11 @@ export function BinControlsPanel({
                         })
                       }
                     />
-
+                    {(selectedFingerHole.lengthMm ?? DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM) < minimumFingerHoleLengthMm(selectedFingerHole) && (
+                      <p className="text-xs text-muted-foreground" role="status">
+                        Requested {selectedFingerHole.lengthMm ?? DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM} mm; increased to fit rounded ends.
+                      </p>
+                    )}
                   </div>
                 )}
 
@@ -1374,10 +1279,10 @@ export function BinControlsPanel({
                   <div className="space-y-3 pb-2 pt-2" key={selectedFingerHole.id}>
                 <MmSlider
                   label="Top edge round"
-                  value={selectedFingerHole.topFilletMm}
+                  value={effectiveFingerHoleTopFilletMm(selectedFingerHole)}
                   min={0}
-                  max={5}
-                  step={0.2}
+                  max={Math.min(5, effectiveFingerHoleDepthMm(selectedFingerHole) / 2)}
+                  step={0.1}
                   onChange={(topFilletMm, transient) =>
                     dispatch({
                       type: "UPDATE_FINGER_HOLE",
@@ -1389,14 +1294,20 @@ export function BinControlsPanel({
                   }
                   hint="Rounds the opening into the bin's top surface."
                 />
+                {selectedFingerHole.topFilletMm > effectiveFingerHoleTopFilletMm(selectedFingerHole) && (
+                  <p className="text-xs text-muted-foreground" role="status">
+                    Requested {selectedFingerHole.topFilletMm} mm; limited by depth.
+                  </p>
+                )}
 
-                {selectedFingerHole.kind === "straight" && (
+                {hasFlatFingerHoleBottom(selectedFingerHole) && (
+                  <>
                   <MmSlider
-                    label="Bottom edge fillet"
-                    value={selectedFingerHole.bottomFilletMm}
+                    label="Bottom edge round"
+                    value={effectiveFingerHoleBottomFilletMm(selectedFingerHole)}
                     min={0}
-                    max={Math.min(4, selectedFingerHole.diameterMm / 2)}
-                    step={0.2}
+                    max={maximumFingerHoleBottomFilletMm(selectedFingerHole)}
+                    step={0.1}
                     onChange={(bottomFilletMm, transient) =>
                       dispatch({
                         type: "UPDATE_FINGER_HOLE",
@@ -1408,6 +1319,12 @@ export function BinControlsPanel({
                     }
                     hint="Rounds the straight wall into its flat floor."
                   />
+                  {selectedFingerHole.bottomFilletMm > effectiveFingerHoleBottomFilletMm(selectedFingerHole) && (
+                    <p className="text-xs text-muted-foreground" role="status">
+                      Requested {selectedFingerHole.bottomFilletMm} mm; limited by depth or opening size.
+                    </p>
+                  )}
+                  </>
                 )}
 
                   </div>
@@ -1424,8 +1341,9 @@ export function BinControlsPanel({
                       <Button
                         variant="outline"
                         size="icon"
-                        className="h-8 w-8 shrink-0"
+                        className="h-11 w-11 shrink-0"
                         aria-label="Rotate elongated finger hole 90 degrees counterclockwise"
+                        title="Rotate counterclockwise"
                         onClick={() =>
                           dispatch({
                             type: "UPDATE_FINGER_HOLE",
@@ -1446,8 +1364,9 @@ export function BinControlsPanel({
                       <Button
                         variant="outline"
                         size="icon"
-                        className="h-8 w-8 shrink-0"
+                        className="h-11 w-11 shrink-0"
                         aria-label="Rotate elongated finger hole 90 degrees clockwise"
+                        title="Rotate clockwise"
                         onClick={() =>
                           dispatch({
                             type: "UPDATE_FINGER_HOLE",
@@ -1496,7 +1415,7 @@ export function BinControlsPanel({
 
         <PanelSection
           id="bin-settings-materials"
-          title="Materials"
+          title="Materials & Colors"
           icon={Palette}
           tone="amber"
           summary={`${activeColorCount} colors`}
@@ -1977,7 +1896,7 @@ export function BinControlsPanel({
             <DialogTitle>Include multiple colors in the 3MF?</DialogTitle>
             <DialogDescription>
               Choose a single printable body or preserve the material colors
-              selected in Materials.
+              selected in Materials &amp; Colors.
             </DialogDescription>
           </DialogHeader>
           {hasFloorMaterialWarning && (
@@ -2030,7 +1949,7 @@ export function BinControlsPanel({
                       ]
                         .filter(Boolean)
                         .join(" and ")} for slicer assignment.`
-                    : "Enable a floor or rim-top color in Materials first."}
+                    : "Enable a floor or rim-top color in Materials & Colors first."}
                 </span>
               </span>
             </Button>
@@ -2444,6 +2363,7 @@ function MmSlider({
       </div>
       <div className={cn("space-y-1.5", inline && "col-start-1 row-start-1 pt-3")}>
         <Slider
+          data-mm-slider-track
           centerOrigin={centered}
           value={[value]}
           onValueChange={([next]) =>

--- a/client/src/components/gridfinity/finger-access-shape-controls.tsx
+++ b/client/src/components/gridfinity/finger-access-shape-controls.tsx
@@ -1,0 +1,69 @@
+import { Circle, RectangleHorizontal } from "lucide-react";
+import { Item as RadioGroupItem } from "@radix-ui/react-radio-group";
+import { fingerAccessOptions, type FingerAccessOptions, type FingerHole } from "@shared/gridfinity/cutout";
+import { RadioGroup } from "@/components/ui/radio-group";
+
+const segmentClass = "flex h-11 min-w-0 flex-1 items-center justify-center gap-1.5 rounded-sm px-2 text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=checked]:bg-background data-[state=checked]:text-foreground data-[state=checked]:shadow-sm";
+
+/** Schematic plan and transverse section, independent of edge-round settings. */
+function ShapePreview({ shape, bottom, ends }: FingerAccessOptions): JSX.Element {
+  return (
+    <svg viewBox="0 0 216 64" className="h-16 w-full text-cyan-700 dark:text-cyan-300" role="img"
+      aria-label={`${shape === "round" ? "Round" : `Slot with ${ends} ends`}, ${bottom} bottom: top and cross-section views`}>
+      <g fill="currentColor" fillOpacity="0.1" stroke="currentColor" strokeWidth="1.5">
+        {shape === "slot"
+          ? <rect x="18" y="13" width="68" height="26" rx={ends === "rounded" ? 13 : 0} />
+          : <circle cx="52" cy="26" r="18" />}
+        <path d={bottom === "flat"
+          ? "M128 8 H136 V43 H184 V8 H192"
+          : "M128 8 H136 V19 A24 24 0 0 0 184 19 V8 H192"} fill="none" />
+      </g>
+      <path d="M136 8 H184" stroke="currentColor" strokeOpacity="0.4" strokeDasharray="2 2" />
+      <g fill="currentColor" fontSize="10" textAnchor="middle">
+        <text x="52" y="60">Top</text>
+        <text x="160" y="60">Cross-section</text>
+      </g>
+    </svg>
+  );
+}
+
+export function FingerAccessShapeControls({ hole, onChange }: {
+  hole: FingerHole;
+  onChange: (change: Partial<FingerAccessOptions>) => void;
+}): JSX.Element {
+  const options = fingerAccessOptions(hole);
+  return (
+    <div className="space-y-2" data-testid="finger-access-shape-controls">
+      <div className="flex items-center gap-2">
+        <span id="finger-access-shape-label" className="w-12 shrink-0 text-xs">Shape</span>
+        <RadioGroup value={options.shape} orientation="horizontal" aria-labelledby="finger-access-shape-label"
+          className="flex min-w-0 flex-1 gap-0 rounded-md border bg-muted p-0.5"
+          onValueChange={(shape: FingerAccessOptions["shape"]) => onChange({ shape })}>
+          <RadioGroupItem value="round" className={segmentClass} data-testid="finger-shape-round"><Circle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />Round</RadioGroupItem>
+          <RadioGroupItem value="slot" className={segmentClass} data-testid="finger-shape-slot"><RectangleHorizontal className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />Slot</RadioGroupItem>
+        </RadioGroup>
+      </div>
+      <div className="flex items-center gap-2">
+        <span id="finger-access-bottom-label" className="w-12 shrink-0 text-xs">Bottom</span>
+        <RadioGroup value={options.bottom} orientation="horizontal" aria-labelledby="finger-access-bottom-label"
+          className="flex min-w-0 flex-1 gap-0 rounded-md border bg-muted p-0.5"
+          onValueChange={(bottom: FingerAccessOptions["bottom"]) => onChange({ bottom })}>
+          <RadioGroupItem value="curved" className={segmentClass} data-testid="finger-bottom-curved">Curved</RadioGroupItem>
+          <RadioGroupItem value="flat" className={segmentClass} data-testid="finger-bottom-flat">Flat</RadioGroupItem>
+        </RadioGroup>
+      </div>
+      {options.shape === "slot" && (
+        <div className="flex items-center gap-2">
+          <span id="finger-access-ends-label" className="w-12 shrink-0 text-xs">Ends</span>
+          <RadioGroup value={options.ends} orientation="horizontal" aria-labelledby="finger-access-ends-label"
+            className="flex min-w-0 flex-1 gap-0 rounded-md border bg-muted p-0.5"
+            onValueChange={(ends: FingerAccessOptions["ends"]) => onChange({ ends })}>
+            <RadioGroupItem value="rounded" className={segmentClass} data-testid="finger-ends-rounded">Rounded</RadioGroupItem>
+            <RadioGroupItem value="flat" className={segmentClass} data-testid="finger-ends-flat">Flat</RadioGroupItem>
+          </RadioGroup>
+        </div>
+      )}
+      <ShapePreview {...options} />
+    </div>
+  );
+}

--- a/client/src/components/gridfinity/layout-canvas.tsx
+++ b/client/src/components/gridfinity/layout-canvas.tsx
@@ -17,6 +17,7 @@ import {
   fingerHoleFootprintRing,
   elongatedFingerHoleEndpoints,
   isElongatedFingerHole,
+  hasFlatFingerHoleBottom,
   placementFootprint,
   resizeCutoutPlacementFromHandle,
   resizeFingerHoleFromWidthHandle,
@@ -893,7 +894,7 @@ function LayoutStage({ onEditPocket }: { onEditPocket?: () => void }): JSX.Eleme
     if (drag.kind === "feature-width") {
       const current = fingerHoles.find((hole) => hole.id === drag.featureId);
       if (!current) return;
-      const resized = resizeFingerHoleFromWidthHandle(current, point);
+      const resized = resizeFingerHoleFromWidthHandle(current, point, spec);
       dispatch({
         type: "UPDATE_FINGER_HOLE",
         id: current.id,
@@ -910,6 +911,7 @@ function LayoutStage({ onEditPocket }: { onEditPocket?: () => void }): JSX.Eleme
         current,
         drag.endpoint,
         point,
+        spec,
       );
       dispatch({
         type: "UPDATE_FINGER_HOLE",
@@ -1419,7 +1421,7 @@ function LayoutStage({ onEditPocket }: { onEditPocket?: () => void }): JSX.Eleme
                   d={ringToCanvasPath(ring, spec)}
                   className={cn(tone, "cursor-move")}
                   strokeWidth={isSelected ? 2 : 1.25}
-                  strokeDasharray={hole.kind === "straight" ? undefined : "3 2"}
+                  strokeDasharray={hasFlatFingerHoleBottom(hole) ? undefined : "3 2"}
                   vectorEffect="non-scaling-stroke"
                   data-feature-id={hole.id}
                   data-testid={`finger-hole-${hole.kind}-${hole.id}`}

--- a/client/src/lib/export/layout.test.ts
+++ b/client/src/lib/export/layout.test.ts
@@ -134,9 +134,9 @@ describe("generateLayoutSVG", () => {
 });
 
 
-it("exports a flat-ended channel as a rectangle at its saved position and rotation", () => {
+it.each(["flat-ended-scoop", "flat-ended-straight"] as const)("exports %s as a rectangle at its saved position and rotation", (kind) => {
   const rings = layoutRingsMm(SPEC, [], BY_ID, [{
-    id: "flat", kind: "flat-ended-scoop", center: { x: 5, y: -8 },
+    id: "flat", kind, center: { x: 5, y: -8 },
     diameterMm: 16, lengthMm: 40, depthMm: 25, rotationDeg: 90,
     topFilletMm: 0, bottomFilletMm: 0,
   }]);

--- a/client/src/lib/gridfinity/bin-worker-handlers.test.ts
+++ b/client/src/lib/gridfinity/bin-worker-handlers.test.ts
@@ -290,13 +290,18 @@ describe("bin worker handlers", () => {
     expect(nonManifoldEdgeCount(result.value.materialMeshes!.stackingRim!)).toBe(0);
   });
 
-  it.each(["oblong-straight", "flat-ended-straight"] as const)("exports a rounded %s through the worker to closed STL/3MF geometry", async (kind) => {
+  it.each([
+    { kind: "oblong-straight", cornerRoundMm: 0 },
+    { kind: "flat-ended-straight", cornerRoundMm: 0 },
+    { kind: "flat-ended-straight", cornerRoundMm: 3 },
+    { kind: "flat-ended-scoop", cornerRoundMm: 3 },
+  ])("exports a rounded $kind with corner radius $cornerRoundMm through the worker to closed STL/3MF geometry", async ({ kind, cornerRoundMm }) => {
     const result = await getHandler()({
       spec: { gridX: 2, gridY: 2, heightUnits: 4, fill: "solid" },
       quality: { circularSegments: 64 }, exportTopology: true,
       layout: { shapes: [], cutouts: [], fingerHoles: [fingerHoleSchema.parse({
         id: "slot", kind, center: { x: 3, y: -2 }, diameterMm: 16, lengthMm: 40,
-        rotationDeg: 37, depthMm: 12, topFilletMm: 1, bottomFilletMm: 2,
+        rotationDeg: 37, depthMm: 12, topFilletMm: 1, bottomFilletMm: 2, cornerRoundMm,
       })] },
     }, context());
     const { mesh } = result.value;

--- a/client/src/lib/gridfinity/bin-worker-handlers.test.ts
+++ b/client/src/lib/gridfinity/bin-worker-handlers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import { strFromU8, unzipSync } from "fflate";
 
-import { parseCutoutPlacement, resolvePocketDepth } from "@shared/gridfinity/cutout";
+import { fingerHoleSchema, parseCutoutPlacement, resolvePocketDepth } from "@shared/gridfinity/cutout";
+import { writeBinarySTL } from "@/lib/export/stl-writer";
+import { writeThreeMf } from "@/lib/mesh/threemf";
 import { binTotalHeightMm } from "@shared/gridfinity/standard";
 import { parseBinSpec } from "@shared/gridfinity/types";
 import { loadManifold } from "@/lib/manifold/runtime";
@@ -285,6 +288,26 @@ describe("bin worker handlers", () => {
     expect(nonManifoldEdgeCount(result.value.mesh)).toBe(0);
     expect(nonManifoldEdgeCount(result.value.materialMeshes!.body)).toBe(0);
     expect(nonManifoldEdgeCount(result.value.materialMeshes!.stackingRim!)).toBe(0);
+  });
+
+  it.each(["oblong-straight", "flat-ended-straight"] as const)("exports a rounded %s through the worker to closed STL/3MF geometry", async (kind) => {
+    const result = await getHandler()({
+      spec: { gridX: 2, gridY: 2, heightUnits: 4, fill: "solid" },
+      quality: { circularSegments: 64 }, exportTopology: true,
+      layout: { shapes: [], cutouts: [], fingerHoles: [fingerHoleSchema.parse({
+        id: "slot", kind, center: { x: 3, y: -2 }, diameterMm: 16, lengthMm: 40,
+        rotationDeg: 37, depthMm: 12, topFilletMm: 1, bottomFilletMm: 2,
+      })] },
+    }, context());
+    const { mesh } = result.value;
+    expect(mesh.normals).toBeNull();
+    expect(nonManifoldEdgeCount(mesh)).toBe(0);
+    const stl = writeBinarySTL(mesh);
+    expect(new DataView(stl).getUint32(80, true)).toBe(mesh.indices.length / 3);
+    expect(stl.byteLength).toBe(84 + mesh.indices.length / 3 * 50);
+    const model = strFromU8(unzipSync(writeThreeMf([{ name: "slot", mesh }]))["3D/3dmodel.model"]);
+    expect(model.match(/<triangle /g)?.length).toBe(mesh.indices.length / 3);
+    expect(model.match(/<vertex /g)?.length).toBe(mesh.positions.length / 3);
   });
 
   it("rejects a malformed layout at the boundary", async () => {

--- a/client/src/lib/gridfinity/cutouts.test.ts
+++ b/client/src/lib/gridfinity/cutouts.test.ts
@@ -1,6 +1,7 @@
 import {
   parseCutoutPlacement,
   fingerHoleSchema,
+  isElongatedFingerHole,
   resolvePocketDepth,
   type CutoutPlacement,
   type FingerHole,
@@ -1120,7 +1121,7 @@ it.each([1, 5, 20])("keeps the exported flat-ended rim free of stair treads at d
 
 
 describe("1 mm finger access across all styles", () => {
-  for (const kind of ["straight", "scoop", "deep-scoop", "oblong-deep-scoop", "flat-ended-scoop"] as const) {
+  for (const kind of ["straight", "scoop", "deep-scoop", "oblong-deep-scoop", "flat-ended-scoop", "oblong-straight", "flat-ended-straight"] as const) {
     it.each([0, 1])(`${kind} preserves depth and a valid solid with top rounding %s`, (topFilletMm) => {
       const hole = fingerHoleSchema.parse({ id: "shallow", kind, center: { x: 0, y: 0 }, diameterMm: 24, lengthMm: 40, depthMm: 1, topFilletMm });
       const cutter = buildFingerHoleCutters(kernel, [hole], SPEC, QUALITY)[0];
@@ -1130,7 +1131,7 @@ describe("1 mm finger access across all styles", () => {
       if (topFilletMm === 0) {
         expect(cutter.boundingBox().min[1]).toBeCloseTo(-12, 6);
         expect(cutter.boundingBox().max[1]).toBeCloseTo(12, 6);
-        const halfLength = kind === "oblong-deep-scoop" || kind === "flat-ended-scoop" ? 20 : 12;
+        const halfLength = isElongatedFingerHole(hole) ? 20 : 12;
         expect(cutter.boundingBox().min[0]).toBeCloseTo(-halfLength, 6);
         expect(cutter.boundingBox().max[0]).toBeCloseTo(halfLength, 6);
       }
@@ -1139,4 +1140,37 @@ describe("1 mm finger access across all styles", () => {
       expect(result.solid.genus()).toBe(0);
     });
   }
+});
+
+describe.each(["oblong-straight", "flat-ended-straight"] as const)("flat-bottom slot %s", (kind) => {
+  it.each([0, 37, 90])("has the full mouth area at every height above its flat floor, rotation %s", (rotationDeg) => {
+    const hole = fingerHoleSchema.parse({ id: "slot", kind, center: { x: 3, y: -2 }, diameterMm: 16, lengthMm: 40, depthMm: 20, rotationDeg });
+    const cutter = buildFingerHoleCutters(kernel, [hole], SPEC, QUALITY)[0];
+    const { infillTopZ, cutterTopZ } = resolvePocketDepth(SPEC, { mode: "mm", value: 20 });
+    const expectedArea = kind === "flat-ended-straight" ? 16 * 40 : 16 * 24 + Math.PI * 8 ** 2;
+    const mouthArea = arena.track(cutter.slice(infillTopZ - 1)).area();
+    expect(cutter.status()).toBe("NoError");
+    expect(cutter.boundingBox().min[2]).toBeCloseTo(infillTopZ - 20, 6);
+    expect(mouthArea).toBeGreaterThan(expectedArea * 0.995);
+    expect(mouthArea).toBeLessThanOrEqual(expectedArea + 1e-6);
+    expect(arena.track(cutter.slice(infillTopZ - 19.999)).area()).toBeCloseTo(mouthArea, 6);
+    expect(cutter.volume()).toBeCloseTo(mouthArea * (cutterTopZ - infillTopZ + 20), 5);
+  });
+
+  it("rounds the bottom edges inward and keeps the top flare separate", () => {
+    const hole = fingerHoleSchema.parse({ id: "slot", kind, center: { x: 0, y: 0 }, diameterMm: 16, lengthMm: 40, depthMm: 20, bottomFilletMm: 2, topFilletMm: 1 });
+    const rounded = buildFingerHoleCutters(kernel, [hole], SPEC, QUALITY)[0];
+    const sharp = buildFingerHoleCutters(kernel, [{ ...hole, bottomFilletMm: 0, topFilletMm: 0 }], SPEC, QUALITY)[0];
+    const top = resolvePocketDepth(SPEC, { mode: "mm", value: 20 }).infillTopZ;
+    expect(rounded.status()).toBe("NoError");
+    expect(rounded.boundingBox().min[2]).toBeCloseTo(top - 20, 6);
+    const area = (solid: typeof rounded, z: number) => arena.track(solid.slice(z)).area();
+    expect(area(rounded, top - 19.99)).toBeLessThan(area(sharp, top - 19.99));
+    expect(area(rounded, top - 10)).toBeCloseTo(area(sharp, top - 10), 5);
+    expect(area(rounded, top - 0.01)).toBeGreaterThan(area(sharp, top - 0.01));
+    const shape = rectShape("pocket", 50, 4);
+    const result = buildBinWithCutouts(kernel, SPEC, layoutFor([shape], [cutout("c", "pocket")], [hole]), QUALITY);
+    expect(result.solid.status()).toBe("NoError");
+    expect(result.solid.genus()).toBe(0);
+  });
 });

--- a/client/src/lib/gridfinity/cutouts.test.ts
+++ b/client/src/lib/gridfinity/cutouts.test.ts
@@ -1117,3 +1117,26 @@ it.each([1, 5, 20])("keeps the exported flat-ended rim free of stair treads at d
   expect(cutter.status()).toBe("NoError");
   expect(treads).toEqual([]);
 });
+
+
+describe("1 mm finger access across all styles", () => {
+  for (const kind of ["straight", "scoop", "deep-scoop", "oblong-deep-scoop", "flat-ended-scoop"] as const) {
+    it.each([0, 1])(`${kind} preserves depth and a valid solid with top rounding %s`, (topFilletMm) => {
+      const hole = fingerHoleSchema.parse({ id: "shallow", kind, center: { x: 0, y: 0 }, diameterMm: 24, lengthMm: 40, depthMm: 1, topFilletMm });
+      const cutter = buildFingerHoleCutters(kernel, [hole], SPEC, QUALITY)[0];
+      const topZ = resolvePocketDepth(SPEC, { mode: "mm", value: 1 }).infillTopZ;
+      expect(cutter.status()).toBe("NoError");
+      expect(cutter.boundingBox().min[2]).toBeCloseTo(topZ - 1, 6);
+      if (topFilletMm === 0) {
+        expect(cutter.boundingBox().min[1]).toBeCloseTo(-12, 6);
+        expect(cutter.boundingBox().max[1]).toBeCloseTo(12, 6);
+        const halfLength = kind === "oblong-deep-scoop" || kind === "flat-ended-scoop" ? 20 : 12;
+        expect(cutter.boundingBox().min[0]).toBeCloseTo(-halfLength, 6);
+        expect(cutter.boundingBox().max[0]).toBeCloseTo(halfLength, 6);
+      }
+      const result = buildBinWithCutouts(kernel, SPEC, layoutFor([], [], [hole]), QUALITY);
+      expect(result.solid.status()).toBe("NoError");
+      expect(result.solid.genus()).toBe(0);
+    });
+  }
+});

--- a/client/src/lib/gridfinity/cutouts.ts
+++ b/client/src/lib/gridfinity/cutouts.ts
@@ -4,11 +4,14 @@ import type { Manifold } from "manifold-3d";
 import {
   effectiveDeepScoopDepthMm,
   effectiveFingerHoleDepthMm,
+  effectiveFingerHoleTopFilletMm,
+  effectiveFingerHoleBottomFilletMm,
   flatEndedScoopRadiusMm,
   effectiveScoopDepthMm,
   fingerHoleFootprintRing,
   elongatedFingerHoleEndpoints,
   isElongatedFingerHole,
+  hasFlatFingerHoleBottom,
   resolvePocketDepth,
   transformOutlinePlacement,
   transformPointPlacement,
@@ -361,11 +364,11 @@ export function buildFingerHoleCutters(
   for (const hole of fingerHoles) {
     const pocket = resolvePocketDepth(spec, { mode: "mm", value: hole.depthMm });
     const cutDepth = effectiveFingerHoleDepthMm(hole);
-    const effectiveTopFillet = Math.min(hole.topFilletMm, cutDepth / 2);
+    const effectiveTopFillet = effectiveFingerHoleTopFilletMm(hole);
     // Sample shallow curved bottoms directly so even a 1 mm cut preserves
     // its mouth width and exact depth, with or without top-edge rounding.
     const shallowCurved = hole.kind !== "flat-ended-scoop" && cutDepth < hole.diameterMm / 2;
-    if (hole.kind !== "straight" && (effectiveTopFillet > 0 || shallowCurved)) {
+    if (!hasFlatFingerHoleBottom(hole) && (effectiveTopFillet > 0 || shallowCurved)) {
       cutters.push(buildRoundedFingerAccessCutter(kernel, hole, pocket.infillTopZ, pocket.cutterTopZ, {
         radiusMm: effectiveTopFillet,
         profileStepMm: filletProfileStepMm,
@@ -380,13 +383,9 @@ export function buildFingerHoleCutters(
     );
     const section = toCrossSection(kernel, [{ outer: ring, holes: [] }]);
     let cutter: Manifold;
-    if (hole.kind === "straight") {
+    if (hasFlatFingerHoleBottom(hole)) {
       const floorZ = pocket.floorZ ?? -1;
-      const effectiveBottomFillet = Math.min(
-        hole.bottomFilletMm,
-        hole.depthMm / 2,
-        hole.diameterMm / 2,
-      );
+      const effectiveBottomFillet = effectiveFingerHoleBottomFilletMm(hole);
       const localCutter = bottomFilletCutter(
         kernel,
         section,

--- a/client/src/lib/gridfinity/cutouts.ts
+++ b/client/src/lib/gridfinity/cutouts.ts
@@ -6,6 +6,7 @@ import {
   effectiveFingerHoleDepthMm,
   effectiveFingerHoleTopFilletMm,
   effectiveFingerHoleBottomFilletMm,
+  effectiveFingerHoleCornerRoundMm,
   flatEndedScoopRadiusMm,
   effectiveScoopDepthMm,
   fingerHoleFootprintRing,
@@ -368,7 +369,8 @@ export function buildFingerHoleCutters(
     // Sample shallow curved bottoms directly so even a 1 mm cut preserves
     // its mouth width and exact depth, with or without top-edge rounding.
     const shallowCurved = hole.kind !== "flat-ended-scoop" && cutDepth < hole.diameterMm / 2;
-    if (!hasFlatFingerHoleBottom(hole) && (effectiveTopFillet > 0 || shallowCurved)) {
+    if (!hasFlatFingerHoleBottom(hole) &&
+        (effectiveTopFillet > 0 || shallowCurved || effectiveFingerHoleCornerRoundMm(hole) > 0)) {
       cutters.push(buildRoundedFingerAccessCutter(kernel, hole, pocket.infillTopZ, pocket.cutterTopZ, {
         radiusMm: effectiveTopFillet,
         profileStepMm: filletProfileStepMm,

--- a/client/src/lib/gridfinity/cutouts.ts
+++ b/client/src/lib/gridfinity/cutouts.ts
@@ -362,7 +362,10 @@ export function buildFingerHoleCutters(
     const pocket = resolvePocketDepth(spec, { mode: "mm", value: hole.depthMm });
     const cutDepth = effectiveFingerHoleDepthMm(hole);
     const effectiveTopFillet = Math.min(hole.topFilletMm, cutDepth / 2);
-    if (hole.kind !== "straight" && effectiveTopFillet > 0) {
+    // Sample shallow curved bottoms directly so even a 1 mm cut preserves
+    // its mouth width and exact depth, with or without top-edge rounding.
+    const shallowCurved = hole.kind !== "flat-ended-scoop" && cutDepth < hole.diameterMm / 2;
+    if (hole.kind !== "straight" && (effectiveTopFillet > 0 || shallowCurved)) {
       cutters.push(buildRoundedFingerAccessCutter(kernel, hole, pocket.infillTopZ, pocket.cutterTopZ, {
         radiusMm: effectiveTopFillet,
         profileStepMm: filletProfileStepMm,

--- a/client/src/lib/gridfinity/finger-access-rounding.test.ts
+++ b/client/src/lib/gridfinity/finger-access-rounding.test.ts
@@ -17,6 +17,8 @@ const cases = [
   { kind: "deep-scoop", depthMm: 1 }, { kind: "deep-scoop", depthMm: 12.5 }, { kind: "deep-scoop", depthMm: 20 },
   { kind: "oblong-deep-scoop", depthMm: 1 }, { kind: "oblong-deep-scoop", depthMm: 12.5 }, { kind: "oblong-deep-scoop", depthMm: 20 },
   { kind: "flat-ended-scoop", depthMm: 1 }, { kind: "flat-ended-scoop", depthMm: 5 }, { kind: "flat-ended-scoop", depthMm: 20 },
+  { kind: "oblong-straight", depthMm: 1 }, { kind: "oblong-straight", depthMm: 20 },
+  { kind: "flat-ended-straight", depthMm: 1 }, { kind: "flat-ended-straight", depthMm: 20 },
 ];
 
 describe.each(cases)("$kind at requested depth $depthMm", (settings) => {
@@ -49,7 +51,7 @@ describe.each(cases)("$kind at requested depth $depthMm", (settings) => {
       if (zs[0] > -r + 1e-5 && zs[0] < -1e-5 && Math.max(...zs) - Math.min(...zs) < 1e-7) steps++;
     }
     expect(steps).toBe(0);
-    if (hole.kind === "oblong-deep-scoop") {
+    if (hole.kind === "oblong-deep-scoop" || hole.kind === "oblong-straight") {
       // The cap tip and long side share the same rounded profile.
       const ring = sectionAt(rim.tangentZ / 2).toPolygons().flat();
       const maxX = Math.max(...ring.map(p => p[0]));
@@ -59,9 +61,9 @@ describe.each(cases)("$kind at requested depth $depthMm", (settings) => {
   });
 });
 
-it("preserves the straight hole's bottom fillet below the top rounding", () => {
+it.each(["straight", "oblong-straight", "flat-ended-straight"] as const)("preserves the %s bottom fillet below the top rounding", (kind) => {
   const hole = fingerHoleSchema.parse({
-    id: "straight", kind: "straight", center: { x: 0, y: 0 },
+    id: "straight", kind, center: { x: 0, y: 0 },
     diameterMm: 24, depthMm: 20, bottomFilletMm: 3,
   });
   const quality = { circularSegments: 64, filletProfileStepMm: 0.1 };

--- a/client/src/lib/gridfinity/finger-access-rounding.test.ts
+++ b/client/src/lib/gridfinity/finger-access-rounding.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { effectiveFingerHoleDepthMm, fingerHoleSchema, resolvePocketDepth } from "@shared/gridfinity/cutout";
+import { effectiveFingerHoleDepthMm, fingerHoleFootprintRing, fingerHoleSchema, resolvePocketDepth } from "@shared/gridfinity/cutout";
+import { signedArea } from "@shared/geometry/rings";
 import { parseBinSpec } from "@shared/gridfinity/types";
 import { Arena } from "@/lib/manifold/arena";
 import { createKernel, loadManifold, type Kernel } from "@/lib/manifold/runtime";
@@ -19,6 +20,11 @@ const cases = [
   { kind: "flat-ended-scoop", depthMm: 1 }, { kind: "flat-ended-scoop", depthMm: 5 }, { kind: "flat-ended-scoop", depthMm: 20 },
   { kind: "oblong-straight", depthMm: 1 }, { kind: "oblong-straight", depthMm: 20 },
   { kind: "flat-ended-straight", depthMm: 1 }, { kind: "flat-ended-straight", depthMm: 20 },
+  { kind: "flat-ended-scoop", depthMm: 1, cornerRoundMm: 3 },
+  { kind: "flat-ended-scoop", depthMm: 5, cornerRoundMm: 3 },
+  { kind: "flat-ended-scoop", depthMm: 20, cornerRoundMm: 3 },
+  { kind: "flat-ended-straight", depthMm: 1, cornerRoundMm: 3 },
+  { kind: "flat-ended-straight", depthMm: 20, cornerRoundMm: 3 },
 ];
 
 describe.each(cases)("$kind at requested depth $depthMm", (settings) => {
@@ -61,9 +67,57 @@ describe.each(cases)("$kind at requested depth $depthMm", (settings) => {
   });
 });
 
-it.each(["straight", "oblong-straight", "flat-ended-straight"] as const)("preserves the %s bottom fillet below the top rounding", (kind) => {
+describe.each(["flat-ended-scoop", "flat-ended-straight"] as const)("corner-rounded %s", (kind) => {
+  it.each([
+    [24, 40, 1, 3], [24, 40, 20, 3], [80, 6, 1, 40], [6, 6, 20, 40],
+  ])("preserves width %s, length %s and depth %s with requested radius %s", (diameterMm, lengthMm, depthMm, cornerRoundMm) => {
+    const hole = fingerHoleSchema.parse({ id: "corners", kind, center: { x: 3, y: -2 },
+      rotationDeg: 37, diameterMm, lengthMm, depthMm, cornerRoundMm });
+    const top = resolvePocketDepth(spec, { mode: "mm", value: depthMm }).infillTopZ;
+    for (const circularSegments of [24, 64]) {
+      const quality = { circularSegments, filletProfileStepMm: 0.1 };
+      const plain = buildFingerHoleCutters(kernel, [hole], spec, quality)[0];
+      const local = arena.track(arena.track(plain.translate([-3, 2, -top])).rotate([0, 0, -37]));
+      expect(local.status()).toBe("NoError");
+      const bounds = local.boundingBox();
+      expect(bounds.min[2]).toBeCloseTo(-depthMm, 6);
+      expect(bounds.min[0]).toBeCloseTo(-lengthMm / 2, 6);
+      expect(bounds.max[0]).toBeCloseTo(lengthMm / 2, 6);
+      expect(bounds.min[1]).toBeCloseTo(-diameterMm / 2, 6);
+      expect(bounds.max[1]).toBeCloseTo(diameterMm / 2, 6);
+      const ring = fingerHoleFootprintRing(hole, { position: { x: 0, y: 0 }, rotationDeg: 0, mirrored: false }, circularSegments);
+      expect(arena.track(local.slice(0.01)).area()).toBeCloseTo(signedArea(ring), 5);
+      const rounded = buildFingerHoleCutters(kernel, [{ ...hole, topFilletMm: 0.4 }], spec, quality)[0];
+      expect(rounded.status()).toBe("NoError");
+      expect(rounded.boundingBox().min[2]).toBeCloseTo(top - depthMm, 6);
+      // Tangency changes the arc samples, but not the underlying bottom profile.
+      for (const z of [top - depthMm * 0.9, top - depthMm * 0.5]) {
+        const before = arena.track(plain.slice(z)).area();
+        const after = arena.track(rounded.slice(z)).area();
+        expect(Math.abs(after - before)).toBeLessThan(before * 0.001);
+      }
+    }
+  });
+
+  it("keeps a flat end between rounded corners, without cutting beyond the ends", () => {
+    const hole = fingerHoleSchema.parse({ id: "end", kind, center: { x: 0, y: 0 },
+      diameterMm: 16, lengthMm: 40, depthMm: 20, cornerRoundMm: 3 });
+    const cutter = buildFingerHoleCutters(kernel, [hole], spec, { circularSegments: 64 })[0];
+    const top = resolvePocketDepth(spec, { mode: "mm", value: 20 }).infillTopZ;
+    const ring = arena.track(cutter.slice(top - 1)).toPolygons().flat();
+    const end = ring.filter(p => Math.abs(p[0] - 20) < 1e-6);
+    expect(Math.max(...end.map(p => p[1]))).toBeCloseTo(5, 6);
+    expect(Math.min(...end.map(p => p[1]))).toBeCloseTo(-5, 6);
+    expect(Math.max(...ring.map(p => p[0]))).toBeCloseTo(20, 6);
+  });
+});
+
+it.each([
+  { kind: "straight" }, { kind: "oblong-straight" }, { kind: "flat-ended-straight" },
+  { kind: "flat-ended-straight", cornerRoundMm: 3 },
+])("preserves the $kind bottom fillet below the top rounding, corner radius $cornerRoundMm", (settings) => {
   const hole = fingerHoleSchema.parse({
-    id: "straight", kind, center: { x: 0, y: 0 },
+    id: "straight", ...settings, center: { x: 0, y: 0 },
     diameterMm: 24, depthMm: 20, bottomFilletMm: 3,
   });
   const quality = { circularSegments: 64, filletProfileStepMm: 0.1 };

--- a/client/src/lib/gridfinity/finger-access-rounding.ts
+++ b/client/src/lib/gridfinity/finger-access-rounding.ts
@@ -4,6 +4,9 @@ import {
   effectiveFingerHoleDepthMm,
   capsuleRing,
   flatEndedScoopRadiusMm,
+  hasFlatFingerHoleBottom,
+  hasFlatFingerHoleEnds,
+  isElongatedFingerHole,
   type FingerHole,
 } from "@shared/gridfinity/cutout";
 import type { Kernel } from "@/lib/manifold/runtime";
@@ -18,7 +21,7 @@ export function fingerAccessRimGeometry(
   const radius = flatEndedScoopRadiusMm({ ...hole, depthMm: depth });
   const centerZ = radius - depth;
   // A shaft at least as tall as the rim radius takes an ordinary quarter circle.
-  const verticalJoin = hole.kind === "straight" || centerZ <= -rimRadius;
+  const verticalJoin = hasFlatFingerHoleBottom(hole) || centerZ <= -rimRadius;
   // The fillet centre is (openingHalfWidth, -rimRadius). External tangency
   // requires its distance from the cylinder centre to equal radius + rimRadius.
   const openingHalfWidth = verticalJoin
@@ -45,7 +48,7 @@ export function fingerAccessHalfWidthAtZ(
   if (z >= rim.tangentZ) {
     return rim.openingHalfWidth - Math.sqrt(Math.max(0, rim.rimRadius ** 2 - (z + rim.rimRadius) ** 2));
   }
-  if (hole.kind === "straight" || z >= rim.centerZ) return hole.diameterMm / 2;
+  if (hasFlatFingerHoleBottom(hole) || z >= rim.centerZ) return hole.diameterMm / 2;
   const height = Math.max(0, z + rim.depth);
   return Math.sqrt(Math.max(0, height * (2 * rim.radius - height)));
 }
@@ -67,9 +70,9 @@ export function buildRoundedFingerAccessCutter(
   const { arena, CrossSection } = kernel;
   const r = options.radiusMm;
   const rim = fingerAccessRimGeometry(hole, r);
-  const flatEnded = hole.kind === "flat-ended-scoop";
-  const oblong = hole.kind === "oblong-deep-scoop";
-  const straight = hole.kind === "straight";
+  const flatEnded = hasFlatFingerHoleEnds(hole);
+  const oblong = isElongatedFingerHole(hole) && !flatEnded;
+  const straight = hasFlatFingerHoleBottom(hole);
   const { lengthMm } = elongatedFingerHoleEndpoints(hole);
   const halfSpan = oblong ? (lengthMm - hole.diameterMm) / 2 : 0;
   const halfWidth = hole.diameterMm / 2;

--- a/client/src/lib/gridfinity/finger-access-rounding.ts
+++ b/client/src/lib/gridfinity/finger-access-rounding.ts
@@ -51,7 +51,8 @@ export function fingerAccessHalfWidthAtZ(
 }
 
 /**
- * Curved styles use a whole cutter with tangent circular profiles. Round holes
+ * Curved styles use a whole cutter with tangent circular profiles (a zero rim
+ * radius also supports unrounded shallow round and oblong cuts). Round holes
  * use circular rings, oblongs sweep them along the capsule spine, and flat-ended
  * scoops retain planar ends with quarter-circle end rounding. Straight holes
  * return only the top flare to preserve their separately built bottom fillet.

--- a/client/src/lib/gridfinity/finger-access-rounding.ts
+++ b/client/src/lib/gridfinity/finger-access-rounding.ts
@@ -2,7 +2,9 @@ import type { Manifold } from "manifold-3d";
 import {
   elongatedFingerHoleEndpoints,
   effectiveFingerHoleDepthMm,
+  effectiveFingerHoleCornerRoundMm,
   capsuleRing,
+  roundedRectangleRing,
   flatEndedScoopRadiusMm,
   hasFlatFingerHoleBottom,
   hasFlatFingerHoleEnds,
@@ -76,6 +78,7 @@ export function buildRoundedFingerAccessCutter(
   const { lengthMm } = elongatedFingerHoleEndpoints(hole);
   const halfSpan = oblong ? (lengthMm - hole.diameterMm) / 2 : 0;
   const halfWidth = hole.diameterMm / 2;
+  const corner = effectiveFingerHoleCornerRoundMm(hole);
   const steps = Math.max(
     12,
     Math.ceil(options.circularSegments / 2),
@@ -83,7 +86,7 @@ export function buildRoundedFingerAccessCutter(
   );
   const heights = [straight ? -r : -rim.depth, rim.tangentZ, -r, 0, cutterTopZ - topZ];
   const bottomAngle = rim.verticalJoin ? Math.PI / 2 : Math.asin(rim.tangentHalfWidth / rim.radius);
-  const rimAngle = Math.acos(Math.max(0, Math.min(1, (rim.tangentZ + r) / r)));
+  const rimAngle = r === 0 ? 0 : Math.acos(Math.max(0, Math.min(1, (rim.tangentZ + r) / r)));
   for (let i = 0; i <= steps; i++) {
     // Sample the cylinder and both fillets by angle, including their tangent joins.
     if (!straight) heights.push(-rim.depth + 2 * rim.radius * Math.sin(bottomAngle * i / (2 * steps)) ** 2);
@@ -94,8 +97,11 @@ export function buildRoundedFingerAccessCutter(
     .sort((a, b) => a - b)
     .filter((z, i, all) => i === 0 || z - all[i - 1] > 1e-9);
   const template = flatEnded
-    ? arena.track(arena.track(CrossSection.square([lengthMm, hole.diameterMm], true))
-        .offset(r, "Round", 2, options.circularSegments))
+    ? corner > 0
+      ? arena.track(new CrossSection([roundedRectangleRing(lengthMm + 2 * r, hole.diameterMm + 2 * r,
+          corner + r, options.circularSegments).map(({ x, y }) => [x, y] as [number, number])]))
+      : arena.track(arena.track(CrossSection.square([lengthMm, hole.diameterMm], true))
+          .offset(r, "Round", 2, options.circularSegments))
     : oblong
       ? arena.track(new CrossSection([capsuleRing(
           { x: -halfSpan, y: 0 }, { x: halfSpan, y: 0 }, halfWidth,
@@ -111,10 +117,14 @@ export function buildRoundedFingerAccessCutter(
       const endOutset = z <= -r
         ? 0
         : z >= 0 ? r : r - Math.sqrt(Math.max(0, r * r - (z + r) ** 2));
-      const baseX = Math.max(-lengthMm / 2, Math.min(lengthMm / 2, vertex[0]));
-      const baseY = Math.max(-halfWidth, Math.min(halfWidth, vertex[1]));
-      vertex[0] = baseX + (vertex[0] - baseX) * endOutset / r;
-      vertex[1] = baseY / halfWidth * (width - endOutset) + (vertex[1] - baseY) * endOutset / r;
+      const baseX = Math.max(-lengthMm / 2 + corner, Math.min(lengthMm / 2 - corner, vertex[0]));
+      const baseY = Math.max(-halfWidth + corner, Math.min(halfWidth - corner, vertex[1]));
+      // Keep the planar ends and scale corner arcs with the narrowing trough.
+      // At a straight wall this is a circular corner plus the outward rim round.
+      const nx = (vertex[0] - baseX) / (corner + r);
+      const ny = (vertex[1] - baseY) / (corner + r);
+      vertex[0] = baseX + nx * (corner + endOutset);
+      vertex[1] = (baseY + ny * corner) / halfWidth * (width - endOutset) + ny * endOutset;
     } else {
       const baseX = Math.max(-halfSpan, Math.min(halfSpan, vertex[0]));
       vertex[0] = baseX + (vertex[0] - baseX) * width / halfWidth;

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -248,7 +248,7 @@ function openSettingsSection(
   React.act(() => {
     (
       container.querySelector(
-        `[data-testid="bin-settings-jump-${section === "tool-cutouts" ? "pockets" : section === "finger-holes" ? "finger-access" : section}"]`,
+        `[data-testid="bin-settings-jump-${section === "tool-cutouts" ? "pockets" : section === "finger-holes" ? "finger-access" : section === "materials" ? "materials-&-colors" : section}"]`,
       ) as HTMLButtonElement
     ).click();
   });
@@ -827,7 +827,7 @@ describe("BinDesignerPage", () => {
     unmount();
   });
 
-  it.each(["straight", "scoop", "deep-scoop", "oblong-deep-scoop", "flat-ended-scoop"] as const)("edits %s at 1 mm depth without a duplicate heading", async (kind) => {
+  it.each(["straight", "scoop", "deep-scoop", "oblong-deep-scoop", "flat-ended-scoop", "oblong-straight", "flat-ended-straight"] as const)("edits %s at 1 mm depth without a duplicate heading", async (kind) => {
     vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
       ...EMPTY_PROJECT, fingerHoles: [fingerHoleSchema.parse({ id: "shallow", kind, center: { x: 0, y: 0 }, depthMm: 12, lengthMm: 40 })],
     });
@@ -836,10 +836,9 @@ describe("BinDesignerPage", () => {
     openSettingsSection(container, "finger-holes");
     React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-finger-hole-shallow"]')!.click());
     const properties = container.querySelector('#finger-access-properties')!;
-    expect(properties.textContent).toContain("Style");
+    expect(properties.textContent).toContain("Shape");
     expect(properties.querySelector('[aria-label="Finger access depth"] h4')).toBeNull();
-    const label = kind === "straight" || kind === "scoop" ? "Depth" : "Total depth";
-    const input = properties.querySelector<HTMLInputElement>(`[aria-label="${label} in millimetres"]`)!;
+    const input = properties.querySelector<HTMLInputElement>('[aria-label="Depth in millimetres"]')!;
     expect(input.min).toBe("1");
     React.act(() => {
       Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, "1");
@@ -847,7 +846,7 @@ describe("BinDesignerPage", () => {
     });
     React.act(() => input.dispatchEvent(new FocusEvent("focusout", { bubbles: true })));
     expect(input.value).toBe("1");
-    expect(vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0]).toMatchObject({ kind, depthMm: 1 });
+    expect(vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0]).toMatchObject({ kind: kind === "scoop" ? "deep-scoop" : kind, depthMm: 1 });
     unmount();
   });
 
@@ -895,7 +894,157 @@ describe("BinDesignerPage", () => {
     unmount();
   });
 
-  it("restores a deep finger scoop with diameter and total-depth controls", async () => {
+  it("switches all six shape combinations without losing dimensions and undoes the change", async () => {
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({ ...EMPTY_PROJECT,
+      fingerHoles: [fingerHoleSchema.parse({ id: "styles", kind: "straight", center: { x: 0, y: 0 }, diameterMm: 18, depthMm: 30, lengthMm: 40, rotationDeg: 37, bottomFilletMm: 2 })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "finger-holes");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-finger-hole-styles"]')!.click());
+    const current = () => vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0];
+    expect(container.querySelector('[data-testid="finger-ends-flat"]')).toBeNull();
+    for (const [option, kind] of [["bottom-curved", "deep-scoop"], ["shape-slot", "oblong-deep-scoop"],
+      ["ends-flat", "flat-ended-scoop"], ["bottom-flat", "flat-ended-straight"],
+      ["ends-rounded", "oblong-straight"], ["shape-round", "straight"]] as const) {
+      React.act(() => container.querySelector<HTMLButtonElement>(`[data-testid="finger-${option}"]`)!.click());
+      expect(current()).toMatchObject({ kind, depthMm: 30, diameterMm: 18, lengthMm: 40, rotationDeg: 37, bottomFilletMm: 2 });
+      expect(container.querySelector('[data-testid="finger-access-shape-controls"] [role="img"]')).not.toBeNull();
+      const bottomRound = container.querySelector('#finger-access-properties [aria-label="Bottom edge round"]');
+      expect(bottomRound !== null).toBe(kind.endsWith("straight"));
+    }
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.click());
+    expect(current()).toMatchObject({ kind: "oblong-straight", depthMm: 30 });
+    expect(container.querySelector('[data-testid="finger-ends-rounded"]')?.getAttribute("aria-checked")).toBe("true");
+    unmount();
+  });
+
+  it.each(["scoop", "oblong-deep-scoop", "flat-ended-scoop"] as const)("keeps saved %s geometry until edited and allows an 80 mm opening", async (kind) => {
+    const original = fingerHoleSchema.parse({ id: "wide", kind, center: { x: 0, y: 0 }, diameterMm: 18, depthMm: 8, lengthMm: 40 });
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({ ...EMPTY_PROJECT, fingerHoles: [original] });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "finger-holes");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-finger-hole-wide"]')!.click());
+    expect(vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0]).toEqual(original);
+    const input = container.querySelector<HTMLInputElement>(`#finger-access-properties [aria-label="${kind === "scoop" ? "Diameter" : "Width"} in millimetres"]`)!;
+    expect(input.max).toBe("80");
+    React.act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, "80");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    React.act(() => input.dispatchEvent(new FocusEvent("focusout", { bubbles: true })));
+    const updated = vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0];
+    expect(updated).toMatchObject({ diameterMm: 80, depthMm: 8, kind: kind === "scoop" ? "deep-scoop" : kind });
+    expect(parseProjectDoc({ ...EMPTY_PROJECT, fingerHoles: [updated] })?.fingerHoles[0]).toEqual(updated);
+    unmount();
+  });
+
+  it("updates finger-access field limits with bin height and slot rotation, rejecting oversized input", async () => {
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({ ...EMPTY_PROJECT,
+      spec: { ...EMPTY_PROJECT.spec, gridX: 1, gridY: 2, heightUnits: 2 },
+      fingerHoles: [fingerHoleSchema.parse({ id: "limits", kind: "flat-ended-straight", center: { x: 0, y: 0 }, diameterMm: 18, lengthMm: 30, depthMm: 12 })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "finger-holes");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-finger-hole-limits"]')!.click());
+    const input = (name: string) => container.querySelector<HTMLInputElement>(`[aria-label="${name}"]`)!;
+    const setNumber = (name: string, value: string) => {
+      const field = input(name);
+      React.act(() => {
+        Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(field, value);
+        field.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      React.act(() => field.dispatchEvent(new FocusEvent("focusout", { bubbles: true })));
+    };
+    expect(input("Depth in millimetres").max).toBe("12.8");
+    const slider = container.querySelector<HTMLElement>('[role="slider"][aria-label="Depth"]')!;
+    expect(input("Length in millimetres").max).toBe("43.57");
+    expect(input("Width in millimetres").max).toBe("80");
+    setNumber("Depth in millimetres", "20");
+    expect(input("Depth in millimetres").value).toBe("12");
+    setNumber("Length in millimetres", "100");
+    expect(input("Length in millimetres").value).toBe("30");
+    setNumber("Elongated finger hole rotation", "90");
+    expect(input("Length in millimetres").max).toBe("87.67");
+    expect(input("Width in millimetres").max).toBe("43.57");
+    React.act(() => container.querySelector<HTMLButtonElement>('#bin-settings-size [data-panel-section-trigger]')!.click());
+    setNumber("Bin height in units", "1");
+    expect(input("Depth in millimetres").max).toBe("5.8");
+    expect(input("Depth in millimetres").value).toBe("5.8");
+    expect(vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0].depthMm).toBe(5.8);
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.click());
+    expect(input("Bin height in units").value).toBe("2");
+    expect(input("Depth in millimetres").value).toBe("12");
+    React.act(() => slider.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true })));
+    expect(input("Depth in millimetres").value).toBe("12.8");
+    expect(vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0].depthMm).toBe(12.8);
+    unmount();
+  });
+
+  it.each([
+    { heightUnits: 4, lip: "standard" as const, flatBottom: false, depth: 26.8 },
+    { heightUnits: 4, lip: "none" as const, flatBottom: true, depth: 28 },
+    { heightUnits: 20, lip: "none" as const, flatBottom: false, depth: 120 },
+  ])("keeps the depth cap without a floor indicator for $heightUnits units, $lip lip, flat bottom $flatBottom", async ({ heightUnits, lip, flatBottom, depth }) => {
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({ ...EMPTY_PROJECT,
+      spec: { ...EMPTY_PROJECT.spec, heightUnits, lip, flatBottom },
+      fingerHoles: [fingerHoleSchema.parse({ id: "floor", center: { x: 0, y: 0 }, depthMm: 12 })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "finger-holes");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-finger-hole-floor"]')!.click());
+    expect(container.querySelector<HTMLInputElement>('[aria-label="Depth in millimetres"]')?.max).toBe(String(depth));
+    expect(container.querySelector('[data-slider-marker]')).toBeNull();
+    expect(container.querySelector('[aria-label="Finger access depth"]')?.textContent).not.toContain("Base floor");
+    unmount();
+  });
+
+  it("flags an oversized saved slot without silently rewriting it or inverting its length range", async () => {
+    const hole = fingerHoleSchema.parse({ id: "old-large", kind: "oblong-straight", center: { x: 0, y: 0 }, diameterMm: 80, lengthMm: 160, depthMm: 120 });
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({ ...EMPTY_PROJECT,
+      spec: { ...EMPTY_PROJECT.spec, gridX: 1, gridY: 1, heightUnits: 1 }, fingerHoles: [hole],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "finger-holes");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-finger-hole-old-large"]')!.click());
+    expect(container.querySelector('#finger-access-properties')?.textContent).toContain("Opening exceeds this bin's size limits.");
+    expect(vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0]).toEqual(hole);
+    const length = container.querySelector<HTMLInputElement>('[aria-label="Length in millimetres"]')!;
+    expect(Number(length.min)).toBeLessThanOrEqual(Number(length.max));
+    unmount();
+  });
+
+  it("shows effective shallow rounding and restores the requested radii when depth increases", async () => {
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({ ...EMPTY_PROJECT,
+      fingerHoles: [fingerHoleSchema.parse({ id: "rounding", center: { x: 0, y: 0 }, depthMm: 1, topFilletMm: 1, bottomFilletMm: 2 })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "finger-holes");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-finger-hole-rounding"]')!.click());
+    for (const label of ["Top edge round", "Bottom edge round"]) {
+      const input = container.querySelector<HTMLInputElement>(`[aria-label="${label} in millimetres"]`)!;
+      expect(input.value).toBe("0.5");
+      expect(input.max).toBe("0.5");
+    }
+    expect(container.textContent).toContain("Requested 1 mm; limited by depth.");
+    const depth = container.querySelector<HTMLInputElement>('[aria-label="Depth in millimetres"]')!;
+    React.act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(depth, "12");
+      depth.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    React.act(() => depth.dispatchEvent(new FocusEvent("focusout", { bubbles: true })));
+    expect(container.querySelector<HTMLInputElement>('[aria-label="Top edge round in millimetres"]')!.value).toBe("1");
+    expect(container.querySelector<HTMLInputElement>('[aria-label="Bottom edge round in millimetres"]')!.value).toBe("2");
+    expect(vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0]).toMatchObject({ depthMm: 12, topFilletMm: 1, bottomFilletMm: 2 });
+    unmount();
+  });
+
+  it("restores a deep finger scoop as Round with a curved bottom without changing geometry", async () => {
     const shape = rectangularShape("shape-deep", "Deep pliers");
     vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
       ...EMPTY_PROJECT,
@@ -932,10 +1081,11 @@ describe("BinDesignerPage", () => {
     });
 
     expect(
-      container.querySelector('[data-testid="selected-finger-hole-kind"]')?.textContent,
-    ).toContain("Deep scoop");
+      container.querySelector('[data-testid="finger-shape-round"]')?.getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(container.querySelector('[data-testid="finger-bottom-curved"]')?.getAttribute("aria-checked")).toBe("true");
     expect(container.querySelector('[aria-label="Diameter"]')).not.toBeNull();
-    expect(container.querySelector('[aria-label="Total depth"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Depth"]')).not.toBeNull();
     const fingerHoleSection = container.querySelector(
       '#bin-settings-finger-holes',
     );
@@ -943,11 +1093,10 @@ describe("BinDesignerPage", () => {
       fingerHoleSection?.querySelector('[aria-label="Top edge round"]'),
     ).not.toBeNull();
     expect(
-      fingerHoleSection?.querySelector('[aria-label="Bottom edge fillet"]'),
+      fingerHoleSection?.querySelector('[aria-label="Bottom edge round"]'),
     ).toBeNull();
     expect(container.querySelector('[aria-label="Reach"]')).toBeNull();
-    expect(container.textContent).toContain("Vertical walls: 22.0 mm");
-    expect(container.textContent).toContain("rounded bottom radius: 8.0 mm");
+    expect(vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0]).toMatchObject({ kind: "deep-scoop", depthMm: 30, diameterMm: 16 });
 
     React.act(() => {
       (container.querySelector('[data-testid="view-toggle-2d"]') as HTMLButtonElement).click();
@@ -960,6 +1109,7 @@ describe("BinDesignerPage", () => {
 
   it.each([
     ["oblong-deep-scoop", 30], ["flat-ended-scoop", 30], ["flat-ended-scoop", 1],
+    ["oblong-straight", 1], ["flat-ended-straight", 30],
   ] as const)("restores %s with rotation controls and endpoint handles", async (kind, depthMm) => {
     const shape = rectangularShape("shape-oblong-deep", "Long pliers");
     vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
@@ -999,10 +1149,11 @@ describe("BinDesignerPage", () => {
     });
 
     expect(
-      container.querySelector('[data-testid="selected-finger-hole-kind"]')?.textContent,
-    ).toContain(kind === "flat-ended-scoop" ? "Flat-ended cylindrical scoop" : "Oblong deep scoop");
-    expect(container.querySelector('[aria-label="Diameter"]')).not.toBeNull();
-    expect(container.querySelector('[aria-label="Total depth"]')).not.toBeNull();
+      container.querySelector('[data-testid="finger-shape-slot"]')?.getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(container.querySelector(`[data-testid="finger-ends-${kind.startsWith("flat-ended") ? "flat" : "rounded"}"]`)?.getAttribute("aria-checked")).toBe("true");
+    expect(container.querySelector('#finger-access-properties [aria-label="Width"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Depth"]')).not.toBeNull();
     expect(container.querySelector('[aria-label="Length"]')).not.toBeNull();
     const rotateClockwise = container.querySelector(
       '[aria-label="Rotate elongated finger hole 90 degrees clockwise"]',
@@ -1013,9 +1164,7 @@ describe("BinDesignerPage", () => {
         '[aria-label="Rotate elongated finger hole 90 degrees counterclockwise"]',
       ),
     ).not.toBeNull();
-    expect(container.textContent).toContain(`Vertical walls: ${Math.max(0, depthMm - 6).toFixed(1)} mm`);
-    expect(container.textContent).toContain(`rounded bottom radius: ${depthMm === 1 ? "18.5" : "6.0"} mm`);
-    const depthInput = container.querySelector<HTMLInputElement>('[aria-label="Total depth in millimetres"]')!;
+    const depthInput = container.querySelector<HTMLInputElement>('[aria-label="Depth in millimetres"]')!;
     expect(depthInput.value).toBe(String(depthMm));
     expect(depthInput.min).toBe("1");
 
@@ -1158,7 +1307,7 @@ describe("BinDesignerPage", () => {
     React.act(() => {
       (
         container.querySelector(
-          '[data-testid="bin-settings-jump-materials"]',
+          '[data-testid="bin-settings-jump-materials-&-colors"]',
         ) as HTMLButtonElement
       ).click();
     });
@@ -1302,7 +1451,7 @@ describe("BinDesignerPage", () => {
     setNumber(depthInput, "39");
     expect(container.querySelector(issueSelector)).not.toBeNull();
 
-    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="bin-settings-jump-materials"]')!.click());
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="bin-settings-jump-materials-&-colors"]')!.click());
     expect(container.querySelector('[aria-label="Pocket floor color warnings"]')).toBeNull();
     expect(container.querySelector('[data-testid="canvas-warnings"]')!.textContent).toContain("Air Duster");
     const thicknessInput = container.querySelector<HTMLInputElement>('[data-testid="input-pocket-floor-thickness"]')!;
@@ -1331,7 +1480,7 @@ describe("BinDesignerPage", () => {
     React.act(() => {
       (
         container.querySelector(
-          '[data-testid="bin-settings-jump-materials"]',
+          '[data-testid="bin-settings-jump-materials-&-colors"]',
         ) as HTMLButtonElement
       ).click();
     });
@@ -1832,11 +1981,8 @@ describe("BinDesignerPage", () => {
       '[data-testid="button-add-finger-hole"]',
     ) as HTMLButtonElement;
     React.act(() => addFingerHole.click());
-    const kind = container.querySelector(
-      '[data-testid="selected-finger-hole-kind"]',
-    ) as HTMLButtonElement | null;
-    expect(kind).not.toBeNull();
-    expect(kind!.textContent).toContain("Vertical Cylinder");
+    expect(container.querySelector('[data-testid="finger-shape-round"]')?.getAttribute("aria-checked")).toBe("true");
+    expect(container.querySelector('[data-testid="finger-bottom-flat"]')?.getAttribute("aria-checked")).toBe("true");
     expect(container.textContent).not.toContain("Scoop depth");
     const fingerHoleSection = container.querySelector(
       '#bin-settings-finger-holes',
@@ -1850,7 +1996,7 @@ describe("BinDesignerPage", () => {
     expect(fingerTopRoundSlider?.getAttribute("aria-valuemax")).toBe("5");
     expect(fingerTopRoundSlider?.getAttribute("aria-valuenow")).toBe("1");
     expect(
-      fingerHoleSection?.querySelector('[aria-label="Bottom edge fillet"]'),
+      fingerHoleSection?.querySelector('[aria-label="Bottom edge round"]'),
     ).not.toBeNull();
 
     React.act(() => {
@@ -2038,10 +2184,12 @@ describe("BinDesignerPage", () => {
 
   it("counts only color regions that exist in the current model", () => {
     const { container, unmount } = renderPage();
+    expect(container.querySelector('[data-testid="bin-settings-jump-materials-&-colors"]')?.textContent)
+      .toBe("Materials & Colors");
     React.act(() => {
       (
         container.querySelector(
-          '[data-testid="bin-settings-jump-materials"]',
+          '[data-testid="bin-settings-jump-materials-&-colors"]',
         ) as HTMLButtonElement
       ).click();
     });
@@ -2049,6 +2197,8 @@ describe("BinDesignerPage", () => {
       container.querySelector("#bin-settings-materials [data-panel-section-trigger]")
         ?.textContent,
     ).toContain("2 colors");
+    expect(container.querySelector("#bin-settings-materials [data-panel-section-trigger]")?.textContent)
+      .toContain("Materials & Colors");
     unmount();
   });
 

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -896,6 +896,51 @@ describe("BinDesignerPage", () => {
     unmount();
   });
 
+  it.each(["flat-ended-scoop", "flat-ended-straight"] as const)("edits %s corner rounding with size limits, undo, and retained shape preferences", async (kind) => {
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({ ...EMPTY_PROJECT,
+      fingerHoles: [fingerHoleSchema.parse({ id: "corners", kind, center: { x: 0, y: 0 }, diameterMm: 24, lengthMm: 16, depthMm: 20 })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "finger-holes");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-finger-hole-corners"]')!.click());
+    const input = () => container.querySelector<HTMLInputElement>('[aria-label="Corner round in millimetres"]');
+    const current = () => vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0];
+    const edit = (label: string, value: string) => {
+      const field = container.querySelector<HTMLInputElement>(`#finger-access-properties [aria-label="${label} in millimetres"]`)!;
+      React.act(() => {
+        Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(field, value);
+        field.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      React.act(() => field.dispatchEvent(new FocusEvent("focusout", { bubbles: true })));
+    };
+    expect(input()!.closest("details")?.getAttribute("data-testid")).toBe("finger-edge-settings");
+    expect(input()!.value).toBe("0");
+    expect(input()!.max).toBe("8");
+    edit("Corner round", "5");
+    expect(current()?.cornerRoundMm).toBe(5);
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.click());
+    expect(input()!.value).toBe("0");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-bin-redo"]')!.click());
+    expect(input()!.value).toBe("5");
+    edit("Width", "6");
+    expect(input()!.max).toBe("3");
+    expect(input()!.value).toBe("3");
+    expect(current()?.cornerRoundMm).toBe(5);
+    edit("Width", "24");
+    expect(input()!.value).toBe("5");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="finger-ends-rounded"]')!.click());
+    expect(input()).toBeNull();
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="finger-ends-flat"]')!.click());
+    expect(input()!.value).toBe("5");
+    edit("Corner round", "99");
+    expect(input()!.value).toBe("5");
+    edit("Corner round", "8");
+    expect(input()!.value).toBe("8");
+    expect(parseProjectDoc({ ...EMPTY_PROJECT, fingerHoles: [current()] })?.fingerHoles[0].cornerRoundMm).toBe(8);
+    unmount();
+  });
+
   it("switches all six shape combinations without losing dimensions and undoes the change", async () => {
     vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({ ...EMPTY_PROJECT,
       fingerHoles: [fingerHoleSchema.parse({ id: "styles", kind: "straight", center: { x: 0, y: 0 }, diameterMm: 18, depthMm: 30, lengthMm: 40, rotationDeg: 37, bottomFilletMm: 2 })],

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -330,6 +330,7 @@ describe("BinDesignerPage", () => {
       expect(editor.querySelector<HTMLDetailsElement>(`[data-testid="${id}"]`)!.open).toBe(false);
     }
     expect(editor.querySelector('[aria-label="Extra pocket clearance in millimetres"]')!.closest('details')!.dataset.testid).toBe('pocket-clearance-settings');
+    expect(editor.lastElementChild?.querySelector('[data-testid="pocket-position-settings"]')).not.toBeNull();
     expect(editor.querySelector('[data-testid="button-inspect-pocket"]')!.closest('details')!.dataset.testid).toBe('pocket-depth-summary');
     expect(editor.querySelector<HTMLDetailsElement>('[data-testid="pocket-depth-summary"]')!.open).toBe(false);
     expect(container.querySelector('[data-testid="button-layout-edit-pocket"]')).toBeNull();
@@ -826,6 +827,74 @@ describe("BinDesignerPage", () => {
     unmount();
   });
 
+  it.each(["straight", "scoop", "deep-scoop", "oblong-deep-scoop", "flat-ended-scoop"] as const)("edits %s at 1 mm depth without a duplicate heading", async (kind) => {
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT, fingerHoles: [fingerHoleSchema.parse({ id: "shallow", kind, center: { x: 0, y: 0 }, depthMm: 12, lengthMm: 40 })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "finger-holes");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-select-finger-hole-shallow"]')!.click());
+    const properties = container.querySelector('#finger-access-properties')!;
+    expect(properties.textContent).toContain("Style");
+    expect(properties.querySelector('[aria-label="Finger access depth"] h4')).toBeNull();
+    const label = kind === "straight" || kind === "scoop" ? "Depth" : "Total depth";
+    const input = properties.querySelector<HTMLInputElement>(`[aria-label="${label} in millimetres"]`)!;
+    expect(input.min).toBe("1");
+    React.act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, "1");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    React.act(() => input.dispatchEvent(new FocusEvent("focusout", { bubbles: true })));
+    expect(input.value).toBe("1");
+    expect(vi.mocked(useBinGeometry).mock.lastCall?.[2]?.fingerHoles?.[0]).toMatchObject({ kind, depthMm: 1 });
+    unmount();
+  });
+
+  it("groups finger access like pockets and supports renaming, undo, and cancellation", async () => {
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
+      ...EMPTY_PROJECT,
+      fingerHoles: [fingerHoleSchema.parse({ id: "named-hole", center: { x: 0, y: 0 } })],
+    });
+    const { container, unmount } = renderPage();
+    await flushHydration();
+    openSettingsSection(container, "finger-holes");
+    const select = () => container.querySelector<HTMLButtonElement>('[data-testid="button-select-finger-hole-named-hole"]')!;
+    React.act(() => select().click());
+    expect(select().getAttribute("aria-pressed")).toBe("true");
+    const properties = container.querySelector("#finger-access-properties")!;
+    expect(properties.firstElementChild?.textContent).toContain("Finger access properties");
+    expect(properties.querySelector('[aria-label="Depth in millimetres"]')!.closest('details')).toBeNull();
+    for (const id of ["finger-size-settings", "finger-edge-settings", "finger-position-settings"]) {
+      expect(properties.querySelector<HTMLDetailsElement>(`[data-testid="${id}"]`)!.open).toBe(false);
+    }
+    expect(properties.lastElementChild?.getAttribute("data-testid")).toBe("finger-position-settings");
+    const editName = (value: string) => {
+      React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-rename-finger-hole-named-hole"]')!.click());
+      const input = container.querySelector<HTMLInputElement>('[aria-label="Finger access name"]')!;
+      React.act(() => {
+        Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, value);
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      return input;
+    };
+    let input = editName("  Thumb access  ");
+    React.act(() => input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+    expect(select().textContent).toBe("Thumb access");
+    expect(properties.firstElementChild?.textContent).toContain("Thumb access");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-bin-undo"]')!.click());
+    expect(select().textContent).toBe("Hole 1");
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-bin-redo"]')!.click());
+    expect(select().textContent).toBe("Thumb access");
+    input = editName("Cancelled name");
+    React.act(() => input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
+    expect(select().textContent).toBe("Thumb access");
+    input = editName("   ");
+    React.act(() => input.blur());
+    expect(select().textContent).toBe("Thumb access");
+    unmount();
+  });
+
   it("restores a deep finger scoop with diameter and total-depth controls", async () => {
     const shape = rectangularShape("shape-deep", "Deep pliers");
     vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue({
@@ -948,7 +1017,7 @@ describe("BinDesignerPage", () => {
     expect(container.textContent).toContain(`rounded bottom radius: ${depthMm === 1 ? "18.5" : "6.0"} mm`);
     const depthInput = container.querySelector<HTMLInputElement>('[aria-label="Total depth in millimetres"]')!;
     expect(depthInput.value).toBe(String(depthMm));
-    expect(depthInput.min).toBe(kind === "flat-ended-scoop" ? "1" : "6");
+    expect(depthInput.min).toBe("1");
 
     React.act(() => {
       (container.querySelector('[data-testid="view-toggle-2d"]') as HTMLButtonElement).click();
@@ -1767,7 +1836,7 @@ describe("BinDesignerPage", () => {
       '[data-testid="selected-finger-hole-kind"]',
     ) as HTMLButtonElement | null;
     expect(kind).not.toBeNull();
-    expect(kind!.textContent).toContain("Straight");
+    expect(kind!.textContent).toContain("Vertical Cylinder");
     expect(container.textContent).not.toContain("Scoop depth");
     const fingerHoleSection = container.querySelector(
       '#bin-settings-finger-holes',

--- a/client/src/state/bin-store.test.tsx
+++ b/client/src/state/bin-store.test.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { parseCutoutPlacement } from "@shared/gridfinity/cutout";
+import { clampFingerHoleToBin, fingerHoleSchema, parseCutoutPlacement } from "@shared/gridfinity/cutout";
 
 import {
   BinProvider,
@@ -47,6 +47,49 @@ const CUTOUT = parseCutoutPlacement({
 });
 
 describe("bin store", () => {
+  it("limits added and edited finger access, and undoes each adjustment atomically", () => {
+    const { store, act } = mountBin();
+    act(() => store().dispatch({ type: "PATCH_SPEC", patch: { gridX: 1, gridY: 1, heightUnits: 2 } }));
+    const hole = fingerHoleSchema.parse({ id: "f", kind: "flat-ended-straight", center: { x: 0, y: 0 }, diameterMm: 80, lengthMm: 160, depthMm: 120 });
+    act(() => store().dispatch({ type: "ADD_FINGER_HOLE", hole }));
+    expect(store().fingerHoles[0]).toMatchObject({ diameterMm: 43.57, lengthMm: 43.57, depthMm: 12.8 });
+    const before = store().fingerHoles[0];
+    act(() => store().dispatch({ type: "UPDATE_FINGER_HOLE", id: "f", patch: { rotationDeg: 45, depthMm: 120 } }));
+    expect(store().fingerHoles[0]).toEqual(clampFingerHoleToBin({ ...before, rotationDeg: 45, depthMm: 120 }, store().spec));
+    act(() => store().dispatch({ type: "UNDO" }));
+    expect(store().fingerHoles[0]).toEqual(before);
+  });
+
+  it("resizes access with the bin, restores dimensions during a drag, and undoes both together", () => {
+    const { store, act } = mountBin();
+    const hole = fingerHoleSchema.parse({ id: "f", kind: "oblong-straight", center: { x: 0, y: 0 }, diameterMm: 60, lengthMm: 80, depthMm: 30 });
+    act(() => store().dispatch({ type: "ADD_FINGER_HOLE", hole }));
+    act(() => store().dispatch({ type: "PATCH_SPEC", patch: { gridX: 1, gridY: 1, heightUnits: 1 }, transient: true }));
+    expect(store().fingerHoles[0].depthMm).toBe(5.8);
+    expect(getCommittedBinDoc(store()).fingerHoles[0]).toEqual(hole);
+    act(() => store().dispatch({ type: "PATCH_SPEC", patch: { gridX: 2, gridY: 2, heightUnits: 6 }, transient: true }));
+    expect(store().fingerHoles[0]).toEqual(hole);
+    act(() => store().dispatch({ type: "PATCH_SPEC", patch: { gridX: 1, gridY: 1, heightUnits: 1 } }));
+    const smallHole = store().fingerHoles[0];
+    expect(smallHole.lengthMm).toBe(43.57);
+    act(() => store().dispatch({ type: "UNDO" }));
+    expect(store().spec.heightUnits).toBe(6);
+    expect(store().fingerHoles[0]).toEqual(hole);
+    act(() => store().dispatch({ type: "REDO" }));
+    expect(store().spec.heightUnits).toBe(1);
+    expect(store().fingerHoles[0]).toEqual(smallHole);
+  });
+
+  it("keeps restored oversize geometry intact until a geometry edit", () => {
+    const { store, act } = mountBin();
+    const hole = fingerHoleSchema.parse({ id: "legacy", center: { x: 0, y: 0 }, depthMm: 120 });
+    act(() => store().dispatch({ type: "HYDRATE", spec: store().spec, cutouts: [], fingerHoles: [hole] }));
+    act(() => store().dispatch({ type: "UPDATE_FINGER_HOLE", id: hole.id, patch: { name: "Old access" } }));
+    expect(store().fingerHoles[0].depthMm).toBe(120);
+    act(() => store().dispatch({ type: "UPDATE_FINGER_HOLE", id: hole.id, patch: { depthMm: 120 } }));
+    expect(store().fingerHoles[0].depthMm).toBe(40.8);
+  });
+
   it("starts solid (the pocket workflow default) and unhydrated", () => {
     const { store } = mountBin();
     expect(store().spec.fill).toBe("solid");

--- a/client/src/state/bin-store.tsx
+++ b/client/src/state/bin-store.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 
-import { defaultPocketFloorThicknessMm, type CutoutPlacement, type FingerHole } from "@shared/gridfinity/cutout";
+import { clampFingerHoleToBin, defaultPocketFloorThicknessMm, type CutoutPlacement, type FingerHole } from "@shared/gridfinity/cutout";
 import { parseBinSpec, type BinSpec, type BinSpecInput } from "@shared/gridfinity/types";
 
 /**
@@ -40,6 +40,7 @@ export interface BinHistoryEntry {
 }
 
 const HISTORY_LIMIT = 50;
+const BIN_SIZE_KEYS = ["gridX", "gridY", "gridPitch", "heightUnits", "lip"] as const;
 
 export interface BinState {
   spec: BinSpec;
@@ -164,6 +165,7 @@ function commit(
   label: string,
   rest: Partial<BinState> = {},
 ): BinState {
+  doc = limitFingerAccessForBinChange(state, doc);
   const stack = [
     ...state.history.stack.slice(0, state.history.index + 1),
     { doc, label },
@@ -177,6 +179,12 @@ function commit(
     fingerHoles: doc.fingerHoles,
     history: { stack: stack.slice(overflow), index: stack.length - 1 - overflow },
   };
+}
+
+function limitFingerAccessForBinChange(state: BinState, doc: BinDoc): BinDoc {
+  const previous = getCommittedBinDoc(state).spec;
+  if (!BIN_SIZE_KEYS.some(key => previous[key] !== doc.spec[key])) return doc;
+  return { ...doc, fingerHoles: doc.fingerHoles.map(hole => clampFingerHoleToBin(hole, doc.spec)) };
 }
 
 function specPatchLabel(patch: Partial<BinSpecInput>): string {
@@ -209,6 +217,7 @@ function cutoutPatchLabel(patch: Partial<CutoutPlacement>): string {
 
 /** A transient change: present state moves, the history does not. */
 function preview(state: BinState, doc: BinDoc): BinState {
+  doc = limitFingerAccessForBinChange(state, doc);
   return {
     ...state,
     spec: doc.spec,
@@ -266,7 +275,9 @@ function reducer(state: BinState, action: BinAction): BinState {
             : {}),
         }),
         cutouts: state.cutouts,
-        fingerHoles: state.fingerHoles,
+        // Resizing back during the same gesture must recover the pre-drag dimensions.
+        fingerHoles: BIN_SIZE_KEYS.some(key => key in action.patch)
+          ? getCommittedBinDoc(state).fingerHoles : state.fingerHoles,
       };
       if (doc.spec.flatBottom !== state.spec.flatBottom) {
         const previousFloor = defaultPocketFloorThicknessMm(state.spec);
@@ -322,7 +333,7 @@ function reducer(state: BinState, action: BinAction): BinState {
         {
           spec: state.spec,
           cutouts: state.cutouts,
-          fingerHoles: [...state.fingerHoles, action.hole],
+          fingerHoles: [...state.fingerHoles, clampFingerHoleToBin(action.hole, state.spec)],
         },
         "Add finger hole",
         { selectedCutoutId: null, selectedFingerHoleId: action.hole.id },
@@ -331,9 +342,12 @@ function reducer(state: BinState, action: BinAction): BinState {
       const doc = {
         spec: state.spec,
         cutouts: state.cutouts,
-        fingerHoles: state.fingerHoles.map((hole) =>
-          hole.id === action.id ? { ...hole, ...action.patch, id: hole.id } : hole,
-        ),
+        fingerHoles: state.fingerHoles.map((hole) => {
+          if (hole.id !== action.id) return hole;
+          const updated = { ...hole, ...action.patch, id: hole.id };
+          return ["diameterMm", "lengthMm", "depthMm", "kind", "rotationDeg"].some(key => key in action.patch)
+            ? clampFingerHoleToBin(updated, state.spec) : updated;
+        }),
       };
       return action.transient
         ? preview(state, doc)

--- a/shared/gridfinity/cutout.test.ts
+++ b/shared/gridfinity/cutout.test.ts
@@ -14,6 +14,8 @@ import {
   fingerAccessOptions,
   fingerAccessOptionsPatch,
   effectiveFingerHoleBottomFilletMm,
+  effectiveFingerHoleCornerRoundMm,
+  maximumFingerHoleCornerRoundMm,
   elongatedFingerHoleEndpoints,
   parseCutoutPlacement,
   placementFootprint,
@@ -30,6 +32,50 @@ import {
 import { BASE_HEIGHT, R_F2 } from "./standard";
 
 const SPEC_2X3 = { gridX: 2, gridY: 3 };
+
+describe("flat-ended slot corner rounding", () => {
+  const slot = fingerHoleSchema.parse({ id: "slot", kind: "flat-ended-scoop", center: { x: 0, y: 0 }, diameterMm: 16, lengthMm: 40 });
+  const placement = { position: { x: 0, y: 0 }, rotationDeg: 0, mirrored: false };
+
+  it("defaults to sharp corners and rejects invalid radii", () => {
+    expect(effectiveFingerHoleCornerRoundMm(slot)).toBe(0);
+    expect(fingerHoleFootprintRing(slot, placement)).toHaveLength(4);
+    for (const cornerRoundMm of [-1, 40.1, Infinity, NaN]) {
+      expect(fingerHoleSchema.safeParse({ ...slot, cornerRoundMm }).success).toBe(false);
+    }
+  });
+
+  it.each(["flat-ended-scoop", "flat-ended-straight"] as const)("rounds %s corners inside the exact dimensions", (kind) => {
+    const hole = { ...slot, kind, cornerRoundMm: 3 };
+    const ring = fingerHoleFootprintRing(hole, placement, 64);
+    expect(signedArea(ring)).toBeCloseTo(40 * 16 - (4 - Math.PI) * 9, 0);
+    expect(Math.max(...ring.map(p => p.x))).toBeCloseTo(20, 8);
+    expect(Math.max(...ring.map(p => p.y))).toBeCloseTo(8, 8);
+    expect(ring.some(p => Math.abs(p.x) > 19.9 && Math.abs(p.y) > 7.9)).toBe(false);
+    const turned = fingerHoleFootprintRing({ ...hole, rotationDeg: 37, center: { x: 3, y: -2 } }, placement, 64);
+    ring.forEach((p, i) => {
+      const radians = 37 * Math.PI / 180;
+      expect(turned[i].x).toBeCloseTo(3 + p.x * Math.cos(radians) - p.y * Math.sin(radians), 8);
+      expect(turned[i].y).toBeCloseTo(-2 + p.x * Math.sin(radians) + p.y * Math.cos(radians), 8);
+    });
+  });
+
+  it("limits the effective radius by both dimensions and retains it across shape changes", () => {
+    const hole = { ...slot, cornerRoundMm: 12 };
+    expect(maximumFingerHoleCornerRoundMm(hole)).toBe(8);
+    expect(effectiveFingerHoleCornerRoundMm(hole)).toBe(8);
+    expect(effectiveFingerHoleCornerRoundMm({ ...hole, lengthMm: 6 })).toBe(3);
+    const round = { ...hole, ...fingerAccessOptionsPatch(hole, { shape: "round" }) };
+    expect(round.cornerRoundMm).toBe(12);
+    expect(effectiveFingerHoleCornerRoundMm(round)).toBe(0);
+    const restored = { ...round, ...fingerAccessOptionsPatch(round, { shape: "slot" }) };
+    expect(effectiveFingerHoleCornerRoundMm(restored)).toBe(8);
+    expect(effectiveFingerHoleCornerRoundMm({ ...restored, kind: "oblong-deep-scoop" })).toBe(0);
+    const ring = fingerHoleFootprintRing({ ...hole, diameterMm: 6, lengthMm: 6 }, placement, 64);
+    expect(signedArea(ring)).toBeCloseTo(Math.PI * 9, 1);
+    expect(ring).toHaveLength(64);
+  });
+});
 
 /** An L-shaped (chiral) outline with a hole — orientation-sensitive fixture. */
 const CHIRAL: Outline = [

--- a/shared/gridfinity/cutout.test.ts
+++ b/shared/gridfinity/cutout.test.ts
@@ -534,7 +534,7 @@ describe("typed finger holes (straight and scoop)", () => {
     };
     expect(
       resizeFingerHoleFromWidthHandle(shallowDeep, { x: 16, y: 5 }).depthMm,
-    ).toBe(12);
+    ).toBe(4);
 
     const oblong = {
       ...round,
@@ -558,9 +558,9 @@ describe("typed finger holes (straight and scoop)", () => {
     expect(effectiveScoopDepthMm({ diameterMm: 20, depthMm: 25 })).toBe(10);
   });
 
-  it("keeps a deep scoop at least one radius deep", () => {
+  it("preserves shallow deep-scoop depth", () => {
     expect(effectiveDeepScoopDepthMm({ diameterMm: 18, depthMm: 30 })).toBe(30);
-    expect(effectiveDeepScoopDepthMm({ diameterMm: 18, depthMm: 4 })).toBe(9);
+    expect(effectiveDeepScoopDepthMm({ diameterMm: 18, depthMm: 4 })).toBe(4);
   });
 });
 
@@ -623,4 +623,9 @@ it("width dragging keeps a shallow flat-ended scoop shallow", () => {
   expect(resizeFingerHoleFromWidthHandle(hole, { x: 0, y: 20 })).toMatchObject({
     diameterMm: 40, depthMm: 1, lengthMm: 40,
   });
+});
+
+it.each(["straight", "scoop", "deep-scoop", "oblong-deep-scoop", "flat-ended-scoop"] as const)("preserves a 1 mm %s depth when resizing its width", (kind) => {
+  const hole = fingerHoleSchema.parse({ id: "shallow", kind, center: { x: 0, y: 0 }, diameterMm: 18, depthMm: 1, lengthMm: 40 });
+  expect(resizeFingerHoleFromWidthHandle(hole, { x: 15, y: 15 }).depthMm).toBe(1);
 });

--- a/shared/gridfinity/cutout.test.ts
+++ b/shared/gridfinity/cutout.test.ts
@@ -11,6 +11,9 @@ import {
   effectiveScoopDepthMm,
   fingerHoleFootprintRing,
   fingerHoleSchema,
+  fingerAccessOptions,
+  fingerAccessOptionsPatch,
+  effectiveFingerHoleBottomFilletMm,
   elongatedFingerHoleEndpoints,
   parseCutoutPlacement,
   placementFootprint,
@@ -625,7 +628,65 @@ it("width dragging keeps a shallow flat-ended scoop shallow", () => {
   });
 });
 
-it.each(["straight", "scoop", "deep-scoop", "oblong-deep-scoop", "flat-ended-scoop"] as const)("preserves a 1 mm %s depth when resizing its width", (kind) => {
+it.each(["straight", "scoop", "deep-scoop", "oblong-deep-scoop", "flat-ended-scoop", "oblong-straight", "flat-ended-straight"] as const)("preserves a 1 mm %s depth when resizing its width", (kind) => {
   const hole = fingerHoleSchema.parse({ id: "shallow", kind, center: { x: 0, y: 0 }, diameterMm: 18, depthMm: 1, lengthMm: 40 });
   expect(resizeFingerHoleFromWidthHandle(hole, { x: 15, y: 15 }).depthMm).toBe(1);
+});
+
+it("keeps a legacy round scoop's actual depth when narrowing its opening", () => {
+  const hole = fingerHoleSchema.parse({ id: "legacy", kind: "scoop", center: { x: 0, y: 0 }, diameterMm: 30, depthMm: 12 });
+  const resized = resizeFingerHoleFromWidthHandle(hole, { x: 4, y: 0 });
+  expect(resized).toMatchObject({ kind: "deep-scoop", diameterMm: 8, depthMm: 12 });
+  expect(hole).toMatchObject({ kind: "scoop", diameterMm: 30, depthMm: 12 });
+});
+
+describe("independent finger access choices", () => {
+  it.each([
+    ["straight", "round", "flat", "rounded"], ["scoop", "round", "curved", "rounded"],
+    ["deep-scoop", "round", "curved", "rounded"], ["oblong-deep-scoop", "slot", "curved", "rounded"],
+    ["flat-ended-scoop", "slot", "curved", "flat"], ["oblong-straight", "slot", "flat", "rounded"],
+    ["flat-ended-straight", "slot", "flat", "flat"],
+  ])("maps %s to %s, %s bottom and %s ends without mutating it", (kind, shape, bottom, ends) => {
+    const hole = fingerHoleSchema.parse({ id: "options", kind, center: { x: 0, y: 0 } });
+    expect(fingerAccessOptions(hole)).toEqual({ shape, bottom, ends });
+    expect(hole.kind).toBe(kind);
+  });
+
+  it("retains short flat-end length, rotation and end preference through round and rounded slots", () => {
+    const original = fingerHoleSchema.parse({ id: "short", kind: "flat-ended-straight", center: { x: 3, y: 5 },
+      diameterMm: 24, lengthMm: 6, depthMm: 20, rotationDeg: 37, topFilletMm: 1, bottomFilletMm: 2 });
+    const round = { ...original, ...fingerAccessOptionsPatch(original, { shape: "round" }) };
+    expect(round).toMatchObject({ kind: "straight", slotEnds: "flat", lengthMm: 6, rotationDeg: 37 });
+    const slot = { ...round, ...fingerAccessOptionsPatch(round, { shape: "slot" }) };
+    expect(slot.kind).toBe("flat-ended-straight");
+    const rounded = { ...slot, ...fingerAccessOptionsPatch(slot, { ends: "rounded", bottom: "curved" }) };
+    expect(elongatedFingerHoleEndpoints(rounded).lengthMm).toBe(26);
+    expect(rounded.lengthMm).toBe(6);
+    const restored = { ...rounded, ...fingerAccessOptionsPatch(rounded, { ends: "flat", bottom: "flat" }) };
+    expect(restored).toEqual({ ...original, slotEnds: "flat" });
+    expect(elongatedFingerHoleEndpoints(restored).lengthMm).toBe(6);
+  });
+
+  it("carries actual legacy dish depth into another shape", () => {
+    const hole = fingerHoleSchema.parse({ id: "legacy", kind: "scoop", center: { x: 0, y: 0 }, diameterMm: 18, depthMm: 30 });
+    expect(fingerAccessOptionsPatch(hole, { shape: "slot" })).toMatchObject({ kind: "oblong-deep-scoop", depthMm: 9 });
+    expect(hole.depthMm).toBe(30);
+  });
+
+  it.each(["oblong-straight", "flat-ended-straight"] as const)("keeps %s plan geometry and endpoint mechanics independent of its bottom", (kind) => {
+    const hole = fingerHoleSchema.parse({ id: "slot", kind, center: { x: 3, y: 5 }, diameterMm: 16, lengthMm: 40, rotationDeg: 37 });
+    const curved = { ...hole, ...fingerAccessOptionsPatch(hole, { bottom: "curved" }) };
+    const placement = { position: { x: 0, y: 0 }, rotationDeg: 0, mirrored: false };
+    expect(fingerHoleFootprintRing(hole, placement)).toEqual(fingerHoleFootprintRing(curved, placement));
+    expect(elongatedFingerHoleEndpoints(hole)).toEqual(elongatedFingerHoleEndpoints(curved));
+    const resized = resizeElongatedFingerHoleFromEndpoint(hole, "end", { x: 40, y: 10 });
+    expect(elongatedFingerHoleEndpoints(resized).start.x).toBeCloseTo(elongatedFingerHoleEndpoints(hole).start.x, 8);
+    expect(elongatedFingerHoleEndpoints(resized).start.y).toBeCloseTo(elongatedFingerHoleEndpoints(hole).start.y, 8);
+  });
+
+  it("limits bottom rounding by the shorter flat-ended dimension", () => {
+    const hole = fingerHoleSchema.parse({ id: "short", kind: "flat-ended-straight", center: { x: 0, y: 0 }, diameterMm: 80, lengthMm: 6, depthMm: 20, bottomFilletMm: 6 });
+    expect(effectiveFingerHoleBottomFilletMm(hole)).toBe(3);
+    expect(hole.bottomFilletMm).toBe(6);
+  });
 });

--- a/shared/gridfinity/cutout.ts
+++ b/shared/gridfinity/cutout.ts
@@ -135,14 +135,16 @@ export const fingerHoleSchema = z
         "deep-scoop",
         "oblong-deep-scoop",
         "flat-ended-scoop",
+        "oblong-straight",
+        "flat-ended-straight",
         "oblong-scoop",
       ])
       .default("straight"),
-    /** Used only for scoops; retained on straight holes so type changes are reversible. */
+    /** Requested top-to-bottom depth, independent of the opening shape. */
     depthMm: z.number().min(1).max(120).default(12),
     /** Rounds the hole wall outward into the bin's top surface. */
     topFilletMm: z.number().min(0).max(5).default(0),
-    /** Used only by straight holes; curved scoop bottoms already provide this transition. */
+    /** Used by flat bottoms; retained while a curved bottom is selected. */
     bottomFilletMm: z.number().min(0).max(6).default(0),
     /** Compatibility only; removed with the directed-trough prototype. */
     reachMm: z.number().min(1).max(120).optional(),
@@ -152,6 +154,8 @@ export const fingerHoleSchema = z
     lengthMm: z.number().min(6).max(160).optional(),
     /** CCW mouth rotation in the bin-local y-up frame. */
     rotationDeg: z.number().finite().optional(),
+    /** Remembers the slot ends while the opening is temporarily round. */
+    slotEnds: z.enum(["rounded", "flat"]).optional(),
   })
   .strict()
   .transform(({ reachMm: _reach, directionDeg: _direction, kind, ...hole }) => ({
@@ -168,6 +172,82 @@ export const DEFAULT_TOP_EDGE_FILLET_MM = 1;
 export const DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM = 36;
 export const MAX_OBLONG_DEEP_SCOOP_LENGTH_MM = 160;
 export const MIN_OBLONG_DEEP_SCOOP_SPAN_MM = 2;
+const FINGER_ACCESS_BIN_ALLOWANCE = 1.05;
+
+type FingerAccessBinSpec = Pick<BinSpec, "gridX" | "gridY" | "gridPitch" | "heightUnits" | "lip">;
+
+function fingerAccessBinBounds(spec: FingerAccessBinSpec) {
+  return {
+    x: binFootprintMm(spec.gridX, spec.gridPitch) * FINGER_ACCESS_BIN_ALLOWANCE,
+    y: binFootprintMm(spec.gridY, spec.gridPitch) * FINGER_ACCESS_BIN_ALLOWANCE,
+  };
+}
+
+function fingerAccessMouthFits(hole: FingerHole, bounds: { x: number; y: number }): boolean {
+  if (!isElongatedFingerHole(hole)) return hole.diameterMm <= Math.min(bounds.x, bounds.y);
+  const angle = (hole.rotationDeg ?? 0) * Math.PI / 180;
+  const c = Math.abs(Math.cos(angle));
+  const s = Math.abs(Math.sin(angle));
+  const length = elongatedFingerHoleEndpoints(hole).lengthMm;
+  const width = hole.diameterMm;
+  return hasFlatFingerHoleEnds(hole)
+    ? length * c + width * s <= bounds.x + 1e-9 && length * s + width * c <= bounds.y + 1e-9
+    : (length - width) * c + width <= bounds.x + 1e-9 && (length - width) * s + width <= bounds.y + 1e-9;
+}
+
+/** Both mouth extents grow monotonically with either dimension, including capsule minimum length. */
+function maximumFingerAccessDimension(
+  hole: FingerHole,
+  bounds: { x: number; y: number },
+  dimension: "diameterMm" | "lengthMm",
+): number {
+  let low = MIN_FINGER_HOLE_DIAMETER_MM;
+  let high = dimension === "diameterMm" ? MAX_FINGER_HOLE_DIAMETER_MM : MAX_OBLONG_DEEP_SCOOP_LENGTH_MM;
+  for (let i = 0; i < 32; i++) {
+    const mid = (low + high) / 2;
+    if (fingerAccessMouthFits({ ...hole, [dimension]: mid }, bounds)) low = mid;
+    else high = mid;
+  }
+  // Round down, never beyond the allowance. Hundredths also match numeric fields.
+  return Math.floor((low + 1e-7) * 100) / 100;
+}
+
+function maximumFingerAccessDepth(spec: FingerAccessBinSpec): number {
+  const top = resolvePocketDepth(spec, { mode: "through" }).infillTopZ;
+  return Math.min(120, top);
+}
+
+/** Editing limits for the nominal mouth, before edge rounding; position validation stays separate. */
+export function fingerHoleSizeLimits(hole: FingerHole, spec: FingerAccessBinSpec) {
+  const bounded = clampFingerHoleToBin(hole, spec);
+  const bounds = fingerAccessBinBounds(spec);
+  return {
+    depthMm: maximumFingerAccessDepth(spec),
+    diameterMm: maximumFingerAccessDimension(bounded, bounds, "diameterMm"),
+    lengthMm: maximumFingerAccessDimension(bounded, bounds, "lengthMm"),
+  };
+}
+
+/** Used on explicit geometry edits and bin resizing, never while opening an older project. */
+export function clampFingerHoleToBin(hole: FingerHole, spec: FingerAccessBinSpec): FingerHole {
+  const bounds = fingerAccessBinBounds(spec);
+  const depth = effectiveFingerHoleDepthMm(hole);
+  const maximumDepth = maximumFingerAccessDepth(spec);
+  let bounded = { ...hole, depthMm: depth > maximumDepth ? maximumDepth : hole.depthMm };
+  // First fit the width at the shortest possible length, then fit the requested length.
+  // Dormant slot length on round holes remains untouched for reversible shape changes.
+  bounded.diameterMm = Math.min(hole.diameterMm,
+    maximumFingerAccessDimension({ ...bounded, lengthMm: MIN_FINGER_HOLE_DIAMETER_MM }, bounds, "diameterMm"));
+  if (hole.kind === "scoop" && bounded.diameterMm !== hole.diameterMm) {
+    bounded = { ...bounded, kind: "deep-scoop", depthMm: Math.min(depth, maximumDepth) };
+  }
+  if (isElongatedFingerHole(bounded)) {
+    const maximum = maximumFingerAccessDimension(bounded, bounds, "lengthMm");
+    if ((hole.lengthMm ?? DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM) > maximum) bounded.lengthMm = maximum;
+  }
+  return bounded.diameterMm === hole.diameterMm && bounded.depthMm === hole.depthMm &&
+    bounded.lengthMm === hole.lengthMm && bounded.kind === hole.kind ? hole : bounded;
+}
 
 /**
  * A spherical dish cut down from the top surface. Placed on the pocket's
@@ -216,6 +296,58 @@ export function effectiveFingerHoleDepthMm(hole: FingerHole): number {
   return hole.depthMm;
 }
 
+export function effectiveFingerHoleTopFilletMm(hole: FingerHole): number {
+  return Math.min(hole.topFilletMm, effectiveFingerHoleDepthMm(hole) / 2);
+}
+
+export function effectiveFingerHoleBottomFilletMm(hole: FingerHole): number {
+  return Math.min(hole.bottomFilletMm, maximumFingerHoleBottomFilletMm(hole));
+}
+
+export function maximumFingerHoleBottomFilletMm(hole: FingerHole): number {
+  return Math.min(6, hole.depthMm / 2, hole.diameterMm / 2,
+    isElongatedFingerHole(hole) ? elongatedFingerHoleEndpoints(hole).lengthMm / 2 : Infinity);
+}
+
+export function hasFlatFingerHoleBottom(hole: Pick<FingerHole, "kind">): boolean {
+  return hole.kind === "straight" || hole.kind === "oblong-straight" || hole.kind === "flat-ended-straight";
+}
+
+export function hasFlatFingerHoleEnds(hole: Partial<Pick<FingerHole, "kind">>): boolean {
+  return hole.kind === "flat-ended-scoop" || hole.kind === "flat-ended-straight";
+}
+
+export interface FingerAccessOptions {
+  shape: "round" | "slot";
+  bottom: "curved" | "flat";
+  ends: "rounded" | "flat";
+}
+
+/** Orthogonal editor choices over the versioned, backward-compatible cutter types. */
+export function fingerAccessOptions(hole: FingerHole): FingerAccessOptions {
+  return {
+    shape: isElongatedFingerHole(hole) ? "slot" : "round",
+    bottom: hasFlatFingerHoleBottom(hole) ? "flat" : "curved",
+    ends: isElongatedFingerHole(hole)
+      ? hasFlatFingerHoleEnds(hole) ? "flat" : "rounded"
+      : hole.slotEnds ?? "rounded",
+  };
+}
+
+/** Changes geometry choices without overwriting requested dimensions or edge radii. */
+export function fingerAccessOptionsPatch(
+  hole: FingerHole,
+  change: Partial<FingerAccessOptions>,
+): Pick<FingerHole, "kind" | "slotEnds" | "depthMm"> {
+  const { shape, bottom, ends } = { ...fingerAccessOptions(hole), ...change };
+  const kind = shape === "round"
+    ? bottom === "flat" ? "straight" : "deep-scoop"
+    : ends === "flat"
+      ? bottom === "flat" ? "flat-ended-straight" : "flat-ended-scoop"
+      : bottom === "flat" ? "oblong-straight" : "oblong-deep-scoop";
+  return { kind, slotEnds: ends, depthMm: effectiveFingerHoleDepthMm(hole) };
+}
+
 /** Circular-segment radius preserving the opening width at shallow depths. */
 export function flatEndedScoopRadiusMm(
   hole: Pick<FingerHole, "diameterMm" | "depthMm">,
@@ -227,12 +359,12 @@ export function flatEndedScoopRadiusMm(
 
 /** Whether the hole has independently editable length and rotation. */
 export function isElongatedFingerHole(hole: Pick<FingerHole, "kind">): boolean {
-  return hole.kind === "oblong-deep-scoop" || hole.kind === "flat-ended-scoop";
+  return hole.kind === "oblong-deep-scoop" || hole.kind === "oblong-straight" || hasFlatFingerHoleEnds(hole);
 }
 
 /** Flat ends can be closer together than the channel width. */
 export function minimumFingerHoleLengthMm(hole: Pick<FingerHole, "kind" | "diameterMm">): number {
-  return hole.kind === "flat-ended-scoop"
+  return hasFlatFingerHoleEnds(hole)
     ? MIN_FINGER_HOLE_DIAMETER_MM
     : hole.diameterMm + MIN_OBLONG_DEEP_SCOOP_SPAN_MM;
 }
@@ -257,7 +389,7 @@ export function elongatedFingerHoleEndpoints(
     MAX_OBLONG_DEEP_SCOOP_LENGTH_MM,
     Math.max(hole.lengthMm ?? DEFAULT_OBLONG_DEEP_SCOOP_LENGTH_MM, minimumLength),
   );
-  const halfSpan = (lengthMm - (hole.kind === "flat-ended-scoop" ? 0 : hole.diameterMm)) / 2;
+  const halfSpan = (lengthMm - (hasFlatFingerHoleEnds(hole) ? 0 : hole.diameterMm)) / 2;
   const radians = ((hole.rotationDeg ?? 0) * Math.PI) / 180;
   const dx = halfSpan * Math.cos(radians);
   const dy = halfSpan * Math.sin(radians);
@@ -277,6 +409,7 @@ export function resizeElongatedFingerHoleFromEndpoint(
   hole: FingerHole,
   endpoint: "start" | "end",
   dragged: Point,
+  spec?: FingerAccessBinSpec,
 ): FingerHole {
   const current = elongatedFingerHoleEndpoints(hole);
   const fixed = endpoint === "start" ? current.end : current.start;
@@ -289,7 +422,7 @@ export function resizeElongatedFingerHoleFromEndpoint(
     dy = Math.sin(radians);
     span = 1;
   }
-  const capLength = hole.kind === "flat-ended-scoop" ? 0 : hole.diameterMm;
+  const capLength = hasFlatFingerHoleEnds(hole) ? 0 : hole.diameterMm;
   const clampedSpan = Math.min(
     MAX_OBLONG_DEEP_SCOOP_LENGTH_MM - capLength,
     Math.max(minimumFingerHoleLengthMm(hole) - capLength, span),
@@ -304,12 +437,21 @@ export function resizeElongatedFingerHoleFromEndpoint(
     : fixed;
   const rotationDeg =
     ((Math.atan2(end.y - start.y, end.x - start.x) * 180) / Math.PI + 360) % 360;
-  return {
+  const resized = {
     ...hole,
     center: { x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 },
     lengthMm: clampedSpan + capLength,
     rotationDeg,
   };
+  if (!spec) return resized;
+  const bounded = clampFingerHoleToBin(resized, spec);
+  const boundedSpan = elongatedFingerHoleEndpoints(bounded).lengthMm -
+    (hasFlatFingerHoleEnds(bounded) ? 0 : bounded.diameterMm);
+  const direction = endpoint === "end" ? 1 : -1;
+  return { ...bounded, center: {
+    x: fixed.x + direction * ux * boundedSpan / 2,
+    y: fixed.y + direction * uy * boundedSpan / 2,
+  } };
 }
 
 /**
@@ -320,20 +462,19 @@ export function resizeElongatedFingerHoleFromEndpoint(
 export function resizeFingerHoleFromWidthHandle(
   hole: FingerHole,
   dragged: Point,
+  spec?: FingerAccessBinSpec,
 ): FingerHole {
   if (!isElongatedFingerHole(hole)) {
     const diameterMm = Math.min(
-      MAX_FINGER_HOLE_DIAMETER_MM,
+      spec ? fingerHoleSizeLimits(hole, spec).diameterMm : MAX_FINGER_HOLE_DIAMETER_MM,
       Math.max(
         MIN_FINGER_HOLE_DIAMETER_MM,
         2 * Math.hypot(dragged.x - hole.center.x, dragged.y - hole.center.y),
       ),
     );
-    const depthMm =
-      hole.kind === "scoop"
-        ? Math.min(hole.depthMm, diameterMm / 2)
-        : hole.depthMm;
-    return { ...hole, diameterMm, depthMm };
+    // Legacy spherical dishes keep their current depth when explicitly resized.
+    return { ...hole, diameterMm, depthMm: effectiveFingerHoleDepthMm(hole),
+      kind: hole.kind === "scoop" ? "deep-scoop" : hole.kind };
   }
 
   const endpoints = elongatedFingerHoleEndpoints(hole);
@@ -346,16 +487,23 @@ export function resizeFingerHoleFromWidthHandle(
   const signedDistance =
     (dragged.x - hole.center.x) * normal.x +
     (dragged.y - hole.center.y) * normal.y;
+  const bounds = spec ? fingerAccessBinBounds(spec) : null;
+  const maximumWidth = !spec || !bounds ? MAX_FINGER_HOLE_DIAMETER_MM
+    : hasFlatFingerHoleEnds(hole) ? fingerHoleSizeLimits(hole, spec).diameterMm
+      : Math.max(MIN_FINGER_HOLE_DIAMETER_MM, Math.min(
+          bounds.x - span * Math.abs(Math.cos(radians)),
+          bounds.y - span * Math.abs(Math.sin(radians)),
+        ));
   const diameterMm = Math.min(
-    MAX_FINGER_HOLE_DIAMETER_MM,
-    hole.kind === "flat-ended-scoop" ? MAX_FINGER_HOLE_DIAMETER_MM : MAX_OBLONG_DEEP_SCOOP_LENGTH_MM - span,
+    MAX_FINGER_HOLE_DIAMETER_MM, Math.floor((maximumWidth + 1e-7) * 100) / 100,
+    hasFlatFingerHoleEnds(hole) ? MAX_FINGER_HOLE_DIAMETER_MM : MAX_OBLONG_DEEP_SCOOP_LENGTH_MM - span,
     Math.max(MIN_FINGER_HOLE_DIAMETER_MM, 2 * Math.abs(signedDistance)),
   );
   return {
     ...hole,
     diameterMm,
     depthMm: hole.depthMm,
-    lengthMm: hole.kind === "flat-ended-scoop" ? endpoints.lengthMm : span + diameterMm,
+    lengthMm: hasFlatFingerHoleEnds(hole) ? endpoints.lengthMm : span + diameterMm,
   };
 }
 
@@ -694,7 +842,7 @@ export function fingerHoleFootprintRing(
   const local = isElongatedFingerHole(hole)
     ? (() => {
         const { start, end } = elongatedFingerHoleEndpoints(hole);
-        if (hole.kind === "flat-ended-scoop") {
+        if (hasFlatFingerHoleEnds(hole)) {
           const radians = ((hole.rotationDeg ?? 0) * Math.PI) / 180;
           const nx = -Math.sin(radians) * hole.diameterMm / 2;
           const ny = Math.cos(radians) * hole.diameterMm / 2;

--- a/shared/gridfinity/cutout.ts
+++ b/shared/gridfinity/cutout.ts
@@ -146,6 +146,8 @@ export const fingerHoleSchema = z
     topFilletMm: z.number().min(0).max(5).default(0),
     /** Used by flat bottoms; retained while a curved bottom is selected. */
     bottomFilletMm: z.number().min(0).max(6).default(0),
+    /** Plan-view corner radius for flat-ended slots; absent means sharp corners. */
+    cornerRoundMm: z.number().min(0).max(40).optional(),
     /** Compatibility only; removed with the directed-trough prototype. */
     reachMm: z.number().min(1).max(120).optional(),
     /** Compatibility only; removed with the directed-trough prototype. */
@@ -315,6 +317,16 @@ export function hasFlatFingerHoleBottom(hole: Pick<FingerHole, "kind">): boolean
 
 export function hasFlatFingerHoleEnds(hole: Partial<Pick<FingerHole, "kind">>): boolean {
   return hole.kind === "flat-ended-scoop" || hole.kind === "flat-ended-straight";
+}
+
+export function maximumFingerHoleCornerRoundMm(hole: FingerHole): number {
+  return Math.min(hole.diameterMm, elongatedFingerHoleEndpoints(hole).lengthMm) / 2;
+}
+
+export function effectiveFingerHoleCornerRoundMm(hole: FingerHole): number {
+  return hasFlatFingerHoleEnds(hole)
+    ? Math.min(hole.cornerRoundMm ?? 0, maximumFingerHoleCornerRoundMm(hole))
+    : 0;
 }
 
 export interface FingerAccessOptions {
@@ -833,6 +845,33 @@ export function capsuleRing(
   return ring;
 }
 
+/** CCW, centred rectangle with circular corners inside its nominal dimensions. */
+export function roundedRectangleRing(
+  width: number,
+  height: number,
+  radius: number,
+  segments = 24,
+): Point[] {
+  const hx = width / 2;
+  const hy = height / 2;
+  const r = Math.max(0, Math.min(radius, hx, hy));
+  if (r === 0) return [{ x: -hx, y: -hy }, { x: hx, y: -hy }, { x: hx, y: hy }, { x: -hx, y: hy }];
+  const steps = Math.max(2, Math.ceil(segments / 4));
+  const ring: Point[] = [];
+  for (let corner = 0; corner < 4; corner++) {
+    const cx = (corner < 2 ? 1 : -1) * (hx - r);
+    const cy = (corner === 0 || corner === 3 ? -1 : 1) * (hy - r);
+    for (let i = 0; i <= steps; i++) {
+      const angle = (corner - 1 + i / steps) * Math.PI / 2;
+      const point = { x: cx + r * Math.cos(angle), y: cy + r * Math.sin(angle) };
+      const previous = ring[ring.length - 1];
+      if (!previous || Math.hypot(point.x - previous.x, point.y - previous.y) > 1e-9) ring.push(point);
+    }
+  }
+  if (Math.hypot(ring[0].x - ring[ring.length - 1].x, ring[0].y - ring[ring.length - 1].y) < 1e-9) ring.pop();
+  return ring;
+}
+
 /** Exact plan-view rim used by rendering, validation, and cutter geometry. */
 export function fingerHoleFootprintRing(
   hole: FingerHole,
@@ -844,14 +883,11 @@ export function fingerHoleFootprintRing(
         const { start, end } = elongatedFingerHoleEndpoints(hole);
         if (hasFlatFingerHoleEnds(hole)) {
           const radians = ((hole.rotationDeg ?? 0) * Math.PI) / 180;
-          const nx = -Math.sin(radians) * hole.diameterMm / 2;
-          const ny = Math.cos(radians) * hole.diameterMm / 2;
-          return [
-            { x: start.x - nx, y: start.y - ny },
-            { x: end.x - nx, y: end.y - ny },
-            { x: end.x + nx, y: end.y + ny },
-            { x: start.x + nx, y: start.y + ny },
-          ];
+          return roundedRectangleRing(elongatedFingerHoleEndpoints(hole).lengthMm,
+            hole.diameterMm, effectiveFingerHoleCornerRoundMm(hole), segments).map(({ x, y }) => ({
+              x: hole.center.x + x * Math.cos(radians) - y * Math.sin(radians),
+              y: hole.center.y + x * Math.sin(radians) + y * Math.cos(radians),
+            }));
         }
         return capsuleRing(start, end, hole.diameterMm / 2, segments);
       })()

--- a/shared/gridfinity/cutout.ts
+++ b/shared/gridfinity/cutout.ts
@@ -121,6 +121,8 @@ export type DepthSpec = z.infer<typeof depthSpecSchema>;
 export const fingerHoleSchema = z
   .object({
     id: z.string().min(1),
+    /** Optional display name; older projects use a numbered label. */
+    name: z.string().trim().min(1).optional(),
     /** Bin-local mm, y-up, origin at the bin centre. */
     center: vec2Schema,
     diameterMm: z.number().min(6).max(80).default(18),
@@ -196,14 +198,13 @@ export function effectiveScoopDepthMm(
 }
 
 /**
- * Total top-to-bottom depth of a deep scoop. The cutter always includes at
- * least one radius so its bottom remains a true hemisphere even when an old
- * or hand-edited project requests a shallower value.
+ * Total top-to-bottom depth of a deep scoop. Shallow cuts use a circular
+ * segment that preserves the opening width; deeper cuts add vertical walls.
  */
 export function effectiveDeepScoopDepthMm(
   scoop: Pick<FingerHole, "diameterMm" | "depthMm">,
 ): number {
-  return Math.max(scoop.depthMm, scoop.diameterMm / 2);
+  return scoop.depthMm;
 }
 
 /** Actual cutting depth shared by controls, geometry, and floor validation. */
@@ -331,9 +332,7 @@ export function resizeFingerHoleFromWidthHandle(
     const depthMm =
       hole.kind === "scoop"
         ? Math.min(hole.depthMm, diameterMm / 2)
-        : hole.kind === "deep-scoop"
-          ? Math.max(hole.depthMm, diameterMm / 2)
-          : hole.depthMm;
+        : hole.depthMm;
     return { ...hole, diameterMm, depthMm };
   }
 
@@ -355,7 +354,7 @@ export function resizeFingerHoleFromWidthHandle(
   return {
     ...hole,
     diameterMm,
-    depthMm: hole.kind === "flat-ended-scoop" ? hole.depthMm : Math.max(hole.depthMm, diameterMm / 2),
+    depthMm: hole.depthMm,
     lengthMm: hole.kind === "flat-ended-scoop" ? endpoints.lengthMm : span + diameterMm,
   };
 }

--- a/shared/gridfinity/finger-access-limits.test.ts
+++ b/shared/gridfinity/finger-access-limits.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampFingerHoleToBin, effectiveFingerHoleDepthMm, elongatedFingerHoleEndpoints,
+  fingerHoleFootprintRing, fingerHoleSchema, fingerHoleSizeLimits,
+  resizeElongatedFingerHoleFromEndpoint, resizeFingerHoleFromWidthHandle,
+} from "./cutout";
+import { binFootprintMm } from "./standard";
+import { parseBinSpec } from "./types";
+
+const small = parseBinSpec({ gridX: 1, gridY: 2, heightUnits: 2 });
+const opening = fingerHoleSchema.parse({ id: "access", center: { x: 4, y: -3 }, kind: "straight", diameterMm: 18, depthMm: 12 });
+
+describe("bin-aware finger access limits", () => {
+  it("stops at the underside while retaining a 5% mouth-size allowance", () => {
+    expect(fingerHoleSizeLimits(opening, small)).toMatchObject({ depthMm: 12.8, diameterMm: 43.57 });
+    expect(fingerHoleSizeLimits(opening, { ...small, lip: "none" }).depthMm).toBe(14);
+    expect(fingerHoleSizeLimits(opening, { ...small, heightUnits: 1 }).depthMm).toBe(5.8);
+  });
+
+  it("rotates slot length and width limits with a rectangular bin", () => {
+    const slot = { ...opening, kind: "flat-ended-straight" as const, lengthMm: 30 };
+    expect(fingerHoleSizeLimits(slot, small)).toMatchObject({ lengthMm: 43.57, diameterMm: 80 });
+    expect(fingerHoleSizeLimits({ ...slot, rotationDeg: 90 }, small)).toMatchObject({ lengthMm: 87.67, diameterMm: 43.57 });
+    const diagonal = fingerHoleSizeLimits({ ...slot, rotationDeg: 45 }, small);
+    expect(diagonal.lengthMm).toBeLessThan(43.63);
+    expect(diagonal.diameterMm).toBeLessThan(31.63);
+  });
+
+  it("retains schema ceilings when the bin is larger", () => {
+    const large = parseBinSpec({ gridX: 4, gridY: 4, heightUnits: 20 });
+    expect(fingerHoleSizeLimits({ ...opening, kind: "oblong-straight", lengthMm: 40 }, large))
+      .toEqual({ depthMm: 120, diameterMm: 80, lengthMm: 160 });
+  });
+
+  it.each(["straight", "scoop", "deep-scoop", "oblong-straight", "flat-ended-straight", "oblong-deep-scoop", "flat-ended-scoop"] as const)(
+    "bounds %s across pitches, rotations, shallow bins and oversize requests", (kind) => {
+      for (const gridPitch of ["full", "half", "quarter"] as const) {
+        const spec = parseBinSpec({ gridX: 1, gridY: 2, gridPitch, heightUnits: 1 });
+        for (const rotationDeg of [0, 37, 90, 135]) {
+          for (const lengthMm of [6, 40, 160]) {
+            const original = { ...opening, kind, diameterMm: 80, depthMm: 120, lengthMm, rotationDeg, topFilletMm: 1 };
+            const bounded = clampFingerHoleToBin(original, spec);
+            expect(fingerHoleSchema.safeParse(bounded).success).toBe(true);
+            expect(clampFingerHoleToBin(bounded, spec)).toEqual(bounded);
+            expect(bounded.center).toEqual(original.center);
+            expect(bounded.rotationDeg).toBe(rotationDeg);
+            expect(bounded.topFilletMm).toBe(1);
+            expect(effectiveFingerHoleDepthMm(bounded)).toBeLessThanOrEqual(5.8);
+            const ring = fingerHoleFootprintRing(bounded, { position: { x: 0, y: 0 }, rotationDeg: 0, mirrored: false }, 128);
+            const xs = ring.map(p => p.x), ys = ring.map(p => p.y);
+            expect(Math.max(...xs) - Math.min(...xs)).toBeLessThanOrEqual(binFootprintMm(1, gridPitch) * 1.05 + 1e-6);
+            expect(Math.max(...ys) - Math.min(...ys)).toBeLessThanOrEqual(binFootprintMm(2, gridPitch) * 1.05 + 1e-6);
+          }
+        }
+      }
+    },
+  );
+
+  it("preserves dormant slot length and legacy depth when no change is needed", () => {
+    const hole = { ...opening, kind: "scoop" as const, depthMm: 30, lengthMm: 160, slotEnds: "flat" as const };
+    expect(clampFingerHoleToBin(hole, small)).toBe(hole);
+  });
+
+  it.each(["oblong-straight", "flat-ended-straight"] as const)("keeps the fixed endpoint when %s dragging reaches the limit", (kind) => {
+    const hole = { ...opening, kind, lengthMm: 30, rotationDeg: 0 };
+    const before = elongatedFingerHoleEndpoints(hole);
+    const result = resizeElongatedFingerHoleFromEndpoint(hole, "end", { x: 300, y: 180 }, small);
+    const after = elongatedFingerHoleEndpoints(result);
+    expect(after.start.x).toBeCloseTo(before.start.x, 8);
+    expect(after.start.y).toBeCloseTo(before.start.y, 8);
+    expect(clampFingerHoleToBin(result, small)).toEqual(result);
+    expect(result.lengthMm).toBeLessThan(60);
+  });
+
+  it.each(["oblong-straight", "flat-ended-straight"] as const)("keeps both ends fixed when widening %s to the bin limit", (kind) => {
+    const hole = { ...opening, kind, diameterMm: 10, lengthMm: 30, rotationDeg: 90 };
+    const before = elongatedFingerHoleEndpoints(hole);
+    const result = resizeFingerHoleFromWidthHandle(hole, { x: 200, y: -3 }, small);
+    expect(result.diameterMm).toBe(43.57);
+    expect(elongatedFingerHoleEndpoints(result).start.x).toBeCloseTo(before.start.x, 8);
+    expect(elongatedFingerHoleEndpoints(result).start.y).toBeCloseTo(before.start.y, 8);
+    expect(elongatedFingerHoleEndpoints(result).end.x).toBeCloseTo(before.end.x, 8);
+    expect(elongatedFingerHoleEndpoints(result).end.y).toBeCloseTo(before.end.y, 8);
+    expect(clampFingerHoleToBin(result, small)).toEqual(result);
+  });
+});

--- a/shared/gridfinity/project.test.ts
+++ b/shared/gridfinity/project.test.ts
@@ -44,6 +44,20 @@ const VALID = {
 };
 
 describe("parseProjectDoc", () => {
+  it("preserves finger access names through save and reload alongside unnamed legacy holes", () => {
+    const doc = parseProjectDoc({
+      ...VALID,
+      fingerHoles: [
+        { id: "named", name: "Thumb access", center: { x: 0, y: 0 } },
+        { id: "legacy", center: { x: 15, y: 0 } },
+      ],
+    });
+    expect(doc?.fingerHoles[0].name).toBe("Thumb access");
+    expect(doc?.fingerHoles[1].name).toBeUndefined();
+    expect(parseProjectDoc(JSON.parse(JSON.stringify(doc)))).toEqual(doc);
+  });
+
+
   it("round-trips a 3 by 5 standard-cell bin at quarter pitch", () => {
     const doc = parseProjectDoc({ ...VALID, spec: { ...VALID.spec, gridX: 12, gridY: 20, gridPitch: "quarter" } });
     expect(doc?.spec).toMatchObject({ gridX: 12, gridY: 20, gridPitch: "quarter" });

--- a/shared/gridfinity/project.test.ts
+++ b/shared/gridfinity/project.test.ts
@@ -409,3 +409,20 @@ it("round-trips flat-ended scoops and migrates v12 without changing existing geo
   expect(doc!.cutouts).toEqual(old!.cutouts);
   expect(parseProjectDoc({ ...doc!, schemaVersion: PROJECT_SCHEMA_VERSION + 1 })).toBeNull();
 });
+
+it("migrates v13 without rewriting finger-access geometry and persists new slot choices", () => {
+  const previous = parseProjectDoc({ ...VALID, fingerHoles: [
+    { id: "legacy", kind: "scoop", center: { x: 0, y: 0 }, diameterMm: 18, depthMm: 30 },
+    { id: "flat", kind: "flat-ended-scoop", center: { x: 10, y: 5 }, diameterMm: 24, lengthMm: 6, depthMm: 1, rotationDeg: 37 },
+  ] })!;
+  expect(parseProjectDoc({ ...previous, schemaVersion: 13 })).toEqual(previous);
+  const current = parseProjectDoc({ ...previous, fingerHoles: [
+    { ...previous.fingerHoles[1], kind: "flat-ended-straight", bottomFilletMm: 2 },
+    { ...previous.fingerHoles[1], id: "rounded", kind: "oblong-straight", lengthMm: 40 },
+    { ...previous.fingerHoles[1], id: "round", kind: "straight", slotEnds: "flat" },
+  ] });
+  expect(current).not.toBeNull();
+  expect(parseProjectDoc(JSON.parse(JSON.stringify(current)))).toEqual(current);
+  expect(current?.fingerHoles[2]).toMatchObject({ slotEnds: "flat", lengthMm: 6, rotationDeg: 37 });
+  expect(parseProjectDoc({ ...current, fingerHoles: [{ ...current!.fingerHoles[0], slotEnds: "invalid" }] })).toBeNull();
+});

--- a/shared/gridfinity/project.test.ts
+++ b/shared/gridfinity/project.test.ts
@@ -426,3 +426,19 @@ it("migrates v13 without rewriting finger-access geometry and persists new slot 
   expect(current?.fingerHoles[2]).toMatchObject({ slotEnds: "flat", lengthMm: 6, rotationDeg: 37 });
   expect(parseProjectDoc({ ...current, fingerHoles: [{ ...current!.fingerHoles[0], slotEnds: "invalid" }] })).toBeNull();
 });
+
+it("migrates v14 with sharp slot corners and round-trips explicit and retained corner radii", () => {
+  const previous = { ...VALID, schemaVersion: 14, fingerHoles: [
+    { id: "slot", kind: "flat-ended-scoop", center: { x: 0, y: 0 }, diameterMm: 24, lengthMm: 6, depthMm: 1 },
+  ] };
+  const source = JSON.stringify(previous);
+  const migrated = parseProjectDoc(previous)!;
+  expect(migrated.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
+  expect(migrated.fingerHoles[0].cornerRoundMm).toBeUndefined();
+  expect(JSON.stringify(previous)).toBe(source);
+  for (const kind of ["flat-ended-scoop", "flat-ended-straight", "straight", "oblong-straight"]) {
+    const doc = parseProjectDoc({ ...migrated, fingerHoles: [{ ...migrated.fingerHoles[0], kind, cornerRoundMm: 8 }] });
+    expect(doc?.fingerHoles[0]).toMatchObject({ kind, cornerRoundMm: 8, lengthMm: 6, depthMm: 1 });
+    expect(parseProjectDoc(JSON.parse(JSON.stringify(doc)))).toEqual(doc);
+  }
+});

--- a/shared/gridfinity/project.ts
+++ b/shared/gridfinity/project.ts
@@ -30,9 +30,10 @@ import { binSpecSchema } from "./types";
  * Version 12 adds an optional flat bottom, defaulting off for existing projects.
  * Version 13 adds flat-ended cylindrical finger scoops.
  * Version 14 adds flat-bottom slots and a retained slot-end preference.
+ * Version 15 adds optional corner rounding for flat-ended slots (absent is sharp).
  */
 
-export const PROJECT_SCHEMA_VERSION = 14 as const;
+export const PROJECT_SCHEMA_VERSION = 15 as const;
 
 const projectFields = {
   shapes: z.array(tracedShapeSchema),
@@ -71,6 +72,8 @@ export const projectDocSchema = z
     keepBinSize: z.boolean().optional(),
   })
   .strict();
+
+const version14ProjectSchema = projectDocSchema.extend({ schemaVersion: z.literal(14) });
 
 const version13ProjectSchema = projectDocSchema.extend({ schemaVersion: z.literal(13) });
 
@@ -160,6 +163,8 @@ export function parseProjectDoc(input: unknown): ProjectDoc | null {
       input = { ...doc, spec };
     }
   }
+  const version14 = version14ProjectSchema.safeParse(input);
+  if (version14.success) return projectDocSchema.parse({ ...version14.data, schemaVersion: PROJECT_SCHEMA_VERSION });
   const version13 = version13ProjectSchema.safeParse(input);
   if (version13.success) return projectDocSchema.parse({ ...version13.data, schemaVersion: PROJECT_SCHEMA_VERSION });
   const version12 = version12ProjectSchema.safeParse(input);

--- a/shared/gridfinity/project.ts
+++ b/shared/gridfinity/project.ts
@@ -29,9 +29,10 @@ import { binSpecSchema } from "./types";
  * Version 11 removes Lite Base; older projects use the ordinary Gridfinity base.
  * Version 12 adds an optional flat bottom, defaulting off for existing projects.
  * Version 13 adds flat-ended cylindrical finger scoops.
+ * Version 14 adds flat-bottom slots and a retained slot-end preference.
  */
 
-export const PROJECT_SCHEMA_VERSION = 13 as const;
+export const PROJECT_SCHEMA_VERSION = 14 as const;
 
 const projectFields = {
   shapes: z.array(tracedShapeSchema),
@@ -70,6 +71,8 @@ export const projectDocSchema = z
     keepBinSize: z.boolean().optional(),
   })
   .strict();
+
+const version13ProjectSchema = projectDocSchema.extend({ schemaVersion: z.literal(13) });
 
 const version12ProjectSchema = projectDocSchema.extend({ schemaVersion: z.literal(12) });
 
@@ -157,6 +160,8 @@ export function parseProjectDoc(input: unknown): ProjectDoc | null {
       input = { ...doc, spec };
     }
   }
+  const version13 = version13ProjectSchema.safeParse(input);
+  if (version13.success) return projectDocSchema.parse({ ...version13.data, schemaVersion: PROJECT_SCHEMA_VERSION });
   const version12 = version12ProjectSchema.safeParse(input);
   if (version12.success) return projectDocSchema.parse({ ...version12.data, schemaVersion: PROJECT_SCHEMA_VERSION });
   const version11 = version11ProjectSchema.safeParse(input);

--- a/shared/gridfinity/validate-layout.test.ts
+++ b/shared/gridfinity/validate-layout.test.ts
@@ -368,7 +368,7 @@ describe("validateLayout: finger holes and scoops (G4)", () => {
     expect(result).not.toContain("finger-hole-out-of-bounds");
   });
 
-  it.each(["deep-scoop", "flat-ended-scoop"])("uses full %s depth for floor validation", (kind) => {
+  it.each(["deep-scoop", "flat-ended-scoop", "oblong-straight", "flat-ended-straight"])("uses full %s depth for floor validation", (kind) => {
     const shape = makeShape("s1", 20, 20);
     const cutout = makeCutout("c1", "s1", 0, 0, {
       fingerHoles: [
@@ -386,7 +386,7 @@ describe("validateLayout: finger holes and scoops (G4)", () => {
     );
   });
 
-  it.each(["oblong-deep-scoop", "flat-ended-scoop"])("validates the full %s mouth against the bin walls", (kind) => {
+  it.each(["oblong-deep-scoop", "flat-ended-scoop", "oblong-straight", "flat-ended-straight"])("validates the full %s mouth against the bin walls", (kind) => {
     const shape = makeShape("s1", 20, 20);
     const cutout = makeCutout("c1", "s1", 0, 0, {
       fingerHoles: [


### PR DESCRIPTION
## Summary
- Simplify finger access to Round or Slot, with Curved or Flat bottoms and Rounded or Flat slot ends, plus compact editable properties and a shape preview.
- Support all combinations in geometry, Layout, exports, and versioned project persistence, including 1 mm shallow cuts.
- Add a separate Corner round control under Edges & corners for flat-ended slots with either bottom style. Rounding stays inside the nominal opening and is limited to half the smaller width or length, independently of top/bottom edge rounds.
- Cap depth at the actual bin underside, without a floor indicator. Limit nominal opening dimensions to the bin footprint plus 5%, accounting for slot rotation and Layout resize handles.
- Resize oversized finger access with the bin in the same undo step, while preserving older saved geometry until explicitly edited.
- Rename the materials heading and settings navigation to Materials & Colors.

## Compatibility
- Project schema v15 migrates older saves, keeps existing slot corners sharp, and retains slot-end preferences and requested edge/corner radii across shape changes.
- Effective corner rounding follows the slot dimensions; larger requested radii are retained if the slot is resized smaller, just like other rounding controls.
- Existing oversized saves are flagged, not silently rewritten on opening. Mouth-size limits are before top-edge rounding; wall and floor validation remains active.
- Includes current main through the library JSON transfer changes in #41. H2D and tutorial branches are untouched. The separate library-management changes remain in #43.

## Validation
- Node.js 22: `npm run check`
- `npm test -- --maxWorkers=2`: 77 files, 1,295 tests passed (including localhost server tests).
- `npm run build` (existing bundle-size/Browserslist warnings)
- `git diff --check`
- Corner-rounding coverage: schema validation and migration, zero/default and maximum radii, short/wide slots, 1 mm and deeper cuts, rotations, Layout/3D mouth agreement, tangent top edges, independent bottom fillets, undo/redo, size-aware input limits, and closed STL/3MF export meshes.
- Browser checks for both bottom styles in 3D, matching rounded Layout outlines, radius editing, and 320 px mobile controls. Existing checks cover bin-aware limits, no floor indicator, and Materials & Colors.
- Physical print and fit validation is not part of this PR.
