### PR TITLE
Clarify project library management and portable backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ processing, project storage, and model generation kept on the user's device.
   preserve the calibrated outline as an editable pocket in a new Bin project.
   When selected, both files share a filename stem.
 - Export top-down layouts for shadow boards and CNC workflows.
+- Save the current design or choose Open saved project under Project's Browser
+  library section. Manage library lets you open saved projects with Open or a
+  double-click, rename or copy any project, and remove projects with confirmation. Copy
+  adds a separately named entry directly after its source, keeping focus on the source
+  and leaving the open project unchanged. Library order stays stable as you work. A single
+  click focuses a project without opening it. The currently open project cannot be removed;
+  switch projects or start a new one first. Rename stays beside the project name.
+  Overflowing project lists keep their scrollbar visible.
+  Portable backup separates a single editable project file from an
+  entire-library JSON backup; Export library and Import library are directly
+  available there, outside the saved-project picker.
 
 Pocketry is still subject to physical print validation. Inspect generated files
 and confirm dimensions and printer settings before relying on them for a final

--- a/client/src/components/gridfinity/bin-controls-panel.tsx
+++ b/client/src/components/gridfinity/bin-controls-panel.tsx
@@ -9,6 +9,7 @@ import {
   FilePlus2,
   FolderOpen,
   LayoutGrid,
+  LibraryBig,
   LoaderCircle,
   Magnet,
   MousePointerClick,
@@ -24,7 +25,7 @@ import {
   Trash2,
   Upload,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useLocation } from "wouter";
 
 import {
@@ -86,6 +87,7 @@ import {
 import { HelpHint } from "@/components/ui/help-hint";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Select,
   SelectContent,
@@ -228,6 +230,8 @@ export interface BinControlsPanelProps {
   currentProjectName: string | null;
   projects: ProjectLibraryItem[];
   onSaveProject: (name: string) => Promise<boolean>;
+  onRenameProject: (projectId: string, name: string) => Promise<boolean>;
+  onDuplicateProject: (projectId: string) => Promise<string | null>;
   onOpenProject: (projectId: string) => Promise<boolean>;
   onDeleteProject: (projectId: string) => Promise<boolean>;
   onRefreshProjects: () => void;
@@ -277,6 +281,8 @@ export function BinControlsPanel({
   currentProjectName,
   projects,
   onSaveProject,
+  onRenameProject,
+  onDuplicateProject,
   onOpenProject,
   onDeleteProject,
   onRefreshProjects,
@@ -469,7 +475,7 @@ export function BinControlsPanel({
     <div className="flex h-full flex-col">
       <div className="shrink-0 border-b px-3 py-2" data-testid="project-status">
         <p className="truncate text-sm font-medium" title={currentProjectName ?? "Untitled project"}>{currentProjectName ?? "Untitled project"}</p>
-        <p className="text-[11px] text-muted-foreground" role="status">{!hydrated ? "Opening project…" : projectBusy || saveStatus === "saving" ? "Saving in this browser…" : saveStatus === "error" ? "Could not save. Download an editable project to keep your work." : "Saved in this browser"}</p>
+        <p className="text-[11px] text-muted-foreground" role="status">{!hydrated ? "Opening project…" : projectBusy ? "Working…" : saveStatus === "saving" ? "Saving in this browser…" : saveStatus === "error" ? "Could not save. Export this project to keep your work." : "Saved in this browser"}</p>
       </div>
       {/* On short screens the section headers remain reachable by scrolling;
           reserve the limited height for editable fields instead of shortcuts. */}
@@ -486,7 +492,7 @@ export function BinControlsPanel({
           title="Project"
           icon={FolderOpen}
           tone="slate"
-          summary={projectBusy ? "Saving…" : activeProjectId ? "Library" : "Draft"}
+          summary={projectBusy ? "Working…" : activeProjectId ? "Library" : "Draft"}
           defaultOpen={false}
           className="scroll-mt-16"
         >
@@ -499,6 +505,8 @@ export function BinControlsPanel({
             currentProjectName={currentProjectName}
             projects={projects}
             onSaveProject={onSaveProject}
+            onRenameProject={onRenameProject}
+            onDuplicateProject={onDuplicateProject}
             onOpenProject={onOpenProject}
             onDeleteProject={onDeleteProject}
             onRefreshProjects={onRefreshProjects}
@@ -1993,6 +2001,8 @@ interface ProjectControlsProps {
   currentProjectName: string | null;
   projects: ProjectLibraryItem[];
   onSaveProject: (name: string) => Promise<boolean>;
+  onRenameProject: (projectId: string, name: string) => Promise<boolean>;
+  onDuplicateProject: (projectId: string) => Promise<string | null>;
   onOpenProject: (projectId: string) => Promise<boolean>;
   onDeleteProject: (projectId: string) => Promise<boolean>;
   onRefreshProjects: () => void;
@@ -2003,6 +2013,8 @@ interface ProjectControlsProps {
   onImportProject: (file: File) => void;
 }
 
+const projectActionClass = "h-auto min-h-11 min-w-0 gap-1.5 whitespace-normal px-2 py-2 text-xs";
+
 function ProjectControls({
   hydrated,
   libraryReady,
@@ -2011,6 +2023,8 @@ function ProjectControls({
   currentProjectName,
   projects,
   onSaveProject,
+  onRenameProject,
+  onDuplicateProject,
   onOpenProject,
   onDeleteProject,
   onRefreshProjects,
@@ -2023,233 +2037,287 @@ function ProjectControls({
 }: ProjectControlsProps): JSX.Element {
   const ready = hydrated && libraryReady;
   const [saveOpen, setSaveOpen] = useState(false);
-  const [libraryOpen, setLibraryOpen] = useState(false);
+  const [renameProjectId, setRenameProjectId] = useState<string | null>(null);
+  const [libraryView, setLibraryView] = useState<"open" | "manage" | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [projectName, setProjectName] = useState("");
   const importInputRef = useRef<HTMLInputElement | null>(null);
   const libraryImportInputRef = useRef<HTMLInputElement | null>(null);
 
-  const handleSave = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (busy) return;
-    if (await onSaveProject(projectName)) setSaveOpen(false);
-  };
-
-  return (
-    <>
-      <div
-        className="rounded-md border bg-muted/40 px-3 py-2"
-        data-testid="project-autosave-status"
-      >
-        <div className="flex items-center gap-1">
-          <p className="min-w-0 truncate text-xs font-medium">
-            {!ready ? "Checking for saved projects…" : (currentProjectName ?? "Untitled project")}
-          </p>
-          {ready && <HelpHint label="project autosave">{activeProjectId
-            ? "Saved automatically in this browser’s Project Library."
-            : "This draft resumes automatically; save it to the library to name it."}</HelpHint>}
-        </div>
-        {saveStatus === "error" && <p className="mt-0.5 text-[11px] text-destructive" role="status">Autosave is unavailable. Download an editable project to keep your work.</p>}
-      </div>
-
-      <div className="grid grid-cols-2 gap-2">
-        <Dialog
-          open={saveOpen}
-          onOpenChange={(open) => {
-            setSaveOpen(open);
-            if (open) setProjectName(currentProjectName ?? "");
-          }}
-        >
-          <DialogTrigger asChild>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={!ready || busy}
-              data-testid="button-save-library"
-            >
-              <Save className="mr-1.5 h-3.5 w-3.5" />
-              {activeProjectId ? "Rename" : "Save to library"}
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <form className="contents" onSubmit={(event) => void handleSave(event)}>
-              <DialogHeader>
-                <DialogTitle>
-                  {activeProjectId ? "Rename project" : "Save project to library"}
-                </DialogTitle>
-                <DialogDescription>
-                  Named projects stay in this browser’s Pocketry library and update
-                  automatically as you work.
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-2">
-                <Label htmlFor="project-library-name">Project name</Label>
-                <Input
-                  id="project-library-name"
-                  value={projectName}
-                  onChange={(event) => setProjectName(event.target.value)}
-                  maxLength={80}
-                  autoFocus
-                  placeholder="Socket wrench tray"
-                  data-testid="input-project-name"
-                />
-              </div>
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setSaveOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  type="submit"
-                  disabled={busy || projectName.trim().length === 0}
-                  data-testid="button-confirm-save-library"
-                >
-                  {busy ? "Saving…" : "Save project"}
-                </Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-
-        <Dialog
-          open={libraryOpen}
-          onOpenChange={(open) => {
-            setLibraryOpen(open);
-            if (open) onRefreshProjects();
-          }}
-        >
-          <DialogTrigger asChild>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={!ready || busy}
-              data-testid="button-open-library"
-            >
-              <FolderOpen className="mr-1.5 h-3.5 w-3.5" />
-              Open library
-            </Button>
-          </DialogTrigger>
-          <DialogContent className="max-h-[85dvh] overflow-y-auto">
+  const renderNameDialog = (project?: ProjectLibraryItem): JSX.Element => {
+    const renaming = !!project || !!activeProjectId;
+    const setOpen = (open: boolean) => {
+      if (project) setRenameProjectId(open ? project.id : null);
+      else setSaveOpen(open);
+      if (open) setProjectName(project?.name ?? currentProjectName ?? "");
+    };
+    return (
+      <Dialog open={project ? renameProjectId === project.id : saveOpen} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button
+            variant={renaming ? "ghost" : "outline"}
+            size={renaming ? "icon" : "sm"}
+            className={renaming
+              ? "h-8 w-8 shrink-0 text-muted-foreground [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
+              : "h-8 shrink-0 gap-1.5 px-2 text-xs [@media(pointer:coarse)]:min-h-11"}
+            aria-label={project ? `Rename ${project.name}` : renaming ? "Rename project" : "Save to library"}
+            title={renaming ? "Rename project" : undefined}
+            disabled={!ready || busy}
+            data-testid={project ? `button-rename-project-${project.id}` : "button-save-library"}
+          >
+            {renaming ? <Pencil className="h-3.5 w-3.5 shrink-0" /> : <Save className="h-3.5 w-3.5 shrink-0" />}
+            {!renaming && "Save to library"}
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <form className="contents" onSubmit={async (event) => {
+            event.preventDefault();
+            if (busy) return;
+            const saved = project ? await onRenameProject(project.id, projectName) : await onSaveProject(projectName);
+            if (saved) setOpen(false);
+          }}>
             <DialogHeader>
-              <DialogTitle>Project Library</DialogTitle>
+              <DialogTitle>{renaming ? "Rename project" : "Save project to library"}</DialogTitle>
               <DialogDescription>
-                Choose a named project saved in this browser. Opening it replaces the
-                current working draft.
+                {project ? `Change the name of “${project.name}”.` : "Named projects stay in this browser’s Pocketry library and update automatically as you work."}
               </DialogDescription>
             </DialogHeader>
             <div className="space-y-2">
-              <div className="flex flex-wrap gap-2">
-                <Button size="sm" variant="outline" disabled={!ready || busy}
-                  onClick={onExportLibrary} data-testid="button-export-library">
-                  <Download className="mr-1.5 h-3.5 w-3.5" />Export library
-                </Button>
-                <Button size="sm" variant="outline" disabled={!ready || busy}
-                  onClick={() => libraryImportInputRef.current?.click()} data-testid="button-import-library">
-                  <Upload className="mr-1.5 h-3.5 w-3.5" />Import library
-                </Button>
-                <input ref={libraryImportInputRef} type="file" accept=".json,application/json"
-                  className="hidden" aria-label="Import library JSON" data-testid="input-import-library"
-                  onChange={(event) => {
-                    const file = event.currentTarget.files?.[0];
-                    event.currentTarget.value = "";
-                    if (file) onImportLibrary(file);
-                  }} />
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Export all named designs as JSON. Save an unnamed draft to the library first.
-                Import adds designs and upgrades older versions. Existing designs stay intact;
-                duplicate names get an “imported” suffix.
-              </p>
+              <Label htmlFor="project-library-name">Project name</Label>
+              <Input
+                id="project-library-name"
+                value={projectName}
+                onChange={(event) => setProjectName(event.target.value)}
+                maxLength={80}
+                autoFocus
+                placeholder="Socket wrench tray"
+                data-testid="input-project-name"
+              />
             </div>
-            <div className="max-h-80 space-y-2 overflow-y-auto" data-testid="project-list">
-              {projects.length === 0 ? (
-                <div className="rounded-md border border-dashed p-5 text-center text-sm text-muted-foreground">
-                  No named projects yet. Save the current draft to add one.
-                </div>
-              ) : (
-                projects.map((project) => {
-                  const active = project.id === activeProjectId;
-                  return (
-                    <div
-                      key={project.id}
-                      className={cn(
-                        "flex items-center gap-3 rounded-md border p-3",
-                        active && "border-primary/50 bg-primary/5",
-                      )}
-                      data-testid={`library-project-${project.id}`}
-                    >
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-medium">
-                          {project.name}
-                          {active ? " · Current" : ""}
-                        </p>
-                        <p className="text-[11px] text-muted-foreground">
-                          Updated {formatProjectTime(project.updatedAt)}
-                        </p>
-                      </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+              <Button type="submit" disabled={busy || projectName.trim().length === 0} data-testid="button-confirm-save-library">
+                {busy ? "Saving…" : renaming ? "Save name" : "Save project"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    );
+  };
+
+  const renderLibraryDialog = (mode: "open" | "manage"): JSX.Element => (
+    <Dialog
+      key={mode}
+      open={libraryView === mode}
+      onOpenChange={(open) => {
+        setLibraryView(open ? mode : null);
+        if (open && mode === "manage") setSelectedProjectId(activeProjectId);
+        if (open) onRefreshProjects();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button
+          variant={mode === "open" ? "outline" : "ghost"}
+          size="sm"
+          disabled={!ready || busy}
+          data-testid={mode === "open" ? "button-open-library" : "button-manage-library"}
+          className={mode === "open"
+            ? "h-auto min-h-9 min-w-0 gap-1.5 whitespace-normal px-2 py-1.5 text-xs [@media(pointer:coarse)]:min-h-11"
+            : "h-8 gap-1 px-2 text-xs text-muted-foreground [@media(pointer:coarse)]:min-h-11"}
+          aria-label={mode === "open" ? "Open saved project" : "Manage library"}
+          title={mode === "manage" ? "Manage browser library" : undefined}
+        >
+          {mode === "open" ? <FolderOpen className="h-3.5 w-3.5 shrink-0" /> : <LibraryBig className="h-3.5 w-3.5 shrink-0" />}
+          {mode === "open" ? "Open saved project" : "Manage"}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[85dvh] overflow-hidden p-4 sm:p-6">
+        <DialogHeader>
+          <DialogTitle>{mode === "open" ? "Open a saved project" : "Manage browser library"}</DialogTitle>
+          <DialogDescription>
+            {mode === "open"
+              ? "Choose a named project saved in this browser. Opening it replaces the current working draft."
+              : `${projects.length} saved project${projects.length === 1 ? "" : "s"} in this browser.`}
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea
+          type="auto"
+          className="min-h-0 [&_[data-radix-scroll-area-viewport]]:max-h-[min(20rem,calc(85dvh_-_8rem))] [&_[data-orientation=vertical]]:bg-muted/50 [&_[data-orientation=vertical]>div]:bg-muted-foreground/50"
+          data-testid={`${mode}-library-scroll`}
+        >
+        <div className="space-y-2 pr-4" data-testid={mode === "open" ? "project-list" : "managed-project-list"}>
+          {projects.length === 0 ? (
+            <div className="rounded-md border border-dashed p-5 text-center text-sm text-muted-foreground">
+              No named projects yet. Save the current draft to add one.
+            </div>
+          ) : (
+            projects.map((project) => {
+              const active = project.id === activeProjectId;
+              const openProject = async () => {
+                if (busy || active) return;
+                if (await onOpenProject(project.id)) setLibraryView(null);
+              };
+              return (
+                <div
+                  key={project.id}
+                  className={cn(
+                    "flex items-center gap-3 rounded-md border p-3",
+                    mode === "manage" && "flex-wrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                    (mode === "manage" ? project.id === selectedProjectId : active) && "border-primary/50 bg-primary/5",
+                  )}
+                  data-testid={`library-project-${project.id}`}
+                  data-selected={mode === "manage" ? project.id === selectedProjectId : undefined}
+                  role="group"
+                  aria-label={project.name}
+                  tabIndex={mode === "manage" ? 0 : undefined}
+                  onFocus={(event) => {
+                    if (mode === "manage" && event.currentTarget.contains(event.target)) setSelectedProjectId(project.id);
+                  }}
+                  onClick={(event) => {
+                    if (mode !== "manage" || !(event.target instanceof Element)) return;
+                    if (!event.currentTarget.contains(event.target)) return;
+                    setSelectedProjectId(project.id);
+                    if (!event.target.closest("button")) event.currentTarget.focus();
+                  }}
+                  onKeyDown={(event) => {
+                    if (mode !== "manage" || event.target !== event.currentTarget || event.key !== "Enter") return;
+                    event.preventDefault();
+                    void openProject();
+                  }}
+                  onDoubleClick={(event) => {
+                    if (mode !== "manage" || !(event.target instanceof Element)) return;
+                    if (!event.currentTarget.contains(event.target) || event.target.closest("button")) return;
+                    void openProject();
+                  }}
+                >
+                  <div className={cn("min-w-0 flex-1", mode === "manage" && "basis-40")}>
+                    <div className="flex min-w-0 items-center gap-1" data-testid={`library-project-name-${project.id}`}>
+                      <p className="min-w-0 truncate text-sm font-medium" title={project.name}>
+                        {project.name}
+                      </p>
+                      {mode === "manage" && renderNameDialog(project)}
+                    </div>
+                    {active && mode === "manage" && <p className="text-xs text-muted-foreground">Current project</p>}
+                    <p className="text-[11px] text-muted-foreground">
+                      Updated {formatProjectTime(project.updatedAt)}
+                    </p>
+                  </div>
+                  <div className="ml-auto flex shrink-0 items-center gap-1.5">
+                  <Button
+                    size="sm"
+                    variant={active ? "secondary" : "outline"}
+                    className="min-h-11 gap-1.5 px-2 text-xs"
+                    disabled={busy || active}
+                    onClick={() => void openProject()}
+                    aria-label={active ? `${project.name} is currently open` : `Open ${project.name}`}
+                    data-testid={`button-open-project-${project.id}`}
+                  >
+                    {!active && <FolderOpen className="h-4 w-4" />}
+                    {active ? "Current" : "Open"}
+                  </Button>
+                  {mode === "manage" && <Button
+                    size="sm"
+                    variant="outline"
+                    className="min-h-11 gap-1.5 px-2 text-xs"
+                    disabled={busy}
+                    aria-label={`Duplicate ${project.name}`}
+                    title="Duplicate project"
+                    data-testid={`button-duplicate-project-${project.id}`}
+                    onClick={(event) => {
+                      event.currentTarget.closest<HTMLElement>('[role="group"]')?.focus();
+                      void onDuplicateProject(project.id);
+                    }}
+                  >
+                    <Copy className="h-4 w-4" />Copy
+                  </Button>}
+                  {mode === "manage" && <AlertDialog>
+                    <AlertDialogTrigger asChild>
                       <Button
                         size="sm"
-                        variant={active ? "secondary" : "outline"}
+                        variant="ghost"
+                        className="min-h-11 shrink-0 gap-1.5 px-2 text-xs text-destructive hover:text-destructive"
                         disabled={busy || active}
-                        onClick={async () => {
-                          if (await onOpenProject(project.id)) setLibraryOpen(false);
-                        }}
-                        data-testid={`button-open-project-${project.id}`}
+                        aria-label={`Remove ${project.name} from library`}
+                        data-testid={`button-remove-project-${project.id}`}
                       >
-                        {active ? "Current" : "Open"}
+                        <Trash2 className="h-4 w-4 shrink-0" />Remove
                       </Button>
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <Button
-                            size="icon"
-                            variant="ghost"
-                            className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                            disabled={busy}
-                            aria-label={`Delete ${project.name}`}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>Delete “{project.name}”?</AlertDialogTitle>
-                            <AlertDialogDescription>
-                              This removes the named copy from this browser’s Project
-                              Library. If it is open, the current design remains as an
-                              unnamed draft.
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>Keep project</AlertDialogCancel>
-                            <AlertDialogAction
-                              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                              onClick={() => void onDeleteProject(project.id)}
-                            >
-                              Delete project
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    </div>
-                  );
-                })
-              )}
-            </div>
-          </DialogContent>
-        </Dialog>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle className="break-words">Remove “{project.name}” from library?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This removes the saved copy from this browser. Your current project
+                          will not change. Exported backup files are not affected.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Keep project</AlertDialogCancel>
+                        <AlertDialogAction
+                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                          disabled={busy || active}
+                          onClick={() => void onDeleteProject(project.id)}
+                          data-testid="button-confirm-remove-project"
+                        >
+                          Remove from library
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
 
+  return (
+    <>
+      <section aria-label="Browser library" className="space-y-2">
+      <div
+        className="space-y-2"
+        data-testid="project-autosave-status"
+      >
+        <div className="flex min-h-8 items-center gap-1">
+          <h3 className="text-sm font-semibold">Browser Library</h3>
+          {ready && <HelpHint label="project autosave">{activeProjectId
+            ? "Saved automatically in this browser’s Project Library."
+            : "This draft resumes automatically; save it to the library to name it."}</HelpHint>}
+          <div className="ml-auto">{renderLibraryDialog("manage")}</div>
+        </div>
+        <div
+          className={cn("flex min-h-8 items-center gap-x-1.5 gap-y-1", !activeProjectId && "flex-wrap")}
+          data-testid="current-project-name-row"
+          role="group"
+          aria-labelledby="current-project-label"
+        >
+        <div className={cn("flex min-w-0 items-baseline gap-1.5", !activeProjectId && "basis-48 grow")}>
+        <p id="current-project-label" className="shrink-0 text-xs text-muted-foreground">Current Project:</p>
+        <p className="min-w-0 truncate text-sm font-medium" title={currentProjectName ?? "Untitled project"}>
+          {!ready ? "Checking for saved projects…" : (currentProjectName ?? "Untitled project")}
+        </p>
+        </div>
+        {renderNameDialog()}
+        </div>
+        {saveStatus === "error" && <p className="text-[11px] text-destructive" role="status">Autosave is unavailable. Export this project to keep your work.</p>}
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        {renderLibraryDialog("open")}
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
               variant="outline"
               size="sm"
-              className="col-span-2"
+              className="h-auto min-h-9 min-w-0 gap-1.5 whitespace-normal px-2 py-1.5 text-xs [@media(pointer:coarse)]:min-h-11"
               disabled={!ready || busy}
               data-testid="button-new-project"
             >
-              <FilePlus2 className="mr-1.5 h-3.5 w-3.5" />
+              <FilePlus2 className="h-3.5 w-3.5 shrink-0" />
               New project
             </Button>
           </AlertDialogTrigger>
@@ -2275,31 +2343,58 @@ function ProjectControls({
           </AlertDialogContent>
         </AlertDialog>
       </div>
+      </section>
 
-      <div className="space-y-1.5 border-t pt-3">
-        <SettingLabel label="Portable backup" hint="Editable .pocketry.json files preserve tools and settings. STL and 3MF are for printing." />
+      <section aria-label="Portable backup" className="space-y-3 border-t pt-3" data-testid="portable-backup">
+        <h3 className="text-sm font-semibold">Portable Backup</h3>
+        <div className="space-y-1.5" data-testid="project-file-backup">
+        <SettingLabel label="Current project" hint="Exports this design as an editable .pocketry.json file. Opening a project file replaces the working draft; saved library projects stay intact." />
         <div className="grid grid-cols-2 gap-2">
           <Button
             variant="outline"
             size="sm"
-            className="h-auto min-h-9 min-w-0 whitespace-normal px-2 py-2 text-xs"
+            className={projectActionClass}
             disabled={!ready || busy}
             onClick={onExportProject}
             data-testid="button-export-project"
           >
-            Download editable project
+            <Download className="h-3.5 w-3.5 shrink-0" />Export project
           </Button>
           <Button
             variant="outline"
             size="sm"
-            className="h-auto min-h-9 min-w-0 whitespace-normal px-2 py-2 text-xs"
+            className={projectActionClass}
             disabled={!ready || busy}
             onClick={() => importInputRef.current?.click()}
             data-testid="button-import-project"
           >
-            Open Pocketry project
+            <FolderOpen className="h-3.5 w-3.5 shrink-0" />Open project file
           </Button>
         </div>
+        </div>
+        <div className="space-y-1.5" data-testid="library-file-backup">
+          <div className="flex items-center justify-between gap-2">
+            <SettingLabel label="Entire library" hint="Exports every named project saved in this browser as one JSON file. Unnamed drafts are not included. Import adds projects without replacing your current design or existing library; duplicate names receive an imported suffix." />
+            <span className="shrink-0 text-[11px] text-muted-foreground">{ready ? `${projects.length} saved` : "Loading…"}</span>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <Button size="sm" variant="outline" className={projectActionClass} disabled={!ready || busy}
+              onClick={onExportLibrary} data-testid="button-export-library">
+              <Download className="h-3.5 w-3.5 shrink-0" />Export library
+            </Button>
+            <Button size="sm" variant="outline" className={projectActionClass} disabled={!ready || busy}
+              onClick={() => libraryImportInputRef.current?.click()} data-testid="button-import-library">
+              <Upload className="h-3.5 w-3.5 shrink-0" />Import library
+            </Button>
+          </div>
+        </div>
+        <input ref={libraryImportInputRef} type="file" accept=".json,application/json"
+          className="hidden" aria-label="Import library JSON" data-testid="input-import-library"
+          onChange={(event) => {
+            const file = event.currentTarget.files?.[0];
+            event.currentTarget.value = "";
+            if (file) onImportLibrary(file);
+          }} />
         <input
           ref={importInputRef}
           type="file"
@@ -2311,7 +2406,7 @@ function ProjectControls({
             event.target.value = "";
           }}
         />
-      </div>
+      </section>
     </>
   );
 }

--- a/client/src/components/help/help-dialog.tsx
+++ b/client/src/components/help/help-dialog.tsx
@@ -183,16 +183,24 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
             <h3 className="mb-1.5 font-medium">3. Save and resume projects</h3>
             <ul className="list-disc space-y-1 pl-6 text-muted-foreground">
               <li>
-                <strong>Save project</strong> stores a named project in the
+                <strong>Save to library</strong> stores a named project in the
                 browser's project library for quick resume.
               </li>
               <li>
-                <strong>Open project</strong> resumes a saved design; portable
-                project files can also be exported and imported with a chosen
-                filename and location.
+                <strong>Browser library → Open saved project</strong> resumes a
+                project saved in this browser.
+                {" "}<strong>Manage library</strong> also opens projects with Open or a
+                double-click, renames any project with the pencil, creates an independent
+                duplicate with Copy directly after its source without moving focus or
+                switching projects, and provides a confirmed
+                Remove action. The currently open project cannot be removed; open another
+                project or start a new one first.
+                In <strong>Portable backup → Current project</strong>, use
+                {" "}<strong>Export project</strong> or <strong>Open project file</strong>
+                {" "}for one editable design.
               </li>
               <li>
-                In <strong>Project → Open library</strong>, use <strong>Export library</strong>
+                In <strong>Project → Portable backup → Entire library</strong>, use <strong>Export library</strong>
                 {" "}to back up every named design in one JSON file, or <strong>Import library</strong>
                 {" "}to add designs from a backup. Supported older designs upgrade automatically.
                 Duplicate names get an “imported” suffix; existing designs and the open draft
@@ -237,7 +245,7 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps): JSX.Element
                 starts unchecked. When selected, the files share the project name
                 (when saved), bin size, and local date/time. Allow multiple
                 downloads if your browser asks, and keep the JSON to restore
-                the design later with Open Pocketry project.
+                the design later with Open project file.
               </li>
               <li>
                 Trace exports offer the same optional JSON download once the outline

--- a/client/src/lib/project/persist.test.ts
+++ b/client/src/lib/project/persist.test.ts
@@ -16,10 +16,12 @@ vi.mock("idb-keyval", () => ({
 import {
   createDebouncedProjectSaver,
   deleteProjectFromLibrary,
+  duplicateProjectInLibrary,
   loadProjectDoc,
   loadProjectLibrary,
   openProjectFromLibrary,
   ProjectNameConflictError,
+  renameProjectInLibrary,
   saveProjectDoc,
   saveProjectToLibrary,
   startNewProject,
@@ -125,6 +127,109 @@ describe("named project library", () => {
     expect(updated.projects[0].name).toBe("Wide wrench tray");
     const opened = await openProjectFromLibrary(updated.projects[0].id);
     expect(opened.doc.spec.gridX).toBe(4);
+  });
+
+  it("copies pending edits from the current project without opening or changing the original", async () => {
+    const saved = await saveProjectToLibrary(DOC, "Tools", null);
+    const working = await loadProjectDoc();
+    const copied = await duplicateProjectInLibrary(saved.activeProjectId!, WIDE_DOC);
+    expect(copied.project.name).toBe("Tools (copy)");
+    expect(copied.project.id).not.toBe(saved.activeProjectId);
+    expect(copied.library.activeProjectId).toBe(saved.activeProjectId);
+    expect(await loadProjectDoc()).toEqual(working);
+    expect((await openProjectFromLibrary(copied.project.id)).doc).toEqual({ ...WIDE_DOC, name: "Tools (copy)" });
+    await saveProjectDoc({ ...WIDE_DOC, keepBinSize: true });
+    expect((await openProjectFromLibrary(saved.activeProjectId!)).doc).toEqual({ ...DOC, name: "Tools" });
+  });
+
+  it("copies the stored design of another project, not the current working design", async () => {
+    const first = await saveProjectToLibrary(DOC, "Small tray", null);
+    const second = await saveProjectToLibrary(WIDE_DOC, "Wide tray", null);
+    const copied = await duplicateProjectInLibrary(first.activeProjectId!, WIDE_DOC);
+    expect(copied.library.activeProjectId).toBe(second.activeProjectId);
+    expect((await loadProjectDoc())!.spec.gridX).toBe(4);
+    expect((await openProjectFromLibrary(copied.project.id)).doc).toEqual({ ...DOC, name: "Small tray (copy)" });
+  });
+
+  it("gives repeated copies unique names within the project name limit", async () => {
+    const saved = await saveProjectToLibrary(DOC, "A".repeat(80), null);
+    const first = await duplicateProjectInLibrary(saved.activeProjectId!);
+    const second = await duplicateProjectInLibrary(saved.activeProjectId!);
+    expect(first.project.name).toHaveLength(80);
+    expect(second.project.name).toHaveLength(80);
+    expect(first.project.name.endsWith(" (copy)")).toBe(true);
+    expect(second.project.name.endsWith(" (copy 2)")).toBe(true);
+    expect(new Set(second.library.projects.map(project => project.id)).size).toBe(3);
+    expect(second.library.activeProjectId).toBe(saved.activeProjectId);
+  });
+
+  it("keeps each copy directly after its source through reloads, renames, and autosave", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-12T12:00:00Z"));
+    const first = await saveProjectToLibrary(DOC, "First", null);
+    vi.setSystemTime(new Date("2026-09-12T13:00:00Z"));
+    const source = await saveProjectToLibrary(WIDE_DOC, "Source", null);
+    vi.setSystemTime(new Date("2026-09-12T14:00:00Z"));
+    const last = await saveProjectToLibrary(DOC, "Last", null);
+    const originalOrder = [first.activeProjectId, source.activeProjectId, last.activeProjectId];
+    expect((await loadProjectLibrary()).projects.map(project => project.id)).toEqual(originalOrder);
+    const copy = await duplicateProjectInLibrary(source.activeProjectId!);
+    const nextCopy = await duplicateProjectInLibrary(source.activeProjectId!);
+    const expectedOrder = [first.activeProjectId, source.activeProjectId, nextCopy.project.id, copy.project.id, last.activeProjectId];
+    expect(nextCopy.library.projects.map(project => project.id)).toEqual(expectedOrder);
+    await renameProjectInLibrary(copy.project.id, "Renamed copy");
+    await saveProjectDoc({ ...DOC, keepBinSize: true });
+    expect((await loadProjectLibrary()).projects.map(project => project.id)).toEqual(expectedOrder);
+    expect((await loadProjectLibrary()).activeProjectId).toBe(last.activeProjectId);
+  });
+
+  it("rejects copying missing or unsupported projects without changing storage", async () => {
+    const future = { id: "future", name: "Future project", updatedAt: "2026-09-12T12:00:00.000Z", doc: { schemaVersion: 999 } };
+    memory.set("tooltrace:project-library:v1", { schemaVersion: 1, activeProjectId: null, projects: [future] });
+    const before = structuredClone([...memory]);
+    await expect(duplicateProjectInLibrary("missing")).rejects.toThrow("no longer");
+    await expect(duplicateProjectInLibrary("future", DOC)).rejects.toThrow("unsupported");
+    expect([...memory]).toEqual(before);
+  });
+
+  it("renames another saved project without changing the open project or either design", async () => {
+    const first = await saveProjectToLibrary(DOC, "Small tray", null);
+    const second = await saveProjectToLibrary(WIDE_DOC, "Wide tray", null);
+    const working = await loadProjectDoc();
+    const renamed = await renameProjectInLibrary(first.activeProjectId!, "  Socket   tray  ");
+    expect(renamed.activeProjectId).toBe(second.activeProjectId);
+    expect(renamed.projects).toHaveLength(2);
+    expect(renamed.projects.find(project => project.id === first.activeProjectId)?.name).toBe("Socket tray");
+    expect(await loadProjectDoc()).toEqual(working);
+    expect((await openProjectFromLibrary(first.activeProjectId!)).doc).toEqual({ ...DOC, name: "Socket tray" });
+    expect((await openProjectFromLibrary(second.activeProjectId!)).doc).toEqual({ ...WIDE_DOC, name: "Wide tray" });
+  });
+
+  it("rejects conflicting library renames without writing any project", async () => {
+    const first = await saveProjectToLibrary(DOC, "Small tray", null);
+    await saveProjectToLibrary(WIDE_DOC, "Wide tray", null);
+    const before = structuredClone([...memory]);
+    await expect(renameProjectInLibrary(first.activeProjectId!, "wide TRAY")).rejects.toBeInstanceOf(ProjectNameConflictError);
+    expect([...memory]).toEqual(before);
+  });
+
+  it.each(["", "x".repeat(81)])("rejects invalid library rename %j without changing storage", async (name) => {
+    const saved = await saveProjectToLibrary(DOC, "Tools", null);
+    const before = structuredClone([...memory]);
+    await expect(renameProjectInLibrary(saved.activeProjectId!, name)).rejects.toThrow();
+    expect([...memory]).toEqual(before);
+  });
+
+  it("preserves unsupported entries and rejects renaming missing or unsupported projects", async () => {
+    const future = { id: "future", name: "Future project", updatedAt: "2026-09-12T12:00:00.000Z", doc: { schemaVersion: 999 } };
+    memory.set("tooltrace:project-library:v1", { schemaVersion: 1, activeProjectId: null, projects: [future] });
+    const saved = await saveProjectToLibrary(DOC, "Tools", null);
+    await renameProjectInLibrary(saved.activeProjectId!, "Renamed tools");
+    const before = structuredClone([...memory]);
+    await expect(renameProjectInLibrary("missing", "Missing")).rejects.toThrow("no longer");
+    await expect(renameProjectInLibrary("future", "Future renamed")).rejects.toThrow("unsupported");
+    expect([...memory]).toEqual(before);
+    expect((memory.get("tooltrace:project-library:v1") as { projects: unknown[] }).projects).toContainEqual(future);
   });
 
   it("rejects ambiguous duplicate names", async () => {

--- a/client/src/lib/project/persist.ts
+++ b/client/src/lib/project/persist.ts
@@ -105,8 +105,7 @@ function toSnapshot(library: StoredProjectLibrary): ProjectLibrarySnapshot {
     activeProjectId: library.activeProjectId,
     projects: library.projects
       .filter((project) => parseProjectDoc(project.doc) !== null)
-      .map(({ id, name, updatedAt }) => ({ id, name, updatedAt }))
-      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)),
+      .map(({ id, name, updatedAt }) => ({ id, name, updatedAt })),
   };
 }
 
@@ -272,6 +271,56 @@ export async function saveProjectToLibrary(
       projects,
     };
     await set(CURRENT_PROJECT_KEY, namedDoc);
+    await set(PROJECT_LIBRARY_KEY, next);
+    return toSnapshot(next);
+  });
+}
+
+/** Copy a saved project, including pending edits when copying the open project. */
+export async function duplicateProjectInLibrary(
+  projectId: string,
+  currentDoc?: ProjectDoc,
+): Promise<{ library: ProjectLibrarySnapshot; project: ProjectLibraryItem }> {
+  return mutateLibrary(async (library) => {
+    const stored = library.projects.find((project) => project.id === projectId);
+    if (!stored) throw new Error("That project is no longer in this browser's library.");
+    const doc = parseProjectDoc(library.activeProjectId === projectId && currentDoc ? currentDoc : stored.doc);
+    if (!doc) throw new Error("That project was saved by an unsupported Pocketry version.");
+    let name: string;
+    let suffix = 1;
+    do {
+      const ending = suffix === 1 ? " (copy)" : ` (copy ${suffix})`;
+      name = `${stored.name.slice(0, PROJECT_NAME_MAX_LENGTH - ending.length).trimEnd()}${ending}`;
+      suffix++;
+    } while (library.projects.some((project) => project.name.localeCompare(name, undefined, { sensitivity: "accent" }) === 0));
+    let id = makeProjectId();
+    while (library.projects.some((project) => project.id === id)) id = makeProjectId();
+    const project = { id, name, updatedAt: new Date().toISOString() };
+    const projects = [...library.projects];
+    projects.splice(projects.indexOf(stored) + 1, 0, { ...project, doc: { ...doc, name } });
+    const next = { ...library, projects };
+    await set(PROJECT_LIBRARY_KEY, next);
+    return { library: toSnapshot(next), project };
+  });
+}
+
+/** Rename a saved entry without opening it or replacing the working copy. */
+export async function renameProjectInLibrary(
+  projectId: string,
+  name: string,
+): Promise<ProjectLibrarySnapshot> {
+  const cleanName = cleanProjectName(name);
+  return mutateLibrary(async (library) => {
+    const stored = library.projects.find((project) => project.id === projectId);
+    if (!stored) throw new Error("That project is no longer in this browser's library.");
+    const doc = parseProjectDoc(stored.doc);
+    if (!doc) throw new Error("That project was saved by an unsupported Pocketry version.");
+    if (library.projects.some((project) => project.id !== projectId &&
+      project.name.localeCompare(cleanName, undefined, { sensitivity: "accent" }) === 0)) {
+      throw new ProjectNameConflictError(cleanName);
+    }
+    const renamed = { ...stored, name: cleanName, doc: { ...doc, name: cleanName }, updatedAt: new Date().toISOString() };
+    const next = { ...library, projects: library.projects.map((project) => project.id === projectId ? renamed : project) };
     await set(PROJECT_LIBRARY_KEY, next);
     return toSnapshot(next);
   });

--- a/client/src/pages/bin-designer.test.tsx
+++ b/client/src/pages/bin-designer.test.tsx
@@ -104,8 +104,10 @@ vi.mock("@/lib/project/persist", () => ({
   loadProjectLibrary: vi.fn(async () => ({ activeProjectId: null, projects: [] })),
   saveProjectDoc: vi.fn(async () => {}),
   saveProjectToLibrary: vi.fn(),
+  renameProjectInLibrary: vi.fn(),
   openProjectFromLibrary: vi.fn(),
   deleteProjectFromLibrary: vi.fn(),
+  duplicateProjectInLibrary: vi.fn(),
   exportProjectLibrary: vi.fn(),
   importProjectLibrary: vi.fn(),
   startNewProject: vi.fn(async () => ({ activeProjectId: null, projects: [] })),
@@ -1609,27 +1611,47 @@ describe("BinDesignerPage", () => {
     const fresh = container.querySelector(
       '[data-testid="button-new-project"]',
     ) as HTMLButtonElement;
+    const manage = container.querySelector<HTMLButtonElement>('[data-testid="button-manage-library"]')!;
 
     expect(status.textContent).toContain("Checking for saved projects");
     expect(save.disabled).toBe(true);
+    expect(manage.disabled).toBe(true);
+    const transfers = ["export-project", "import-project", "export-library", "import-library"].map(action =>
+      container.querySelector<HTMLButtonElement>(`[data-testid="button-${action}"]`)!,
+    );
+    for (const action of transfers) expect(action.disabled).toBe(true);
     await flushHydration();
 
     expect(status.textContent).toContain("Untitled project");
+    expect(status.querySelector('[role="group"][aria-labelledby="current-project-label"]')?.textContent).toContain("Untitled project");
+    expect(container.querySelector('#current-project-label')?.textContent).toBe("Current Project:");
+    expect(container.querySelector('section[aria-label="Browser library"] h3')?.textContent).toBe("Browser Library");
+    expect(container.querySelector('section[aria-label="Portable backup"] h3')?.textContent).toBe("Portable Backup");
     expect(status.textContent).not.toContain("draft resumes automatically");
     const autosaveHelp = status.querySelector<HTMLButtonElement>('[aria-label="About project autosave"]')!;
     React.act(() => autosaveHelp.click());
     expect(document.querySelector('[role="tooltip"]')!.textContent).toContain("draft resumes automatically");
     React.act(() => autosaveHelp.click());
     expect(save.textContent).toContain("Save to library");
-    expect(open.textContent).toContain("Open library");
+    expect(open.textContent).toContain("Open saved project");
     expect(fresh.textContent).toContain("New project");
     expect(save.disabled).toBe(false);
     expect(open.disabled).toBe(false);
     expect(fresh.disabled).toBe(false);
+    expect(manage.disabled).toBe(false);
+    expect(manage.getAttribute("aria-label")).toBe("Manage library");
+    expect(save.closest('section')?.getAttribute("aria-label")).toBe("Browser library");
+    expect(open.closest('section')?.getAttribute("aria-label")).toBe("Browser library");
+    for (const action of transfers) {
+      expect(action.disabled).toBe(false);
+      expect(action.closest('section')?.getAttribute("aria-label")).toBe("Portable backup");
+    }
+    expect(container.querySelector('[data-testid="project-file-backup"]')?.textContent).toContain("Current project");
+    expect(container.querySelector('[data-testid="library-file-backup"]')?.textContent).toContain("Entire library");
     unmount();
   });
 
-  it("names the current draft in the cross-browser Project Library", async () => {
+  it("names the current draft in the browser library without exporting a backup", async () => {
     const { container, unmount } = renderPage();
     openSettingsSection(container, "project");
     await flushHydration();
@@ -1665,12 +1687,17 @@ describe("BinDesignerPage", () => {
       "Socket wrench tray",
       null,
     );
+    expect(ProjectPersistence.exportProjectLibrary).not.toHaveBeenCalled();
+    expect(downloadBlob).not.toHaveBeenCalled();
     expect(
       container.querySelector('[data-testid="project-autosave-status"]')?.textContent,
     ).toContain("Socket wrench tray");
     expect(
-      container.querySelector('[data-testid="button-save-library"]')?.textContent,
-    ).toContain("Rename");
+      container.querySelector('[data-testid="button-save-library"]')?.getAttribute("aria-label"),
+    ).toBe("Rename project");
+    expect(container.querySelector('[data-testid="current-project-name-row"] [data-testid="button-save-library"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="current-project-name-row"] p[title]')?.textContent).toBe("Socket wrench tray");
+    expect(container.querySelector('[data-testid="button-save-library"]')?.textContent).toBe("");
     unmount();
   });
 
@@ -1706,6 +1733,11 @@ describe("BinDesignerPage", () => {
     expect(document.querySelector('[data-testid="project-list"]')?.textContent).toContain(
       "Pliers tray",
     );
+    const picker = document.querySelector('[role="dialog"]')!;
+    expect(picker.textContent).toContain("Open a saved project");
+    expect(picker.querySelector('[data-testid="button-export-library"]')).toBeNull();
+    expect(picker.querySelector('[data-testid="button-import-library"]')).toBeNull();
+    expect(picker.querySelector('[data-testid^="button-remove-project-"]')).toBeNull();
     expect(
       (document.querySelector(
         '[data-testid="button-open-project-project-1"]',
@@ -1727,15 +1759,335 @@ describe("BinDesignerPage", () => {
     unmount();
   });
 
-  it("exports the full library from its dialog with the latest design snapshot", async () => {
+  it.each(["open", "manage"])("keeps the %s library scrollbar visible while its projects overflow", async (mode) => {
+    const projects = Array.from({ length: 8 }, (_, index) => ({
+      id: `project-${index}`, name: `Project ${index}`, updatedAt: "2026-09-12T12:00:00.000Z",
+    }));
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: null, projects });
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    const resizeCallbacks = new Set<() => void>();
+    vi.stubGlobal("ResizeObserver", class implements ResizeObserver {
+      private notify: () => void;
+      constructor(callback: ResizeObserverCallback) { this.notify = () => callback([], this); }
+      observe() { resizeCallbacks.add(this.notify); }
+      unobserve() { resizeCallbacks.delete(this.notify); }
+      disconnect() { resizeCallbacks.delete(this.notify); }
+    });
+    vi.useFakeTimers();
+    try {
+      React.act(() => container.querySelector<HTMLButtonElement>(`[data-testid="button-${mode === "open" ? "open" : "manage"}-library"]`)!.click());
+      const scroll = document.querySelector(`[data-testid="${mode}-library-scroll"]`)!;
+      const viewport = scroll.querySelector('[data-radix-scroll-area-viewport]')!;
+      Object.defineProperties(viewport, {
+        offsetHeight: { configurable: true, value: 120 },
+        scrollHeight: { configurable: true, value: 600 },
+      });
+      await React.act(async () => {
+        for (const resize of resizeCallbacks) resize();
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      expect(scroll.querySelector('[data-orientation="vertical"]')?.getAttribute("data-state")).toBe("visible");
+      await React.act(async () => {
+        scroll.dispatchEvent(new MouseEvent("pointerout", { bubbles: true }));
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(scroll.querySelector('[data-orientation="vertical"]')?.getAttribute("data-state")).toBe("visible");
+      Object.defineProperty(viewport, "scrollHeight", { configurable: true, value: 80 });
+      await React.act(async () => {
+        for (const resize of resizeCallbacks) resize();
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      expect(scroll.querySelector('[data-orientation="vertical"]')).toBeNull();
+    } finally {
+      unmount();
+      vi.useRealTimers();
+    }
+  });
+
+  it("manages library removal separately, protects the open project, and preserves it when another is removed", async () => {
+    const projects = [
+      { id: "current", name: "Current tray", updatedAt: "2026-09-12T12:00:00.000Z" },
+      { id: "old", name: "Old tray", updatedAt: "2026-09-11T12:00:00.000Z" },
+    ];
+    vi.mocked(ProjectPersistence.loadProjectDoc).mockResolvedValue(EMPTY_PROJECT);
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: "current", projects });
+    vi.mocked(ProjectPersistence.deleteProjectFromLibrary).mockResolvedValue({ activeProjectId: "current", projects: [projects[0]] });
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    const before = vi.mocked(useBinGeometry).mock.lastCall;
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-manage-library"]')!.click());
+    await flushHydration();
+    expect(document.querySelector('[role="dialog"]')?.textContent).toContain("Manage browser library");
+    expect(document.querySelector('[data-testid="project-list"]')).toBeNull();
+    expect(document.querySelector<HTMLButtonElement>('[data-testid="button-open-project-current"]')!.disabled).toBe(true);
+    expect(document.querySelector<HTMLButtonElement>('[data-testid="button-open-project-old"]')!.disabled).toBe(false);
+    const current = document.querySelector<HTMLButtonElement>('[data-testid="button-remove-project-current"]')!;
+    expect(current.disabled).toBe(true);
+    expect(current.title).toBe("");
+    expect(document.querySelector('[aria-label="About removing the current project"]')).toBeNull();
+    React.act(() => current.click());
+    expect(ProjectPersistence.deleteProjectFromLibrary).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alertdialog"]')).toBeNull();
+    const remove = () => document.querySelector<HTMLButtonElement>('[data-testid="button-remove-project-old"]')!;
+    React.act(() => remove().click());
+    expect(document.querySelector('[role="alertdialog"]')?.textContent).toContain("Old tray");
+    expect(document.querySelector('[role="alertdialog"]')?.textContent).toContain("Your current project will not change");
+    const keep = [...document.querySelectorAll<HTMLButtonElement>('[role="alertdialog"] button')].find(button => button.textContent === "Keep project")!;
+    React.act(() => keep.click());
+    expect(ProjectPersistence.deleteProjectFromLibrary).not.toHaveBeenCalled();
+    React.act(() => remove().click());
+    await React.act(async () => document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-remove-project"]')!.click());
+    expect(ProjectPersistence.deleteProjectFromLibrary).toHaveBeenCalledExactlyOnceWith("old");
+    expect(document.querySelector('[data-testid="managed-project-list"]')?.textContent).not.toContain("Old tray");
+    expect(document.querySelector('[data-testid="managed-project-list"]')?.textContent).toContain("Current tray");
+    expect(container.querySelector('[data-testid="project-autosave-status"]')?.textContent).toContain("Current tray");
+    expect(vi.mocked(useBinGeometry).mock.lastCall).toEqual(before);
+    expect(ProjectPersistence.openProjectFromLibrary).not.toHaveBeenCalled();
+    expect(ProjectPersistence.startNewProject).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it.each(["Open button", "double-click", "Enter"])("opens a saved project from Manage library using %s", async (action) => {
+    const projects = [
+      { id: "current", name: "Current tray", updatedAt: "2026-09-12T12:00:00.000Z" },
+      { id: "saved", name: "Saved tray", updatedAt: "2026-09-11T12:00:00.000Z" },
+    ];
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: "current", projects });
+    vi.mocked(ProjectPersistence.openProjectFromLibrary).mockResolvedValue({
+      doc: EMPTY_PROJECT,
+      project: projects[1],
+      library: { activeProjectId: "saved", projects },
+    });
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-manage-library"]')!.click());
+    await flushHydration();
+    const row = document.querySelector<HTMLElement>('[data-testid="library-project-saved"]')!;
+    React.act(() => row.querySelector<HTMLElement>('p')!.click());
+    expect(document.activeElement).toBe(row);
+    expect(row.getAttribute("data-selected")).toBe("true");
+    expect(document.querySelector('[data-testid="library-project-current"]')?.getAttribute("data-selected")).toBe("false");
+    expect(container.querySelector('[data-testid="current-project-name-row"] p[title]')?.textContent).toBe("Current tray");
+    React.act(() => {
+      document.querySelector('[data-testid="library-project-current"]')!.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+      document.querySelector('[data-testid="button-remove-project-saved"]')!.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+    expect(ProjectPersistence.openProjectFromLibrary).not.toHaveBeenCalled();
+    await React.act(async () => {
+      if (action === "Open button") {
+        document.querySelector<HTMLButtonElement>('[data-testid="button-open-project-saved"]')!.click();
+      } else if (action === "Enter") {
+        row.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      } else {
+        document.querySelector('[data-testid="library-project-saved"] p')!.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+      }
+    });
+    expect(ProjectPersistence.openProjectFromLibrary).toHaveBeenCalledExactlyOnceWith("saved");
+    expect(document.querySelector('[data-testid="managed-project-list"]')).toBeNull();
+    expect(container.querySelector('[data-testid="current-project-name-row"] p[title]')?.textContent).toBe("Saved tray");
+    expect(ProjectPersistence.deleteProjectFromLibrary).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("guards repeated manager opens while busy and leaves the manager available after an open failure", async () => {
+    const project = { id: "saved", name: "Saved tray", updatedAt: "2026-09-12T12:00:00.000Z" };
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: null, projects: [project] });
+    let rejectOpen!: (error: Error) => void;
+    vi.mocked(ProjectPersistence.openProjectFromLibrary).mockReturnValue(new Promise((_, reject) => { rejectOpen = reject; }));
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-manage-library"]')!.click());
+    await flushHydration();
+    const open = () => document.querySelector<HTMLButtonElement>('[data-testid="button-open-project-saved"]')!;
+    React.act(() => open().click());
+    expect(open().disabled).toBe(true);
+    expect(document.querySelector<HTMLButtonElement>('[data-testid="button-remove-project-saved"]')!.disabled).toBe(true);
+    React.act(() => document.querySelector('[data-testid="library-project-saved"]')!.dispatchEvent(new MouseEvent("dblclick", { bubbles: true })));
+    expect(ProjectPersistence.openProjectFromLibrary).toHaveBeenCalledExactlyOnceWith("saved");
+    await React.act(async () => rejectOpen(new Error("Storage unavailable")));
+    expect(document.querySelector('[data-testid="managed-project-list"]')).not.toBeNull();
+    expect(open().disabled).toBe(false);
+    expect(container.querySelector('[data-testid="current-project-name-row"] p[title]')?.textContent).toBe("Untitled project");
+    unmount();
+  });
+
+  it.each(["current", "saved"])("copies the %s project after its source while retaining focus and the open design", async (id) => {
+    const projects = [
+      { id: "current", name: "Current tray", updatedAt: "2026-09-12T12:00:00.000Z" },
+      { id: "saved", name: "Saved tray", updatedAt: "2026-09-11T12:00:00.000Z" },
+    ];
+    const project = { id: "copy", name: `${projects.find(project => project.id === id)!.name} (copy)`, updatedAt: "2026-09-12T13:00:00.000Z" };
+    const copiedProjects = [...projects];
+    copiedProjects.splice(projects.findIndex(project => project.id === id) + 1, 0, project);
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: "current", projects });
+    vi.mocked(ProjectPersistence.duplicateProjectInLibrary).mockResolvedValue({ project, library: { activeProjectId: "current", projects: copiedProjects } });
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    const before = vi.mocked(useBinGeometry).mock.lastCall;
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-manage-library"]')!.click());
+    await flushHydration();
+    const copy = document.querySelector<HTMLButtonElement>(`[data-testid="button-duplicate-project-${id}"]`)!;
+    expect(copy.disabled).toBe(false);
+    await React.act(async () => copy.click());
+    expect(ProjectPersistence.duplicateProjectInLibrary).toHaveBeenCalledExactlyOnceWith(id, expect.objectContaining({ schemaVersion: PROJECT_SCHEMA_VERSION }));
+    const copiedRow = document.querySelector('[data-testid="library-project-copy"]')!;
+    const sourceRow = document.querySelector(`[data-testid="library-project-${id}"]`)!;
+    expect(copiedRow.textContent).toContain(project.name);
+    expect(copiedRow.getAttribute("data-selected")).toBe("false");
+    expect(sourceRow.getAttribute("data-selected")).toBe("true");
+    expect(document.activeElement).toBe(sourceRow);
+    expect(sourceRow.nextElementSibling).toBe(copiedRow);
+    expect([...document.querySelectorAll('[data-testid="managed-project-list"] > [role="group"]')].map(row => row.getAttribute("aria-label"))).toEqual(copiedProjects.map(project => project.name));
+    expect(container.querySelector('[data-testid="current-project-name-row"] p[title]')?.textContent).toBe("Current tray");
+    expect(vi.mocked(useBinGeometry).mock.lastCall).toEqual(before);
+    expect(ProjectPersistence.openProjectFromLibrary).not.toHaveBeenCalled();
+    expect(ProjectPersistence.saveProjectToLibrary).not.toHaveBeenCalled();
+    expect(document.querySelector<HTMLButtonElement>('[data-testid="button-remove-project-current"]')!.disabled).toBe(true);
+    unmount();
+  });
+
+  it("disables copying while busy and leaves the library unchanged after a copy failure", async () => {
+    const project = { id: "saved", name: "Saved tray", updatedAt: "2026-09-12T12:00:00.000Z" };
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: "saved", projects: [project] });
+    let rejectCopy!: (error: Error) => void;
+    vi.mocked(ProjectPersistence.duplicateProjectInLibrary).mockReturnValue(new Promise((_, reject) => { rejectCopy = reject; }));
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-manage-library"]')!.click());
+    await flushHydration();
+    const copy = document.querySelector<HTMLButtonElement>('[data-testid="button-duplicate-project-saved"]')!;
+    React.act(() => copy.click());
+    expect(copy.disabled).toBe(true);
+    const sourceRow = document.querySelector('[data-testid="library-project-saved"]')!;
+    expect(document.activeElement).toBe(sourceRow);
+    expect(document.querySelector<HTMLButtonElement>('[data-testid="button-rename-project-saved"]')!.disabled).toBe(true);
+    await React.act(async () => rejectCopy(new Error("Storage unavailable")));
+    expect(copy.disabled).toBe(false);
+    expect(document.activeElement).toBe(sourceRow);
+    expect(document.querySelectorAll('[data-testid="managed-project-list"] > [role="group"]')).toHaveLength(1);
+    expect(container.querySelector('[data-testid="current-project-name-row"] p[title]')?.textContent).toBe("Saved tray");
+    expect(ProjectPersistence.openProjectFromLibrary).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it.each(["current", "saved"])("renames the %s project from Manage library without switching designs", async (id) => {
+    const projects = [
+      { id: "current", name: "Current tray", updatedAt: "2026-09-12T12:00:00.000Z" },
+      { id: "saved", name: "Saved tray", updatedAt: "2026-09-11T12:00:00.000Z" },
+    ];
+    const renamed = { activeProjectId: "current", projects: projects.map(project => project.id === id ? { ...project, name: "Renamed tray" } : project) };
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: "current", projects });
+    vi.mocked(ProjectPersistence.renameProjectInLibrary).mockResolvedValue(renamed);
+    vi.mocked(ProjectPersistence.saveProjectToLibrary).mockResolvedValue(renamed);
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    const before = vi.mocked(useBinGeometry).mock.lastCall;
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-manage-library"]')!.click());
+    await flushHydration();
+    const rename = document.querySelector<HTMLButtonElement>(`[data-testid="button-rename-project-${id}"]`)!;
+    expect(rename.disabled).toBe(false);
+    expect(rename.parentElement?.getAttribute("data-testid")).toBe(`library-project-name-${id}`);
+    React.act(() => rename.click());
+    const input = document.querySelector<HTMLInputElement>('[data-testid="input-project-name"]')!;
+    expect(input.value).toBe(projects.find(project => project.id === id)!.name);
+    React.act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, "Renamed tray");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await React.act(async () => document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-save-library"]')!.click());
+    if (id === "current") {
+      expect(ProjectPersistence.saveProjectToLibrary).toHaveBeenCalledWith(expect.objectContaining({ schemaVersion: PROJECT_SCHEMA_VERSION }), "Renamed tray", "current");
+      expect(ProjectPersistence.renameProjectInLibrary).not.toHaveBeenCalled();
+    } else {
+      expect(ProjectPersistence.renameProjectInLibrary).toHaveBeenCalledExactlyOnceWith("saved", "Renamed tray");
+      expect(ProjectPersistence.saveProjectToLibrary).not.toHaveBeenCalled();
+    }
+    expect(document.querySelector('[data-testid="input-project-name"]')).toBeNull();
+    expect(document.querySelector(`[data-testid="library-project-${id}"] p`)?.textContent).toBe("Renamed tray");
+    expect(container.querySelector('[data-testid="current-project-name-row"] p[title]')?.textContent).toBe(id === "current" ? "Renamed tray" : "Current tray");
+    expect(vi.mocked(useBinGeometry).mock.lastCall).toEqual(before);
+    expect(ProjectPersistence.openProjectFromLibrary).not.toHaveBeenCalled();
+    expect(document.querySelector<HTMLButtonElement>('[data-testid="button-remove-project-current"]')!.disabled).toBe(true);
+    unmount();
+  });
+
+  it("keeps the rename dialog and existing name after a failed manager rename", async () => {
+    const project = { id: "saved", name: "Saved tray", updatedAt: "2026-09-12T12:00:00.000Z" };
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: null, projects: [project] });
+    vi.mocked(ProjectPersistence.renameProjectInLibrary).mockRejectedValue(new Error("That name already exists."));
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-manage-library"]')!.click());
+    await flushHydration();
+    React.act(() => document.querySelector<HTMLButtonElement>('[data-testid="button-rename-project-saved"]')!.click());
+    await React.act(async () => document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-save-library"]')!.click());
+    expect(document.querySelector<HTMLInputElement>('[data-testid="input-project-name"]')!.value).toBe("Saved tray");
+    expect(document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-save-library"]')!.disabled).toBe(false);
+    expect(document.querySelector('[data-testid="library-project-saved"] p')?.textContent).toBe("Saved tray");
+    expect(ProjectPersistence.openProjectFromLibrary).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("allows removing a formerly open project after starting a new project", async () => {
+    const project = { id: "saved", name: "Saved tray", updatedAt: "2026-09-12T12:00:00.000Z" };
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: "saved", projects: [project] });
+    vi.mocked(ProjectPersistence.startNewProject).mockResolvedValue({ activeProjectId: null, projects: [project] });
+    vi.mocked(ProjectPersistence.deleteProjectFromLibrary).mockResolvedValue({ activeProjectId: null, projects: [] });
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-new-project"]')!.click());
+    await React.act(async () => document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-new-project"]')!.click());
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: null, projects: [project] });
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-manage-library"]')!.click());
+    await flushHydration();
+    const remove = document.querySelector<HTMLButtonElement>('[data-testid="button-remove-project-saved"]')!;
+    expect(remove.disabled).toBe(false);
+    React.act(() => remove.click());
+    await React.act(async () => document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-remove-project"]')!.click());
+    expect(ProjectPersistence.deleteProjectFromLibrary).toHaveBeenCalledExactlyOnceWith("saved");
+    expect(document.querySelector('[data-testid="managed-project-list"]')?.textContent).toContain("No named projects yet");
+    unmount();
+  });
+
+  it("keeps a saved project in the manager when removal fails", async () => {
+    const project = { id: "saved", name: "Saved tray", updatedAt: "2026-09-12T12:00:00.000Z" };
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: null, projects: [project] });
+    vi.mocked(ProjectPersistence.deleteProjectFromLibrary).mockRejectedValue(new Error("Storage unavailable"));
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    React.act(() => container.querySelector<HTMLButtonElement>('[data-testid="button-manage-library"]')!.click());
+    await flushHydration();
+    React.act(() => document.querySelector<HTMLButtonElement>('[data-testid="button-remove-project-saved"]')!.click());
+    await React.act(async () => document.querySelector<HTMLButtonElement>('[data-testid="button-confirm-remove-project"]')!.click());
+    expect(document.querySelector('[data-testid="managed-project-list"]')?.textContent).toContain("Saved tray");
+    expect(document.querySelector<HTMLButtonElement>('[data-testid="button-remove-project-saved"]')!.disabled).toBe(false);
+    expect(ProjectPersistence.openProjectFromLibrary).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("exports the full library directly from Portable backup with the latest design snapshot", async () => {
     const backup = { format: "pocketry-library" as const, schemaVersion: 1 as const, projects: [] };
     vi.mocked(ProjectPersistence.exportProjectLibrary).mockResolvedValue(backup);
     const { container, unmount } = renderPage();
     openSettingsSection(container, "project");
     await flushHydration();
-    React.act(() => { (container.querySelector('[data-testid="button-open-library"]') as HTMLButtonElement).click(); });
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Portable backup"] [data-testid="button-export-library"]')).not.toBeNull();
     await React.act(async () => { (document.querySelector('[data-testid="button-export-library"]') as HTMLButtonElement).click(); });
     expect(ProjectPersistence.exportProjectLibrary).toHaveBeenCalledWith(expect.objectContaining({ schemaVersion: PROJECT_SCHEMA_VERSION }));
+    expect(ProjectPersistence.saveProjectToLibrary).not.toHaveBeenCalled();
+    expect(ProjectPersistence.openProjectFromLibrary).not.toHaveBeenCalled();
     expect(downloadBlob).toHaveBeenCalledWith(expect.any(Blob), expect.stringMatching(/^pocketry-library-.*\.json$/));
     const [blob] = vi.mocked(downloadBlob).mock.calls[0];
     const json = await new Promise<string>((resolve, reject) => {
@@ -1756,8 +2108,7 @@ describe("BinDesignerPage", () => {
     const { container, unmount } = renderPage();
     openSettingsSection(container, "project");
     await flushHydration();
-    React.act(() => { (container.querySelector('[data-testid="button-open-library"]') as HTMLButtonElement).click(); });
-    await flushHydration();
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
     const input = document.querySelector('[data-testid="input-import-library"]') as HTMLInputElement;
     const click = vi.spyOn(input, "click");
     React.act(() => { (document.querySelector('[data-testid="button-import-library"]') as HTMLButtonElement).click(); });
@@ -1769,9 +2120,33 @@ describe("BinDesignerPage", () => {
     await React.act(async () => { input.dispatchEvent(new Event("change", { bubbles: true })); });
     expect(ProjectPersistence.importProjectLibrary).toHaveBeenCalledWith(data);
     expect(input.value).toBe("");
-    expect(document.querySelector('[data-testid="project-list"]')?.textContent).toContain("Imported tray");
+    expect(container.querySelector('[data-testid="library-file-backup"]')?.textContent).toContain("1 saved");
     expect(ProjectPersistence.startNewProject).not.toHaveBeenCalled();
     expect(ProjectPersistence.openProjectFromLibrary).not.toHaveBeenCalled();
+    vi.mocked(ProjectPersistence.loadProjectLibrary).mockResolvedValue({ activeProjectId: null, projects: [project] });
+    React.act(() => { (container.querySelector('[data-testid="button-open-library"]') as HTMLButtonElement).click(); });
+    await flushHydration();
+    expect(document.querySelector('[data-testid="project-list"]')?.textContent).toContain("Imported tray");
+    unmount();
+  });
+
+  it("disables project and library actions while exporting and recovers after an export error", async () => {
+    let rejectExport!: (error: Error) => void;
+    vi.mocked(ProjectPersistence.exportProjectLibrary).mockReturnValue(new Promise((_, reject) => { rejectExport = reject; }));
+    const { container, unmount } = renderPage();
+    openSettingsSection(container, "project");
+    await flushHydration();
+    const button = (action: string) => container.querySelector<HTMLButtonElement>(`[data-testid="button-${action}"]`)!;
+    React.act(() => button("export-library").click());
+    for (const action of ["save-library", "open-library", "manage-library", "new-project", "export-project", "import-project", "export-library", "import-library"]) {
+      expect(button(action).disabled).toBe(true);
+    }
+    expect(container.querySelector('[data-testid="project-status"]')?.textContent).toContain("Working");
+    await React.act(async () => { rejectExport(new Error("Library unavailable")); });
+    expect(button("export-library").disabled).toBe(false);
+    expect(button("import-library").disabled).toBe(false);
+    expect(downloadBlob).not.toHaveBeenCalled();
+    expect(ProjectPersistence.saveProjectToLibrary).not.toHaveBeenCalled();
     unmount();
   });
 
@@ -1779,7 +2154,6 @@ describe("BinDesignerPage", () => {
     const { container, unmount } = renderPage();
     openSettingsSection(container, "project");
     await flushHydration();
-    React.act(() => { (container.querySelector('[data-testid="button-open-library"]') as HTMLButtonElement).click(); });
     const input = document.querySelector('[data-testid="input-import-library"]') as HTMLInputElement;
     const file = new File(["{"], "broken.json");
     Object.defineProperty(file, "text", { value: async () => "{" });

--- a/client/src/pages/bin-designer.tsx
+++ b/client/src/pages/bin-designer.tsx
@@ -50,11 +50,13 @@ import {
 import {
   createDebouncedProjectSaver,
   deleteProjectFromLibrary,
+  duplicateProjectInLibrary,
   exportProjectLibrary,
   importProjectLibrary,
   loadProjectDoc,
   loadProjectLibrary,
   openProjectFromLibrary,
+  renameProjectInLibrary,
   saveProjectToLibrary,
   startNewProject,
   type ProjectLibrarySnapshot,
@@ -581,6 +583,48 @@ function BinDesignerWorkspace(): JSX.Element {
     }
   }, [currentProjectDoc, projectLibrary.activeProjectId, saveProject, toast]);
 
+  const handleDuplicateProject = useCallback(async (projectId: string): Promise<string | null> => {
+    setProjectBusy(true);
+    try {
+      const copied = await duplicateProjectInLibrary(projectId, currentProjectDoc);
+      setProjectLibrary(copied.library);
+      toast({ title: "Project duplicated", description: copied.project.name });
+      return copied.project.id;
+    } catch (cause) {
+      toast({
+        title: "Could not duplicate project",
+        description: cause instanceof Error ? cause.message : String(cause),
+        variant: "destructive",
+      });
+      return null;
+    } finally {
+      setProjectBusy(false);
+    }
+  }, [currentProjectDoc, toast]);
+
+  const handleRenameProject = useCallback(async (projectId: string, name: string): Promise<boolean> => {
+    setProjectBusy(true);
+    const active = projectId === projectLibrary.activeProjectId;
+    if (active) saveProject.cancel();
+    try {
+      const saved = active
+        ? await saveProjectToLibrary(currentProjectDoc, name, projectId)
+        : await renameProjectInLibrary(projectId, name);
+      setProjectLibrary(saved);
+      toast({ title: "Project renamed" });
+      return true;
+    } catch (cause) {
+      toast({
+        title: "Could not rename project",
+        description: cause instanceof Error ? cause.message : String(cause),
+        variant: "destructive",
+      });
+      return false;
+    } finally {
+      setProjectBusy(false);
+    }
+  }, [currentProjectDoc, projectLibrary.activeProjectId, saveProject, toast]);
+
   const handleOpenProject = useCallback(async (projectId: string): Promise<boolean> => {
     setProjectBusy(true);
     saveProject.cancel();
@@ -616,18 +660,19 @@ function BinDesignerWorkspace(): JSX.Element {
 
   const handleDeleteProject = useCallback(
     async (projectId: string): Promise<boolean> => {
+      if (projectId === projectLibrary.activeProjectId) return false;
       setProjectBusy(true);
       try {
         const saved = await deleteProjectFromLibrary(projectId);
         setProjectLibrary(saved);
         toast({
-          title: "Project deleted",
+          title: "Removed from library",
           description: "The named library copy was removed.",
         });
         return true;
       } catch (cause) {
         toast({
-          title: "Could not delete project",
+          title: "Could not remove project",
           description: cause instanceof Error ? cause.message : String(cause),
           variant: "destructive",
         });
@@ -636,7 +681,7 @@ function BinDesignerWorkspace(): JSX.Element {
         setProjectBusy(false);
       }
     },
-    [toast],
+    [projectLibrary.activeProjectId, toast],
   );
 
   const handleRefreshProjects = useCallback(() => {
@@ -930,6 +975,8 @@ function BinDesignerWorkspace(): JSX.Element {
           currentProjectName={currentProjectName}
           projects={projectLibrary.projects}
           onSaveProject={handleSaveProject}
+          onRenameProject={handleRenameProject}
+          onDuplicateProject={handleDuplicateProject}
           onOpenProject={handleOpenProject}
           onDeleteProject={handleDeleteProject}
           onRefreshProjects={handleRefreshProjects}


### PR DESCRIPTION
## Summary
- Separate Browser Library from Portable Backup, with clear routes for reopening saved projects and importing/exporting a single project or the entire library.
- Add a compact current-project row and a dedicated manager with single-click focus, Open/double-click/Enter, inline Rename, Copy, and confirmed removal.
- Keep the open project protected from removal. Copies use unique "(copy)" names, include pending edits when copying the open project, retain source focus, and appear directly after their source in stable library order.
- Keep scrollbars visible whenever either project list overflows, including on narrow screens.
- Update help text and regression coverage for persistence, focus, ordering, errors, and overflow behavior.

## Dependency
#42 has merged. This PR now targets `main` and includes that merge, including flat-ended slot corner rounding, for combined regression verification. Its diff against `main` contains only the library changes.

## Verification
- [x] Node.js 22: `npm run check`
- [x] `npm test -- --maxWorkers=2`: 1,321 tests across 77 files after integrating #42
- [x] `npm run build` (existing bundle-size/Browserslist warnings)
- [x] `git diff --check origin/main...HEAD`
- [x] Browser verification at desktop and 320px mobile widths: copy naming/order/focus, inline rename, opening/removal, and persistent overflow scrollbar
- [x] Combined build loaded successfully in the browser; Browser Library and Portable Backup controls remain intact
- [x] Browser tests used a separate local origin; temporary test projects were removed and the working library was left untouched

No additional dependency or project-schema changes beyond the merged #42.
